### PR TITLE
fix: left-align string parity with parse when width is set (#39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,10 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.os }}" == "windows-latest" ] || [ "${{ matrix.os }}" == "windows-11-arm" ]; then
-            .venv/Scripts/python -m pip install hypothesis pytest-cov pytest-benchmark pympler memory_profiler
+            .venv/Scripts/python -m pip install hypothesis pytest-cov pytest-benchmark pytest-xdist pympler memory_profiler
           else
             source .venv/bin/activate
-            pip install hypothesis pytest-cov pytest-benchmark pympler memory_profiler
+            pip install hypothesis pytest-cov pytest-benchmark pytest-xdist pympler memory_profiler
           fi
 
       - name: Run pytest suite

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -55,6 +55,7 @@ jobs:
             "hypothesis>=6.0" \
             "pytest-cov>=4.0" \
             "pytest-benchmark>=4.0" \
+            "pytest-xdist>=3.0" \
             "pympler>=0.9" \
             "memory_profiler>=0.60" \
             "mutmut>=2.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "formatparse-core"
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -189,9 +189,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown",
 ]

--- a/formatparse-core/src/error.rs
+++ b/formatparse-core/src/error.rs
@@ -57,4 +57,3 @@ impl fmt::Display for FormatParseError {
 }
 
 impl std::error::Error for FormatParseError {}
-

--- a/formatparse-core/src/lib.rs
+++ b/formatparse-core/src/lib.rs
@@ -4,16 +4,15 @@
 //! and type definitions. It has no dependencies on Python or PyO3.
 
 pub mod error;
-pub mod types;
 pub mod parser;
+pub mod types;
 
 pub use parser::{
-    validate_pattern_length, validate_input_length, validate_field_name,
-    MAX_PATTERN_LENGTH, MAX_INPUT_LENGTH, MAX_FIELDS, MAX_FIELD_NAME_LENGTH,
+    validate_field_name, validate_input_length, validate_pattern_length, MAX_FIELDS,
+    MAX_FIELD_NAME_LENGTH, MAX_INPUT_LENGTH, MAX_PATTERN_LENGTH,
 };
 // pub mod datetime;  // TODO: Extract pure Rust datetime utilities
 
-pub use types::{FieldType, FieldSpec};
-pub use types::regex::strftime_to_regex;
 pub use parser::regex::*;
-
+pub use types::regex::strftime_to_regex;
+pub use types::{FieldSpec, FieldType};

--- a/formatparse-core/src/parser/mod.rs
+++ b/formatparse-core/src/parser/mod.rs
@@ -3,7 +3,7 @@ pub mod regex;
 
 /// Security constants for input validation
 pub const MAX_PATTERN_LENGTH: usize = 10_000;
-pub const MAX_INPUT_LENGTH: usize = 10_000_000;  // 10MB
+pub const MAX_INPUT_LENGTH: usize = 10_000_000; // 10MB
 pub const MAX_FIELDS: usize = 100;
 pub const MAX_FIELD_NAME_LENGTH: usize = 200;
 
@@ -40,11 +40,11 @@ pub fn validate_field_name(field_name: &str) -> Result<(), String> {
             MAX_FIELD_NAME_LENGTH
         ));
     }
-    
+
     // Check for null bytes
     if field_name.contains('\0') {
         return Err("Field name contains null byte".to_string());
     }
-    
+
     Ok(())
 }

--- a/formatparse-core/src/parser/regex.rs
+++ b/formatparse-core/src/parser/regex.rs
@@ -9,17 +9,17 @@ const MAX_REGEX_COMPILATION_TIME_MS: u128 = 200;
 /// Includes timeout protection against ReDoS attacks
 pub fn build_regex(pattern: &str) -> Result<Regex, FormatParseError> {
     let start = Instant::now();
-    
+
     // Pre-allocate with estimated capacity
     let mut regex_with_flags = String::with_capacity(pattern.len() + 4);
     regex_with_flags.push_str("(?s)");
     regex_with_flags.push_str(pattern);
-    
+
     let regex = Regex::new(&regex_with_flags).map_err(|e| {
         // Sanitize error message - don't expose full regex pattern to prevent information disclosure
         FormatParseError::RegexError(format!("Invalid regex pattern: {}", e))
     })?;
-    
+
     // Check compilation time
     let elapsed = start.elapsed().as_millis();
     if elapsed > MAX_REGEX_COMPILATION_TIME_MS {
@@ -28,7 +28,7 @@ pub fn build_regex(pattern: &str) -> Result<Regex, FormatParseError> {
             elapsed, MAX_REGEX_COMPILATION_TIME_MS
         )));
     }
-    
+
     Ok(regex)
 }
 
@@ -36,20 +36,20 @@ pub fn build_regex(pattern: &str) -> Result<Regex, FormatParseError> {
 /// Includes timeout protection against ReDoS attacks
 pub fn build_case_insensitive_regex(pattern: &str) -> Option<Regex> {
     let start = Instant::now();
-    
+
     // Pre-allocate with estimated capacity
     let mut regex_with_flags = String::with_capacity(pattern.len() + 8);
     regex_with_flags.push_str("(?s)(?i)");
     regex_with_flags.push_str(pattern);
-    
+
     let regex = Regex::new(&regex_with_flags).ok()?;
-    
+
     // Check compilation time
     let elapsed = start.elapsed().as_millis();
     if elapsed > MAX_REGEX_COMPILATION_TIME_MS {
         return None;
     }
-    
+
     Some(regex)
 }
 
@@ -58,22 +58,22 @@ pub fn build_case_insensitive_regex(pattern: &str) -> Option<Regex> {
 pub fn prepare_search_regex(regex_str: &str) -> String {
     let mut start = 0;
     let mut end = regex_str.len();
-    
+
     // Remove (?s) flag if present
     if regex_str.starts_with("(?s)") {
         start = 4;
     }
-    
+
     // Remove ^ anchor
     if regex_str[start..].starts_with("^") {
         start += 1;
     }
-    
+
     // Remove $ anchor
     if regex_str[..end].ends_with("$") {
         end -= 1;
     }
-    
+
     // Only allocate if we need to modify the string
     if start > 0 || end < regex_str.len() {
         regex_str[start..end].to_string()
@@ -84,11 +84,14 @@ pub fn prepare_search_regex(regex_str: &str) -> String {
 
 /// Build a search regex (without anchors) with optional case sensitivity
 /// Includes timeout protection against ReDoS attacks
-pub fn build_search_regex(regex_str: &str, case_sensitive: bool) -> Result<Regex, FormatParseError> {
+pub fn build_search_regex(
+    regex_str: &str,
+    case_sensitive: bool,
+) -> Result<Regex, FormatParseError> {
     let start = Instant::now();
-    
+
     let search_regex_str = prepare_search_regex(regex_str);
-    
+
     // Pre-allocate with estimated capacity
     let capacity = search_regex_str.len() + if case_sensitive { 4 } else { 8 };
     let mut pattern = String::with_capacity(capacity);
@@ -97,12 +100,12 @@ pub fn build_search_regex(regex_str: &str, case_sensitive: bool) -> Result<Regex
         pattern.push_str("(?i)");
     }
     pattern.push_str(&search_regex_str);
-    
+
     let regex = Regex::new(&pattern).map_err(|e| {
         // Sanitize error message - don't expose full regex pattern to prevent information disclosure
         FormatParseError::RegexError(format!("Invalid regex pattern: {}", e))
     })?;
-    
+
     // Check compilation time
     let elapsed = start.elapsed().as_millis();
     if elapsed > MAX_REGEX_COMPILATION_TIME_MS {
@@ -111,7 +114,7 @@ pub fn build_search_regex(regex_str: &str, case_sensitive: bool) -> Result<Regex
             elapsed, MAX_REGEX_COMPILATION_TIME_MS
         )));
     }
-    
+
     Ok(regex)
 }
 
@@ -204,4 +207,3 @@ mod tests {
         assert!(regex.is_match("prefix test\nline suffix"));
     }
 }
-

--- a/formatparse-core/src/types/definitions.rs
+++ b/formatparse-core/src/types/definitions.rs
@@ -6,24 +6,24 @@ pub enum FieldType {
     Integer,
     Float,
     Boolean,
-    Letters,      // 'l' - matches only letters
-    Word,         // 'w' - matches word characters (letters, digits, underscore)
-    NonLetters,   // 'W' - matches non-letter characters
-    NonWhitespace,// 'S' - matches non-whitespace characters
-    NonDigits,    // 'D' - matches non-digit characters
+    Letters,             // 'l' - matches only letters
+    Word,                // 'w' - matches word characters (letters, digits, underscore)
+    NonLetters,          // 'W' - matches non-letter characters
+    NonWhitespace,       // 'S' - matches non-whitespace characters
+    NonDigits,           // 'D' - matches non-digit characters
     NumberWithThousands, // 'n' - numbers with thousands separators
-    Scientific,   // 'e' - scientific notation
-    GeneralNumber,// 'g' - general number (int or float)
-    Percentage,   // '%' - percentage
-    DateTimeISO,  // 'ti' - ISO 8601 datetime format
-    DateTimeRFC2822, // 'te' - RFC2822 email format
-    DateTimeGlobal, // 'tg' - Global (day/month) format
-    DateTimeUS,   // 'ta' - US (month/day) format
-    DateTimeCtime, // 'tc' - ctime() format
-    DateTimeHTTP, // 'th' - HTTP log format
-    DateTimeTime, // 'tt' - Time format
-    DateTimeSystem, // 'ts' - Linux system log format
-    DateTimeStrftime, // For %Y-%m-%d style patterns
+    Scientific,          // 'e' - scientific notation
+    GeneralNumber,       // 'g' - general number (int or float)
+    Percentage,          // '%' - percentage
+    DateTimeISO,         // 'ti' - ISO 8601 datetime format
+    DateTimeRFC2822,     // 'te' - RFC2822 email format
+    DateTimeGlobal,      // 'tg' - Global (day/month) format
+    DateTimeUS,          // 'ta' - US (month/day) format
+    DateTimeCtime,       // 'tc' - ctime() format
+    DateTimeHTTP,        // 'th' - HTTP log format
+    DateTimeTime,        // 'tt' - Time format
+    DateTimeSystem,      // 'ts' - Linux system log format
+    DateTimeStrftime,    // For %Y-%m-%d style patterns
     Custom(String),
 }
 
@@ -94,13 +94,13 @@ mod tests {
         let t1 = FieldType::String;
         let t2 = FieldType::String;
         let t3 = FieldType::Integer;
-        
+
         // Test pattern matching (since FieldType doesn't implement Eq)
         match (&t1, &t2) {
             (FieldType::String, FieldType::String) => (),
             _ => panic!("Should match"),
         }
-        
+
         match (&t1, &t3) {
             (FieldType::String, FieldType::Integer) => (),
             _ => panic!("Should be different"),
@@ -148,4 +148,3 @@ mod tests {
         assert_eq!(cloned.width, spec.width);
     }
 }
-

--- a/formatparse-core/src/types/mod.rs
+++ b/formatparse-core/src/types/mod.rs
@@ -3,5 +3,5 @@
 pub mod definitions;
 pub mod regex;
 
-pub use definitions::{FieldType, FieldSpec};
+pub use definitions::{FieldSpec, FieldType};
 pub use regex::strftime_to_regex;

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -6,30 +6,30 @@ use std::collections::HashMap;
 pub fn strftime_to_regex(format_str: &str) -> String {
     let mut regex_parts = Vec::new();
     let mut chars = format_str.chars().peekable();
-    
+
     while let Some(ch) = chars.next() {
         if ch == '%' {
             if let Some(next_ch) = chars.next() {
                 let regex_part = match next_ch {
-                    'Y' => r"\d{4}",           // Year with century
-                    'y' => r"\d{2}",           // Year without century
-                    'm' => r"\d{1,2}",         // Month (1-12 or 01-12) - flexible
-                    'd' => r"\d{1,2}",         // Day (1-31 or 01-31) - flexible
-                    'H' => r"\d{1,2}",         // Hour (0-23 or 00-23) - flexible
-                    'M' => r"\d{1,2}",         // Minute (0-59 or 00-59) - flexible
-                    'S' => r"\d{1,2}",         // Second (0-59 or 00-59) - flexible
+                    'Y' => r"\d{4}",             // Year with century
+                    'y' => r"\d{2}",             // Year without century
+                    'm' => r"\d{1,2}",           // Month (1-12 or 01-12) - flexible
+                    'd' => r"\d{1,2}",           // Day (1-31 or 01-31) - flexible
+                    'H' => r"\d{1,2}",           // Hour (0-23 or 00-23) - flexible
+                    'M' => r"\d{1,2}",           // Minute (0-59 or 00-59) - flexible
+                    'S' => r"\d{1,2}",           // Second (0-59 or 00-59) - flexible
                     'b' | 'h' => r"[A-Za-z]{3}", // Abbreviated month name
-                    'B' => r"[A-Za-z]+",       // Full month name
-                    'a' => r"[A-Za-z]{3}",     // Abbreviated weekday
-                    'A' => r"[A-Za-z]+",       // Full weekday
-                    'w' => r"\d",              // Weekday as decimal (0=Sunday)
-                    'j' => r"\d{1,3}",         // Day of year (1-366, flexible padding)
-                    'U' | 'W' => r"\d{2}",     // Week number
-                    'c' => r".+",              // Date and time representation (locale dependent)
-                    'x' => r".+",              // Date representation (locale dependent)
-                    'X' => r".+",              // Time representation (locale dependent)
-                    '%' => "%",                // Literal %
-                    _ => ".+?",                // Unknown directive - match anything
+                    'B' => r"[A-Za-z]+",         // Full month name
+                    'a' => r"[A-Za-z]{3}",       // Abbreviated weekday
+                    'A' => r"[A-Za-z]+",         // Full weekday
+                    'w' => r"\d",                // Weekday as decimal (0=Sunday)
+                    'j' => r"\d{1,3}",           // Day of year (1-366, flexible padding)
+                    'U' | 'W' => r"\d{2}",       // Week number
+                    'c' => r".+",                // Date and time representation (locale dependent)
+                    'x' => r".+",                // Date representation (locale dependent)
+                    'X' => r".+",                // Time representation (locale dependent)
+                    '%' => "%",                  // Literal %
+                    _ => ".+?",                  // Unknown directive - match anything
                 };
                 regex_parts.push(regex_part.to_string());
             }
@@ -38,12 +38,16 @@ pub fn strftime_to_regex(format_str: &str) -> String {
             regex_parts.push(regex::escape(&ch.to_string()));
         }
     }
-    
+
     regex_parts.join("")
 }
 
 impl FieldSpec {
-    pub fn to_regex_pattern(&self, custom_patterns: &HashMap<String, String>, next_field_is_greedy: Option<bool>) -> String {
+    pub fn to_regex_pattern(
+        &self,
+        custom_patterns: &HashMap<String, String>,
+        next_field_is_greedy: Option<bool>,
+    ) -> String {
         let base_pattern = match &self.field_type {
             FieldType::String => {
                 // Handle alignment and width for strings
@@ -57,15 +61,15 @@ impl FieldSpec {
                             '<' => {
                                 // Left-aligned: content (precision chars) + optional trailing fill chars
                                 format!(".{{{}}}(?:{}*)", prec, fill_escaped)
-                            },
+                            }
                             '>' => {
                                 // Right-aligned: optional leading fill chars + content (precision chars)
                                 format!("(?:{}*).{{{}}}", fill_escaped, prec)
-                            },
+                            }
                             '^' => {
                                 // Center-aligned: optional leading fill + content + optional trailing fill
                                 format!("(?:{}*).{{{}}}(?:{}*)", fill_escaped, prec, fill_escaped)
-                            },
+                            }
                             _ => format!(".{{{}}}", prec),
                         }
                     } else {
@@ -73,13 +77,13 @@ impl FieldSpec {
                         format!(".{{{}}}", prec)
                     }
                 } else if let Some(width) = self.width {
-                    // Width only (no precision): 
+                    // Width only (no precision):
                     // - If there's a next field with precision (like {:.4}), use greedy (at least width)
                     // - If there's a next field without precision (like {}), use exact width
                     // - If it's the last field, use greedy (at least width)
                     match next_field_is_greedy {
-                        Some(false) => format!(".{{{}}}", width),  // Exact when followed by non-greedy field
-                        _ => format!(".{{{},}}", width),  // Greedy when followed by greedy field or last field
+                        Some(false) => format!(".{{{}}}", width), // Exact when followed by non-greedy field
+                        _ => format!(".{{{},}}", width), // Greedy when followed by greedy field or last field
                     }
                 } else if self.alignment.is_some() {
                     // Alignment specified but no width - match with optional surrounding whitespace
@@ -102,24 +106,29 @@ impl FieldSpec {
                 }
             }
             FieldType::Integer => {
-                let sign = self.sign.as_ref().map(|s| match s {
-                    '+' => r"\+?",
-                    '-' => "-?",
-                    ' ' => r"[- ]?",
-                    _ => r"[+-]?",  // Default: allow optional + or -
-                }).unwrap_or(r"[+-]?");  // Default: allow optional + or -
-                
+                let sign = self
+                    .sign
+                    .as_ref()
+                    .map(|s| match s {
+                        '+' => r"\+?",
+                        '-' => "-?",
+                        ' ' => r"[- ]?",
+                        _ => r"[+-]?", // Default: allow optional + or -
+                    })
+                    .unwrap_or(r"[+-]?"); // Default: allow optional + or -
+
                 // Handle fill character with alignment (e.g., {:x=5d})
                 // For '=' alignment, fill goes between sign and digits
                 // Pattern should match: [sign][fill*][digits]
-                let (fill_prefix, fill_suffix) = if let (Some(fill_ch), Some('=')) = (self.fill, self.alignment) {
-                    // For '=' alignment with fill, match fill characters between sign and number
-                    let fill_escaped = regex::escape(&fill_ch.to_string());
-                    (format!("{}*", fill_escaped), String::new())
-                } else {
-                    (String::new(), String::new())
-                };
-                
+                let (fill_prefix, fill_suffix) =
+                    if let (Some(fill_ch), Some('=')) = (self.fill, self.alignment) {
+                        // For '=' alignment with fill, match fill characters between sign and number
+                        let fill_escaped = regex::escape(&fill_ch.to_string());
+                        (format!("{}*", fill_escaped), String::new())
+                    } else {
+                        (String::new(), String::new())
+                    };
+
                 let base_pattern = if self.zero_pad {
                     // Zero-padded: if width is specified, match 1 to width digits
                     // This allows unpadded values (e.g., '9' for {c:02d}) but rejects values exceeding width
@@ -133,33 +142,46 @@ impl FieldSpec {
                     match self.original_type_char {
                         Some('x') | Some('X') => {
                             // Hex: match hex digits with or without 0x prefix
-                            format!("{}{}{}(?:0[xX][0-9a-fA-F]+|[0-9a-fA-F]+)", sign, fill_prefix, fill_suffix)
-                        },
+                            format!(
+                                "{}{}{}(?:0[xX][0-9a-fA-F]+|[0-9a-fA-F]+)",
+                                sign, fill_prefix, fill_suffix
+                            )
+                        }
                         Some('o') => {
                             // Octal: match octal digits with or without 0o prefix
-                            format!("{}{}{}(?:0[oO][0-7]+|[0-7]+)", sign, fill_prefix, fill_suffix)
-                        },
+                            format!(
+                                "{}{}{}(?:0[oO][0-7]+|[0-7]+)",
+                                sign, fill_prefix, fill_suffix
+                            )
+                        }
                         Some('b') => {
                             // Binary: match binary digits with or without 0b prefix
                             format!("{}{}{}(?:0[bB][01]+|[01]+)", sign, fill_prefix, fill_suffix)
-                        },
+                        }
                         _ => {
                             // Decimal: match decimal digits, or hex/octal/binary with prefix
-                            format!("{}{}{}(?:0[xX][0-9a-fA-F]+|0[oO][0-7]+|0[bB][01]+|[0-9]+)", sign, fill_prefix, fill_suffix)
+                            format!(
+                                "{}{}{}(?:0[xX][0-9a-fA-F]+|0[oO][0-7]+|0[bB][01]+|[0-9]+)",
+                                sign, fill_prefix, fill_suffix
+                            )
                         }
                     }
                 };
-                
+
                 base_pattern
             }
             FieldType::Float => {
-                let sign = self.sign.as_ref().map(|s| match s {
-                    '+' => r"\+?",
-                    '-' => "-?",
-                    ' ' => r"[- ]?",
-                    _ => r"[+-]?",  // Default: allow optional + or -
-                }).unwrap_or(r"[+-]?");  // Default: allow optional + or -
-                
+                let sign = self
+                    .sign
+                    .as_ref()
+                    .map(|s| match s {
+                        '+' => r"\+?",
+                        '-' => "-?",
+                        ' ' => r"[- ]?",
+                        _ => r"[+-]?", // Default: allow optional + or -
+                    })
+                    .unwrap_or(r"[+-]?"); // Default: allow optional + or -
+
                 // For floats, precision affects how we match
                 // Width is mainly for formatting, but we need to handle it in parsing
                 // When width is specified, there may be leading/trailing spaces
@@ -169,9 +191,15 @@ impl FieldSpec {
                     // Also allow negative sign
                     if self.width.is_some() {
                         // Width specified - allow optional leading spaces
-                        format!(r"\s*{}(?:\d*\.\d{{{}}}|\.\d{{{}}})(?:[eE][+-]?\d+)?", sign, prec, prec)
+                        format!(
+                            r"\s*{}(?:\d*\.\d{{{}}}|\.\d{{{}}})(?:[eE][+-]?\d+)?",
+                            sign, prec, prec
+                        )
                     } else {
-                        format!(r"{}(?:\d*\.\d{{{}}}|\.\d{{{}}})(?:[eE][+-]?\d+)?", sign, prec, prec)
+                        format!(
+                            r"{}(?:\d*\.\d{{{}}}|\.\d{{{}}})(?:[eE][+-]?\d+)?",
+                            sign, prec, prec
+                        )
                     }
                 } else {
                     // Float must have a decimal point (not just an integer)
@@ -185,83 +213,102 @@ impl FieldSpec {
             FieldType::NonWhitespace => r"\S+".to_string(),
             FieldType::NonDigits => r"[^0-9]+".to_string(),
             FieldType::NumberWithThousands => {
-                let sign = self.sign.as_ref().map(|s| match s {
-                    '+' => r"\+?",
-                    '-' => "-?",
-                    ' ' => r"[- ]?",
-                    _ => r"[+-]?",  // Default: allow optional + or -
-                }).unwrap_or(r"[+-]?");  // Default: allow optional + or -
-                // Match numbers with thousands separators (comma or dot)
-                // Pattern: either number with valid thousands separators (1,234,567 or 1.234.567)
-                // or plain number without separators
-                // The regex matches the pattern, validation happens in conversion
+                let sign = self
+                    .sign
+                    .as_ref()
+                    .map(|s| match s {
+                        '+' => r"\+?",
+                        '-' => "-?",
+                        ' ' => r"[- ]?",
+                        _ => r"[+-]?", // Default: allow optional + or -
+                    })
+                    .unwrap_or(r"[+-]?"); // Default: allow optional + or -
+                                          // Match numbers with thousands separators (comma or dot)
+                                          // Pattern: either number with valid thousands separators (1,234,567 or 1.234.567)
+                                          // or plain number without separators
+                                          // The regex matches the pattern, validation happens in conversion
                 format!(r"{}(?:\d{{1,3}}(?:[.,]\d{{3}})*|\d+)", sign)
-            },
+            }
             FieldType::Scientific => {
                 // Scientific notation: matches floats with e/E exponent, or nan/inf
                 // Pattern matches original parse library exactly: \d*\.\d+[eE][-+]?\d+|nan|NAN|[-+]?inf|[-+]?INF
-                let sign = self.sign.as_ref().map(|s| match s {
-                    '+' => r"\+?",
-                    '-' => "-?",
-                    ' ' => r"[- ]?",
-                    _ => "-?",
-                }).unwrap_or("-?");
+                let sign = self
+                    .sign
+                    .as_ref()
+                    .map(|s| match s {
+                        '+' => r"\+?",
+                        '-' => "-?",
+                        ' ' => r"[- ]?",
+                        _ => "-?",
+                    })
+                    .unwrap_or("-?");
                 // Sign applies to numeric part; nan/inf have their own optional signs in the pattern
                 format!(r"{}\d*\.\d+[eE][-+]?\d+|nan|NAN|[-+]?inf|[-+]?INF", sign)
-            },
+            }
             FieldType::GeneralNumber => {
-                let sign = self.sign.as_ref().map(|s| match s {
-                    '+' => r"\+?",
-                    '-' => "-?",
-                    ' ' => r"[- ]?",
-                    _ => "-?",
-                }).unwrap_or("-?");
+                let sign = self
+                    .sign
+                    .as_ref()
+                    .map(|s| match s {
+                        '+' => r"\+?",
+                        '-' => "-?",
+                        ' ' => r"[- ]?",
+                        _ => "-?",
+                    })
+                    .unwrap_or("-?");
                 // General number: can be int or float or scientific, or nan/inf
-                format!(r"{}(?:\d+\.\d+|\.\d+|\d+\.|\d+)(?:[eE][+-]?\d+)?|nan|NAN|[-+]?inf|[-+]?INF", sign)
-            },
+                format!(
+                    r"{}(?:\d+\.\d+|\.\d+|\d+\.|\d+)(?:[eE][+-]?\d+)?|nan|NAN|[-+]?inf|[-+]?INF",
+                    sign
+                )
+            }
             FieldType::Percentage => {
-                let sign = self.sign.as_ref().map(|s| match s {
-                    '+' => r"\+?",
-                    '-' => "-?",
-                    ' ' => r"[- ]?",
-                    _ => "-?",
-                }).unwrap_or("-?");
+                let sign = self
+                    .sign
+                    .as_ref()
+                    .map(|s| match s {
+                        '+' => r"\+?",
+                        '-' => "-?",
+                        ' ' => r"[- ]?",
+                        _ => "-?",
+                    })
+                    .unwrap_or("-?");
                 // Percentage: number followed by %
                 format!(r"{}(?:\d+\.\d+|\.\d+|\d+)%", sign)
-            },
+            }
             FieldType::DateTimeISO => {
                 // ISO 8601 format: YYYY-MM-DD, YYYY-MM-DDTHH:MM, YYYY-MM-DDTHH:MM:SS, etc.
                 // Supports various separators and timezone formats (with optional space before timezone)
                 r"\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)?(?:\s*[Zz]|\s*[+-]\d{2}:?\d{2}|\s*[+-]\d{4})?".to_string()
-            },
+            }
             FieldType::DateTimeRFC2822 => {
                 // RFC2822: Mon, 21 Nov 2011 10:21:36 +1000 or +10:00 (optional weekday)
                 r"(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s+)?\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+[+-]\d{2}:?\d{2,4}".to_string()
-            },
+            }
             FieldType::DateTimeGlobal => {
                 // Global format: 21/11/2011 10:21:36 AM +1000 or 21-Nov-2011 10:21:36 AM +1:00
                 r"\d{1,2}[-/](?:\d{1,2}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|June|July|August|September|October|November|December)[-/]\d{4}(?:\s+\d{1,2}:\d{2}(?::\d{2})?(?:\s+[AP]M)?(?:\s+[+-]\d{1,2}:?\d{2,4})?)?".to_string()
-            },
+            }
             FieldType::DateTimeUS => {
                 // US format: 11/21/2011 10:21:36 AM +1000 or 11-Nov-2011 10:21:36 AM +1000 or Nov-21-2011 10:21:36 AM +1000
                 r"(?:\d{1,2}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|June|July|August|September|October|November|December)[-/]\d{1,2}[-/]\d{4}(?:\s+\d{1,2}:\d{2}(?::\d{2})?(?:\s+[AP]M)?(?:\s+[+-]\d{2}:?\d{2,4})?)?".to_string()
-            },
+            }
             FieldType::DateTimeCtime => {
                 // ctime format: Mon Nov 21 10:21:36 2011
                 r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4}".to_string()
-            },
+            }
             FieldType::DateTimeHTTP => {
                 // HTTP log format: 21/Nov/2011:00:07:11 +0000
                 r"\d{2}/[A-Za-z]{3}/\d{4}:\d{2}:\d{2}:\d{2}\s+[+-]\d{2}:?\d{2,4}".to_string()
-            },
+            }
             FieldType::DateTimeTime => {
                 // Time format: 10:21:36 PM -5:30
                 r"\d{1,2}:\d{2}(?::\d{2})?(?:\s+[AP]M)?(?:\s+[+-]\d{1,2}:?\d{2,4})?".to_string()
-            },
+            }
             FieldType::DateTimeSystem => {
                 // Linux system log format: Nov 21 10:21:36
                 r"[A-Za-z]{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}".to_string()
-            },
+            }
             FieldType::DateTimeStrftime => {
                 // Convert strftime format to regex pattern
                 if let Some(ref fmt) = self.strftime_format {
@@ -269,12 +316,16 @@ impl FieldSpec {
                 } else {
                     r".+?".to_string()
                 }
-            },
-            FieldType::Boolean => "true|false|True|False|TRUE|FALSE|1|0|yes|no|Yes|No|YES|NO|on|off|On|Off|ON|OFF".to_string(),
+            }
+            FieldType::Boolean => {
+                "true|false|True|False|TRUE|FALSE|1|0|yes|no|Yes|No|YES|NO|on|off|On|Off|ON|OFF"
+                    .to_string()
+            }
             FieldType::Custom(name) => {
-                custom_patterns.get(name)
+                custom_patterns
+                    .get(name)
                     .cloned()
-                    .unwrap_or_else(|| r"\S+".to_string())  // Default to non-whitespace for custom types without patterns
+                    .unwrap_or_else(|| r"\S+".to_string()) // Default to non-whitespace for custom types without patterns
             }
         };
 
@@ -569,4 +620,3 @@ mod tests {
         assert!(pattern.contains("x*"));
     }
 }
-

--- a/formatparse-pyo3/Cargo.toml
+++ b/formatparse-pyo3/Cargo.toml
@@ -17,7 +17,7 @@ formatparse-core = { path = "../formatparse-core" }
 pyo3 = { version = "0.24", features = ["extension-module"] }
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
-lru = "0.12"
+lru = "0.16.3"
 once_cell = "1.19"
 rayon = "1.8"
 

--- a/formatparse-pyo3/Cargo.toml
+++ b/formatparse-pyo3/Cargo.toml
@@ -12,6 +12,11 @@ description = "PyO3 bindings for formatparse"
 name = "_formatparse"
 crate-type = ["cdylib"]
 
+[features]
+default = []
+# Opt-in tests that require a Python interpreter (see raw_match.rs).
+python-tests = []
+
 [dependencies]
 formatparse-core = { path = "../formatparse-core" }
 pyo3 = { version = "0.24", features = ["extension-module"] }

--- a/formatparse-pyo3/src/datetime/common.rs
+++ b/formatparse-pyo3/src/datetime/common.rs
@@ -1,55 +1,81 @@
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
 // Cached regex patterns for timezone and time parsing
-pub(crate) static RE_TZ_COLON: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"([+-])(\d{1,2}):?(\d{2})").unwrap()
-});
+pub(crate) static RE_TZ_COLON: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"([+-])(\d{1,2}):?(\d{2})").unwrap());
 
-pub(crate) static RE_TZ_4DIGIT: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"([+-])(\d{4})").unwrap()
-});
+pub(crate) static RE_TZ_4DIGIT: Lazy<Regex> = Lazy::new(|| Regex::new(r"([+-])(\d{4})").unwrap());
 
-pub(crate) static RE_TZ_IN_STRING: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"\s+([+-]\d{2}:?\d{2})$").unwrap()
-});
+pub(crate) static RE_TZ_IN_STRING: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\s+([+-]\d{2}:?\d{2})$").unwrap());
 
-pub(crate) static RE_TZ_IN_STRING_EXTENDED: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"\s+([+-]\d{2}:?\d{2,4})$").unwrap()
-});
+pub(crate) static RE_TZ_IN_STRING_EXTENDED: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\s+([+-]\d{2}:?\d{2,4})$").unwrap());
 
-pub(crate) static RE_TIME_24H: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(\d{1,2}):(\d{2})(?::(\d{2}))?").unwrap()
-});
+pub(crate) static RE_TIME_24H: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(\d{1,2}):(\d{2})(?::(\d{2}))?").unwrap());
 
 /// Month name to number mapping (abbreviated and full names)
 pub fn get_month_map() -> HashMap<&'static str, u8> {
     [
-        ("Jan", 1), ("Feb", 2), ("Mar", 3), ("Apr", 4),
-        ("May", 5), ("Jun", 6), ("Jul", 7), ("Aug", 8),
-        ("Sep", 9), ("Oct", 10), ("Nov", 11), ("Dec", 12),
-        ("January", 1), ("February", 2), ("March", 3), ("April", 4),
-        ("June", 6), ("July", 7), ("August", 8),
-        ("September", 9), ("October", 10), ("November", 11), ("December", 12),
-    ].iter().cloned().collect()
+        ("Jan", 1),
+        ("Feb", 2),
+        ("Mar", 3),
+        ("Apr", 4),
+        ("May", 5),
+        ("Jun", 6),
+        ("Jul", 7),
+        ("Aug", 8),
+        ("Sep", 9),
+        ("Oct", 10),
+        ("Nov", 11),
+        ("Dec", 12),
+        ("January", 1),
+        ("February", 2),
+        ("March", 3),
+        ("April", 4),
+        ("June", 6),
+        ("July", 7),
+        ("August", 8),
+        ("September", 9),
+        ("October", 10),
+        ("November", 11),
+        ("December", 12),
+    ]
+    .iter()
+    .cloned()
+    .collect()
 }
 
 /// Month name to number mapping (abbreviated only)
 pub fn get_abbreviated_month_map() -> HashMap<&'static str, u8> {
     [
-        ("Jan", 1), ("Feb", 2), ("Mar", 3), ("Apr", 4),
-        ("May", 5), ("Jun", 6), ("Jul", 7), ("Aug", 8),
-        ("Sep", 9), ("Oct", 10), ("Nov", 11), ("Dec", 12),
-    ].iter().cloned().collect()
+        ("Jan", 1),
+        ("Feb", 2),
+        ("Mar", 3),
+        ("Apr", 4),
+        ("May", 5),
+        ("Jun", 6),
+        ("Jul", 7),
+        ("Aug", 8),
+        ("Sep", 9),
+        ("Oct", 10),
+        ("Nov", 11),
+        ("Dec", 12),
+    ]
+    .iter()
+    .cloned()
+    .collect()
 }
 
 /// Create a FixedTzOffset from offset minutes
 pub fn create_fixed_tz(py: Python, offset_minutes: i32, name: &str) -> PyResult<PyObject> {
-    let fixed_tz_module = py.import_bound("formatparse")?;
+    let fixed_tz_module = py.import("formatparse")?;
     let fixed_tz_class = fixed_tz_module.getattr("FixedTzOffset")?;
-    let tz = fixed_tz_class.call1((offset_minutes, name.to_string(),))?;
+    let tz = fixed_tz_class.call1((offset_minutes, name.to_string()))?;
     Ok(tz.to_object(py))
 }
 
@@ -58,9 +84,14 @@ pub fn create_fixed_tz(py: Python, offset_minutes: i32, name: &str) -> PyResult<
 pub fn parse_timezone(py: Python, tz_str: &str) -> PyResult<PyObject> {
     // Handle formats: +1:00, +10:00, +10:30, +1000, etc.
     if let Some(caps) = RE_TZ_COLON.captures(tz_str) {
-        if let (Some(sign_match), Some(hour_match), Some(min_match)) = (caps.get(1), caps.get(2), caps.get(3)) {
+        if let (Some(sign_match), Some(hour_match), Some(min_match)) =
+            (caps.get(1), caps.get(2), caps.get(3))
+        {
             let sign = if sign_match.as_str() == "+" { 1 } else { -1 };
-            let hour: i32 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone"))?;
+            let hour: i32 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone"))?;
             let min: i32 = min_match.as_str().parse().unwrap_or(0);
             let offset_minutes = sign * (hour * 60 + min);
             return create_fixed_tz(py, offset_minutes, "");
@@ -73,8 +104,12 @@ pub fn parse_timezone(py: Python, tz_str: &str) -> PyResult<PyObject> {
             let tz_str = tz_match.as_str();
             // Regex ensures exactly 4 digits, but add defensive check
             if tz_str.len() >= 4 {
-                let hour: i32 = tz_str[..2].parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone"))?;
-                let min: i32 = tz_str[2..4].parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone"))?;
+                let hour: i32 = tz_str[..2].parse().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone")
+                })?;
+                let min: i32 = tz_str[2..4].parse().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone")
+                })?;
                 let offset_minutes = sign * (hour * 60 + min);
                 return create_fixed_tz(py, offset_minutes, "");
             }
@@ -89,13 +124,24 @@ pub fn parse_time_with_ampm(time_str: &str) -> Result<(u8, u8, u8), PyErr> {
     let mut hour = 0u8;
     let mut minute = 0u8;
     let mut second = 0u8;
-    
+
     if let Some(ampm_idx) = time_str.to_uppercase().find("AM") {
         let time_part = &time_str[..ampm_idx].trim();
         if let Some(caps) = RE_TIME_24H.captures(time_part) {
-            hour = caps.get(1).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            minute = caps.get(2).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            second = caps.get(3).map(|m| m.as_str().parse().unwrap_or(0)).unwrap_or(0);
+            hour = caps
+                .get(1)
+                .unwrap()
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            minute =
+                caps.get(2).unwrap().as_str().parse().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute")
+                })?;
+            second = caps
+                .get(3)
+                .map(|m| m.as_str().parse().unwrap_or(0))
+                .unwrap_or(0);
             // 12 AM becomes 0 (midnight), other AM hours stay as-is
             if hour == 12 {
                 hour = 0;
@@ -104,9 +150,20 @@ pub fn parse_time_with_ampm(time_str: &str) -> Result<(u8, u8, u8), PyErr> {
     } else if let Some(pm_idx) = time_str.to_uppercase().find("PM") {
         let time_part = &time_str[..pm_idx].trim();
         if let Some(caps) = RE_TIME_24H.captures(time_part) {
-            hour = caps.get(1).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            minute = caps.get(2).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            second = caps.get(3).map(|m| m.as_str().parse().unwrap_or(0)).unwrap_or(0);
+            hour = caps
+                .get(1)
+                .unwrap()
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            minute =
+                caps.get(2).unwrap().as_str().parse().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute")
+                })?;
+            second = caps
+                .get(3)
+                .map(|m| m.as_str().parse().unwrap_or(0))
+                .unwrap_or(0);
             // 12 PM stays as 12 (noon), other PM hours add 12
             if hour != 12 {
                 hour += 12;
@@ -115,12 +172,23 @@ pub fn parse_time_with_ampm(time_str: &str) -> Result<(u8, u8, u8), PyErr> {
     } else {
         // 24-hour format
         if let Some(caps) = RE_TIME_24H.captures(time_str) {
-            hour = caps.get(1).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            minute = caps.get(2).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            second = caps.get(3).map(|m| m.as_str().parse().unwrap_or(0)).unwrap_or(0);
+            hour = caps
+                .get(1)
+                .unwrap()
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            minute =
+                caps.get(2).unwrap().as_str().parse().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute")
+                })?;
+            second = caps
+                .get(3)
+                .map(|m| m.as_str().parse().unwrap_or(0))
+                .unwrap_or(0);
         }
     }
-    
+
     Ok((hour, minute, second))
 }
 
@@ -133,7 +201,12 @@ pub fn parse_microseconds(micros_str: &str) -> Result<u32, PyErr> {
         micros_str
     };
     let padded = format!("{:0<6}", micros_str);
-    padded.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid microsecond: {}", micros_str)))
+    padded.parse().map_err(|_| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "Invalid microsecond: {}",
+            micros_str
+        ))
+    })
 }
 
 /// Extract microseconds from a capture group, handling padding
@@ -142,7 +215,8 @@ pub fn extract_microseconds(cap: Option<regex::Match>) -> u32 {
         let s = m.as_str();
         let padded = format!("{:0<6}", s);
         padded[..6.min(padded.len())].parse().unwrap_or(0)
-    }).unwrap_or(0)
+    })
+    .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -230,7 +304,7 @@ mod tests {
     fn test_extract_microseconds() {
         use regex::Regex;
         let re = Regex::new(r"(\d+)").unwrap();
-        
+
         let cap = re.captures("123456").and_then(|c| c.get(1));
         let result = extract_microseconds(cap);
         assert_eq!(result, 123456);
@@ -263,4 +337,3 @@ mod tests {
         assert!(RE_TIME_24H.is_match("23:59:59"));
     }
 }
-

--- a/formatparse-pyo3/src/datetime/ctime.rs
+++ b/formatparse-pyo3/src/datetime/ctime.rs
@@ -1,7 +1,7 @@
+use crate::datetime::common::get_abbreviated_month_map;
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
-use crate::datetime::common::get_abbreviated_month_map;
 
 // Cached regex pattern for ctime datetime parsing
 static RE_CTIME_DATETIME: Lazy<Regex> = Lazy::new(|| {
@@ -10,27 +10,63 @@ static RE_CTIME_DATETIME: Lazy<Regex> = Lazy::new(|| {
 
 /// Parse ctime() format: Mon Nov 21 10:21:36 2011
 pub fn parse_ctime_datetime(py: Python, value: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
-    
+
     let month_map = get_abbreviated_month_map();
-    
+
     if let Some(caps) = RE_CTIME_DATETIME.captures(value) {
-        if let (Some(month_match), Some(day_match), Some(hour_match), Some(minute_match), Some(second_match), Some(year_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5), caps.get(6)) {
+        if let (
+            Some(month_match),
+            Some(day_match),
+            Some(hour_match),
+            Some(minute_match),
+            Some(second_match),
+            Some(year_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+            caps.get(6),
+        ) {
             let month_name = month_match.as_str();
-            let month = *month_map.get(month_name).ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid month: {}", month_name)))?;
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = second_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            
-            let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, py.None()))?;
+            let month = *month_map.get(month_name).ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid month: {}",
+                    month_name
+                ))
+            })?;
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = second_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+
+            let dt =
+                datetime_class.call1((year, month, day, hour, minute, second, 0, py.None()))?;
             return Ok(dt.to_object(py));
         }
     }
-    
-    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid ctime datetime: {}", value)))
-}
 
+    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+        "Invalid ctime datetime: {}",
+        value
+    )))
+}

--- a/formatparse-pyo3/src/datetime/fixed_tz.rs
+++ b/formatparse-pyo3/src/datetime/fixed_tz.rs
@@ -21,7 +21,10 @@ impl FixedTzOffset {
         let hours = self.offset_seconds.abs() / 3600;
         let minutes = (self.offset_seconds.abs() % 3600) / 60;
         let sign = if self.offset_seconds >= 0 { "" } else { "-" };
-        format!("<FixedTzOffset {} {}{}:{:02}:00>", self.name, sign, hours, minutes)
+        format!(
+            "<FixedTzOffset {} {}{}:{:02}:00>",
+            self.name, sign, hours, minutes
+        )
     }
 
     fn __str__(&self) -> String {
@@ -30,8 +33,8 @@ impl FixedTzOffset {
 
     fn __eq__(&self, other: &Bound<'_, PyAny>) -> PyResult<bool> {
         if let Ok(other_tz) = other.downcast::<Self>() {
-            Ok(self.offset_seconds == other_tz.borrow().offset_seconds && 
-               self.name == other_tz.borrow().name)
+            Ok(self.offset_seconds == other_tz.borrow().offset_seconds
+                && self.name == other_tz.borrow().name)
         } else {
             Ok(false)
         }
@@ -55,10 +58,10 @@ impl FixedTzOffset {
 
     /// tzinfo.utcoffset() - returns timedelta for offset
     fn utcoffset(&self, py: Python, _dt: Option<&Bound<'_, PyAny>>) -> PyResult<PyObject> {
-        let datetime_module = py.import_bound("datetime")?;
+        let datetime_module = py.import("datetime")?;
         let timedelta_class = datetime_module.getattr("timedelta")?;
         // timedelta(seconds=offset_seconds)
-        let delta = timedelta_class.call1((0, 0, self.offset_seconds,))?;
+        let delta = timedelta_class.call1((0, 0, self.offset_seconds))?;
         Ok(delta.to_object(py))
     }
 
@@ -72,4 +75,3 @@ impl FixedTzOffset {
         self.name.clone()
     }
 }
-

--- a/formatparse-pyo3/src/datetime/global.rs
+++ b/formatparse-pyo3/src/datetime/global.rs
@@ -1,12 +1,11 @@
+use crate::datetime::common::{get_month_map, parse_timezone, RE_TZ_IN_STRING};
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
-use crate::datetime::common::{get_month_map, parse_timezone, RE_TZ_IN_STRING};
 
 // Cached regex patterns for global datetime parsing
-static RE_GLOBAL_NUMERIC: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^(\d{1,2})[-/](\d{1,2})[-/](\d{4})(?:\s+(.+))?$").unwrap()
-});
+static RE_GLOBAL_NUMERIC: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(\d{1,2})[-/](\d{1,2})[-/](\d{4})(?:\s+(.+))?$").unwrap());
 
 static RE_GLOBAL_NAMED: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(\d{1,2})[-/](Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)[-/](\d{4})(?:\s+(.+))?$").unwrap()
@@ -15,79 +14,104 @@ static RE_GLOBAL_NAMED: Lazy<Regex> = Lazy::new(|| {
 /// Parse Global (day/month) datetime format
 /// Formats: 21/11/2011, 21-11-2011, 21-Nov-2011, 21-November-2011
 pub fn parse_global_datetime(py: Python, value: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
-    
+
     let month_map = get_month_map();
-    
+
     // Helper to parse timezone - use common function
-    let parse_tz = |tz_str: &str| -> PyResult<PyObject> {
-        parse_timezone(py, tz_str)
-    };
-    
+    let parse_tz = |tz_str: &str| -> PyResult<PyObject> { parse_timezone(py, tz_str) };
+
     // Helper to parse AM/PM - use common function
     let parse_time_with_ampm = |time_str: &str| -> Result<(u8, u8, u8), PyErr> {
         crate::datetime::common::parse_time_with_ampm(time_str)
     };
-    
+
     // Try numeric format: 21/11/2011 or 21-11-2011 with optional time/timezone
     if let Some(caps) = RE_GLOBAL_NUMERIC.captures(value) {
-        if let (Some(day_match), Some(month_match), Some(year_match)) = (caps.get(1), caps.get(2), caps.get(3)) {
-                let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-                let month: u8 = month_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
-                let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-                
-                let (hour, minute, second) = if let Some(time_part) = caps.get(4) {
-                    let time_str = time_part.as_str().trim();
-                    // Check if there's a timezone
-                    if let Some(tz_match) = RE_TZ_IN_STRING.captures(time_str).and_then(|c| c.get(1)) {
-                        let tz_str = tz_match.as_str();
-                        let time_only = time_str[..time_str.len() - tz_str.len()].trim();
-                        let (h, m, s) = parse_time_with_ampm(time_only)?;
-                        let tzinfo = parse_tz(tz_str)?;
-                        let dt = datetime_class.call1((year, month, day, h, m, s, 0, tzinfo))?;
-                        return Ok(dt.to_object(py));
-                    } else {
-                        parse_time_with_ampm(time_str)?
-                    }
+        if let (Some(day_match), Some(month_match), Some(year_match)) =
+            (caps.get(1), caps.get(2), caps.get(3))
+        {
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let month: u8 = month_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+
+            let (hour, minute, second) = if let Some(time_part) = caps.get(4) {
+                let time_str = time_part.as_str().trim();
+                // Check if there's a timezone
+                if let Some(tz_match) = RE_TZ_IN_STRING.captures(time_str).and_then(|c| c.get(1)) {
+                    let tz_str = tz_match.as_str();
+                    let time_only = time_str[..time_str.len() - tz_str.len()].trim();
+                    let (h, m, s) = parse_time_with_ampm(time_only)?;
+                    let tzinfo = parse_tz(tz_str)?;
+                    let dt = datetime_class.call1((year, month, day, h, m, s, 0, tzinfo))?;
+                    return Ok(dt.to_object(py));
                 } else {
-                    (0, 0, 0)
-                };
-                
-                let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, py.None()))?;
-                return Ok(dt.to_object(py));
+                    parse_time_with_ampm(time_str)?
+                }
+            } else {
+                (0, 0, 0)
+            };
+
+            let dt =
+                datetime_class.call1((year, month, day, hour, minute, second, 0, py.None()))?;
+            return Ok(dt.to_object(py));
         }
     }
-    
+
     // Try named month format: 21-Nov-2011 or 21-November-2011
     if let Some(caps) = RE_GLOBAL_NAMED.captures(value) {
-        if let (Some(day_match), Some(month_match), Some(year_match)) = (caps.get(1), caps.get(2), caps.get(3)) {
-                let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-                let month_name = month_match.as_str();
-                let month = *month_map.get(month_name).ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid month: {}", month_name)))?;
-                let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-                
-                let (hour, minute, second, tzinfo) = if let Some(time_part) = caps.get(4) {
-                    let time_str = time_part.as_str().trim();
-                    if let Some(tz_match) = RE_TZ_IN_STRING.captures(time_str).and_then(|c| c.get(1)) {
-                        let tz_str = tz_match.as_str();
-                        let time_only = time_str[..time_str.len() - tz_str.len()].trim();
-                        let (h, m, s) = parse_time_with_ampm(time_only)?;
-                        let tz = parse_tz(tz_str)?;
-                        (h, m, s, tz)
-                    } else {
-                        let (h, m, s) = parse_time_with_ampm(time_str)?;
-                        (h, m, s, py.None())
-                    }
+        if let (Some(day_match), Some(month_match), Some(year_match)) =
+            (caps.get(1), caps.get(2), caps.get(3))
+        {
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let month_name = month_match.as_str();
+            let month = *month_map.get(month_name).ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid month: {}",
+                    month_name
+                ))
+            })?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+
+            let (hour, minute, second, tzinfo) = if let Some(time_part) = caps.get(4) {
+                let time_str = time_part.as_str().trim();
+                if let Some(tz_match) = RE_TZ_IN_STRING.captures(time_str).and_then(|c| c.get(1)) {
+                    let tz_str = tz_match.as_str();
+                    let time_only = time_str[..time_str.len() - tz_str.len()].trim();
+                    let (h, m, s) = parse_time_with_ampm(time_only)?;
+                    let tz = parse_tz(tz_str)?;
+                    (h, m, s, tz)
                 } else {
-                    (0, 0, 0, py.None())
-                };
-                
-                let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-                return Ok(dt.to_object(py));
+                    let (h, m, s) = parse_time_with_ampm(time_str)?;
+                    (h, m, s, py.None())
+                }
+            } else {
+                (0, 0, 0, py.None())
+            };
+
+            let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
+            return Ok(dt.to_object(py));
         }
     }
-    
-    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid Global datetime: {}", value)))
-}
 
+    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+        "Invalid Global datetime: {}",
+        value
+    )))
+}

--- a/formatparse-pyo3/src/datetime/http.rs
+++ b/formatparse-pyo3/src/datetime/http.rs
@@ -1,7 +1,7 @@
+use crate::datetime::common::{create_fixed_tz, get_abbreviated_month_map};
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
-use crate::datetime::common::{get_abbreviated_month_map, create_fixed_tz};
 
 // Cached regex pattern for HTTP datetime parsing
 static RE_HTTP_DATETIME: Lazy<Regex> = Lazy::new(|| {
@@ -10,35 +10,78 @@ static RE_HTTP_DATETIME: Lazy<Regex> = Lazy::new(|| {
 
 /// Parse HTTP log format: 21/Nov/2011:10:21:36 +1000
 pub fn parse_http_datetime(py: Python, value: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
-    
+
     let month_map = get_abbreviated_month_map();
-    
+
     // 21/Nov/2011:10:21:36 +1000 or +10:00
     if let Some(caps) = RE_HTTP_DATETIME.captures(value) {
-        if let (Some(day_match), Some(month_match), Some(year_match), Some(hour_match), Some(minute_match), Some(second_match), Some(tz_sign), Some(tz_hour_match), Some(tz_min_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5), caps.get(6), caps.get(7), caps.get(8), caps.get(9)) {
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+        if let (
+            Some(day_match),
+            Some(month_match),
+            Some(year_match),
+            Some(hour_match),
+            Some(minute_match),
+            Some(second_match),
+            Some(tz_sign),
+            Some(tz_hour_match),
+            Some(tz_min_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+            caps.get(6),
+            caps.get(7),
+            caps.get(8),
+            caps.get(9),
+        ) {
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
             let month_name = month_match.as_str();
-            let month = *month_map.get(month_name).ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid month: {}", month_name)))?;
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = second_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
-            
+            let month = *month_map.get(month_name).ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid month: {}",
+                    month_name
+                ))
+            })?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = second_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
+
             let sign_str = tz_sign.as_str();
-            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour"))?;
+            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour")
+            })?;
             let tz_min: i32 = tz_min_match.as_str().parse().unwrap_or(0);
             let sign = if sign_str == "+" { 1 } else { -1 };
             let offset_minutes = sign * (tz_hour * 60 + tz_min);
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
-            
+
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
             return Ok(dt.to_object(py));
         }
     }
-    
-    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid HTTP datetime: {}", value)))
-}
 
+    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+        "Invalid HTTP datetime: {}",
+        value
+    )))
+}

--- a/formatparse-pyo3/src/datetime/iso.rs
+++ b/formatparse-pyo3/src/datetime/iso.rs
@@ -1,15 +1,14 @@
+use crate::datetime::common::{create_fixed_tz, extract_microseconds};
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
-use crate::datetime::common::{create_fixed_tz, extract_microseconds};
 
 // Cached regex patterns for ISO 8601 datetime parsing
-static RE_ISO_DATE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^(\d{4})-(\d{2})-(\d{2})$").unwrap()
-});
+static RE_ISO_DATE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(\d{4})-(\d{2})-(\d{2})$").unwrap());
 
 static RE_ISO_DATETIME_Z: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?[Zz]$").unwrap()
+    Regex::new(r"^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?[Zz]$")
+        .unwrap()
 });
 
 static RE_ISO_DATETIME_TZ_4DIGIT: Lazy<Regex> = Lazy::new(|| {
@@ -26,107 +25,293 @@ static RE_ISO_DATETIME_NO_TZ: Lazy<Regex> = Lazy::new(|| {
 
 /// Parse ISO 8601 datetime string and return Python datetime object
 pub fn parse_iso_datetime(py: Python, value: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
-    
+
     // Try to parse various ISO 8601 formats
     // YYYY-MM-DD
     if let Some(caps) = RE_ISO_DATE.captures(value) {
-        if let (Some(year_match), Some(month_match), Some(day_match)) = (caps.get(1), caps.get(2), caps.get(3)) {
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let month: u8 = month_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+        if let (Some(year_match), Some(month_match), Some(day_match)) =
+            (caps.get(1), caps.get(2), caps.get(3))
+        {
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let month: u8 = month_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
             // Return datetime with time 00:00:00
             let dt = datetime_class.call1((year, month, day, 0, 0, 0, 0, py.None()))?;
             return Ok(dt.to_object(py));
         }
     }
-    
+
     // YYYY-MM-DDTHH:MM or YYYY-MM-DD HH:MM with optional timezone
     // First try with Z timezone
     if let Some(caps) = RE_ISO_DATETIME_Z.captures(value) {
-        if let (Some(year_match), Some(month_match), Some(day_match), Some(hour_match), Some(minute_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5)) {
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let month: u8 = month_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = caps.get(6).map(|m| m.as_str().parse().unwrap_or(0)).unwrap_or(0);
+        if let (
+            Some(year_match),
+            Some(month_match),
+            Some(day_match),
+            Some(hour_match),
+            Some(minute_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+        ) {
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let month: u8 = month_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = caps
+                .get(6)
+                .map(|m| m.as_str().parse().unwrap_or(0))
+                .unwrap_or(0);
             let microsecond: u32 = extract_microseconds(caps.get(7));
-            
+
             let tzinfo = create_fixed_tz(py, 0, "UTC")?;
-            let dt = datetime_class.call1((year, month, day, hour, minute, second, microsecond, tzinfo))?;
+            let dt = datetime_class.call1((
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                microsecond,
+                tzinfo,
+            ))?;
             return Ok(dt.to_object(py));
         }
     }
-    
+
     // Try with timezone offset +0100 or -0530 (4 digits) - allow optional space
     if let Some(caps) = RE_ISO_DATETIME_TZ_4DIGIT.captures(value) {
-        if let (Some(year_match), Some(month_match), Some(day_match), Some(hour_match), Some(minute_match), Some(tz_sign), Some(tz_hour_match), Some(tz_min_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5), caps.get(8), caps.get(9), caps.get(10)) {
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let month: u8 = month_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = caps.get(6).map(|m| m.as_str().parse().unwrap_or(0)).unwrap_or(0);
+        if let (
+            Some(year_match),
+            Some(month_match),
+            Some(day_match),
+            Some(hour_match),
+            Some(minute_match),
+            Some(tz_sign),
+            Some(tz_hour_match),
+            Some(tz_min_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+            caps.get(8),
+            caps.get(9),
+            caps.get(10),
+        ) {
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let month: u8 = month_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = caps
+                .get(6)
+                .map(|m| m.as_str().parse().unwrap_or(0))
+                .unwrap_or(0);
             let microsecond: u32 = extract_microseconds(caps.get(7));
-            
+
             let sign_str = tz_sign.as_str();
-            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour"))?;
-            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute"))?;
+            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour")
+            })?;
+            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute")
+            })?;
             let sign = if sign_str == "+" { 1 } else { -1 };
             let offset_minutes = sign * (tz_hour * 60 + tz_min);
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
-            
-            let dt = datetime_class.call1((year, month, day, hour, minute, second, microsecond, tzinfo))?;
+
+            let dt = datetime_class.call1((
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                microsecond,
+                tzinfo,
+            ))?;
             return Ok(dt.to_object(py));
         }
     }
-    
+
     // Try with timezone offset +01:00 or -05:30 (with colon) - allow optional space before timezone
     if let Some(caps) = RE_ISO_DATETIME_TZ_COLON.captures(value) {
-        if let (Some(year_match), Some(month_match), Some(day_match), Some(hour_match), Some(minute_match), Some(tz_sign), Some(tz_hour_match), Some(tz_min_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5), caps.get(8), caps.get(9), caps.get(10)) {
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let month: u8 = month_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = caps.get(6).map(|m| m.as_str().parse().unwrap_or(0)).unwrap_or(0);
+        if let (
+            Some(year_match),
+            Some(month_match),
+            Some(day_match),
+            Some(hour_match),
+            Some(minute_match),
+            Some(tz_sign),
+            Some(tz_hour_match),
+            Some(tz_min_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+            caps.get(8),
+            caps.get(9),
+            caps.get(10),
+        ) {
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let month: u8 = month_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = caps
+                .get(6)
+                .map(|m| m.as_str().parse().unwrap_or(0))
+                .unwrap_or(0);
             let microsecond: u32 = extract_microseconds(caps.get(7));
-            
+
             let sign_str = tz_sign.as_str();
-            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour"))?;
-            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute"))?;
+            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour")
+            })?;
+            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute")
+            })?;
             let sign = if sign_str == "+" { 1 } else { -1 };
             let offset_minutes = sign * (tz_hour * 60 + tz_min);
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
-            
-            let dt = datetime_class.call1((year, month, day, hour, minute, second, microsecond, tzinfo))?;
+
+            let dt = datetime_class.call1((
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                microsecond,
+                tzinfo,
+            ))?;
             return Ok(dt.to_object(py));
         }
     }
-    
+
     // Try without timezone
     if let Some(caps) = RE_ISO_DATETIME_NO_TZ.captures(value) {
-        if let (Some(year_match), Some(month_match), Some(day_match), Some(hour_match), Some(minute_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5)) {
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let month: u8 = month_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = caps.get(6).map(|m| m.as_str().parse().unwrap_or(0)).unwrap_or(0);
+        if let (
+            Some(year_match),
+            Some(month_match),
+            Some(day_match),
+            Some(hour_match),
+            Some(minute_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+        ) {
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let month: u8 = month_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = caps
+                .get(6)
+                .map(|m| m.as_str().parse().unwrap_or(0))
+                .unwrap_or(0);
             let microsecond: u32 = extract_microseconds(caps.get(7));
-            
-            let dt = datetime_class.call1((year, month, day, hour, minute, second, microsecond, py.None()))?;
+
+            let dt = datetime_class.call1((
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                microsecond,
+                py.None(),
+            ))?;
             return Ok(dt.to_object(py));
         }
     }
-    
-    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid ISO 8601 datetime: {}", value)))
+
+    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+        "Invalid ISO 8601 datetime: {}",
+        value
+    )))
 }
 
 #[cfg(test)]
@@ -170,4 +355,3 @@ mod tests {
         assert!(RE_ISO_DATETIME_NO_TZ.is_match("2023-12-25T10:30:45.123456"));
     }
 }
-

--- a/formatparse-pyo3/src/datetime/mod.rs
+++ b/formatparse-pyo3/src/datetime/mod.rs
@@ -14,25 +14,24 @@
 //! - `fixed_tz`: Fixed timezone offset support
 
 pub mod common;
+pub mod ctime;
 pub mod fixed_tz;
+pub mod global;
+pub mod http;
 pub mod iso;
 pub mod rfc2822;
-pub mod global;
-pub mod us;
-pub mod ctime;
-pub mod http;
+pub mod strftime;
 pub mod system;
 pub mod time;
-pub mod strftime;
+pub mod us;
 
+pub use ctime::parse_ctime_datetime;
 pub use fixed_tz::FixedTzOffset;
+pub use global::parse_global_datetime;
+pub use http::parse_http_datetime;
 pub use iso::parse_iso_datetime;
 pub use rfc2822::parse_rfc2822_datetime;
-pub use global::parse_global_datetime;
-pub use us::parse_us_datetime;
-pub use ctime::parse_ctime_datetime;
-pub use http::parse_http_datetime;
+pub use strftime::parse_strftime_datetime;
 pub use system::parse_system_datetime;
 pub use time::parse_time;
-pub use strftime::parse_strftime_datetime;
-
+pub use us::parse_us_datetime;

--- a/formatparse-pyo3/src/datetime/rfc2822.rs
+++ b/formatparse-pyo3/src/datetime/rfc2822.rs
@@ -1,7 +1,7 @@
+use crate::datetime::common::{create_fixed_tz, get_abbreviated_month_map};
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
-use crate::datetime::common::{get_abbreviated_month_map, create_fixed_tz};
 
 // Cached regex patterns for RFC2822 datetime parsing
 static RE_RFC2822_WITH_WEEKDAY_4DIGIT: Lazy<Regex> = Lazy::new(|| {
@@ -19,84 +19,215 @@ static RE_RFC2822_NO_WEEKDAY: Lazy<Regex> = Lazy::new(|| {
 /// Parse RFC2822 datetime string and return Python datetime object
 /// Format: Mon, 21 Nov 2011 10:21:36 +1000
 pub fn parse_rfc2822_datetime(py: Python, value: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
-    
+
     // Map month abbreviations to numbers
     let month_map = get_abbreviated_month_map();
-    
+
     // Try with optional weekday prefix: Mon, 21 Nov 2011 10:21:36 +1000
     if let Some(caps) = RE_RFC2822_WITH_WEEKDAY_4DIGIT.captures(value) {
-        if let (Some(day_match), Some(month_match), Some(year_match), Some(hour_match), Some(minute_match), Some(second_match), Some(tz_sign), Some(tz_hour_match), Some(tz_min_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5), caps.get(6), caps.get(7), caps.get(8), caps.get(9)) {
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+        if let (
+            Some(day_match),
+            Some(month_match),
+            Some(year_match),
+            Some(hour_match),
+            Some(minute_match),
+            Some(second_match),
+            Some(tz_sign),
+            Some(tz_hour_match),
+            Some(tz_min_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+            caps.get(6),
+            caps.get(7),
+            caps.get(8),
+            caps.get(9),
+        ) {
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
             let month_name = month_match.as_str();
-            let month = *month_map.get(month_name).ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid month: {}", month_name)))?;
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = second_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
-            
+            let month = *month_map.get(month_name).ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid month: {}",
+                    month_name
+                ))
+            })?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = second_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
+
             let sign_str = tz_sign.as_str();
-            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour"))?;
-            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute"))?;
+            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour")
+            })?;
+            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute")
+            })?;
             let sign = if sign_str == "+" { 1 } else { -1 };
             let offset_minutes = sign * (tz_hour * 60 + tz_min);
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
-            
+
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
             return Ok(dt.to_object(py));
         }
     }
-    
+
     // Try with timezone +10:00 format
     if let Some(caps) = RE_RFC2822_WITH_WEEKDAY_COLON.captures(value) {
-        if let (Some(day_match), Some(month_match), Some(year_match), Some(hour_match), Some(minute_match), Some(second_match), Some(tz_sign), Some(tz_hour_match), Some(tz_min_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5), caps.get(6), caps.get(7), caps.get(8), caps.get(9)) {
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+        if let (
+            Some(day_match),
+            Some(month_match),
+            Some(year_match),
+            Some(hour_match),
+            Some(minute_match),
+            Some(second_match),
+            Some(tz_sign),
+            Some(tz_hour_match),
+            Some(tz_min_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+            caps.get(6),
+            caps.get(7),
+            caps.get(8),
+            caps.get(9),
+        ) {
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
             let month_name = month_match.as_str();
-            let month = *month_map.get(month_name).ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid month: {}", month_name)))?;
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = second_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
-            
+            let month = *month_map.get(month_name).ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid month: {}",
+                    month_name
+                ))
+            })?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = second_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
+
             let sign_str = tz_sign.as_str();
-            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour"))?;
-            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute"))?;
+            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour")
+            })?;
+            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute")
+            })?;
             let sign = if sign_str == "+" { 1 } else { -1 };
             let offset_minutes = sign * (tz_hour * 60 + tz_min);
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
-            
+
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
             return Ok(dt.to_object(py));
         }
     }
-    
+
     // Try without weekday prefix: 21 Nov 2011 10:21:36 +1000
     if let Some(caps) = RE_RFC2822_NO_WEEKDAY.captures(value) {
-        if let (Some(day_match), Some(month_match), Some(year_match), Some(hour_match), Some(minute_match), Some(second_match), Some(tz_sign), Some(tz_hour_match), Some(tz_min_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5), caps.get(6), caps.get(7), caps.get(8), caps.get(9)) {
-            let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+        if let (
+            Some(day_match),
+            Some(month_match),
+            Some(year_match),
+            Some(hour_match),
+            Some(minute_match),
+            Some(second_match),
+            Some(tz_sign),
+            Some(tz_hour_match),
+            Some(tz_min_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+            caps.get(6),
+            caps.get(7),
+            caps.get(8),
+            caps.get(9),
+        ) {
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
             let month_name = month_match.as_str();
-            let month = *month_map.get(month_name).ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid month: {}", month_name)))?;
-            let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = second_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
-            
+            let month = *month_map.get(month_name).ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid month: {}",
+                    month_name
+                ))
+            })?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = second_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
+
             let sign_str = tz_sign.as_str();
-            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour"))?;
-            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute"))?;
+            let tz_hour: i32 = tz_hour_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone hour")
+            })?;
+            let tz_min: i32 = tz_min_match.as_str().parse().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone minute")
+            })?;
             let sign = if sign_str == "+" { 1 } else { -1 };
             let offset_minutes = sign * (tz_hour * 60 + tz_min);
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
-            
+
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
             return Ok(dt.to_object(py));
         }
     }
-    
-    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid RFC2822 datetime: {}", value)))
-}
 
+    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+        "Invalid RFC2822 datetime: {}",
+        value
+    )))
+}

--- a/formatparse-pyo3/src/datetime/strftime.rs
+++ b/formatparse-pyo3/src/datetime/strftime.rs
@@ -1,6 +1,6 @@
+use crate::datetime::common::get_month_map;
 use pyo3::prelude::*;
 use regex::Regex;
-use crate::datetime::common::get_month_map;
 
 /// Check if a PyErr is a regex group redefinition error from strptime
 fn is_regex_group_redefinition_error(err: &PyErr) -> bool {
@@ -11,19 +11,19 @@ fn is_regex_group_redefinition_error(err: &PyErr) -> bool {
 /// Fallback parser for strftime format strings when strptime fails due to regex group conflicts
 /// This manually parses the format string and extracts datetime components
 fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
     let date_class = datetime_module.getattr("date")?;
     let time_class = datetime_module.getattr("time")?;
-    
+
     // Month name mapping
     let month_map = get_month_map();
-    
+
     // Build a regex with capturing groups for format codes we need to extract
     let mut regex_parts = Vec::new();
     let mut format_code_groups: Vec<(char, usize)> = Vec::new();
     let mut group_index = 1;
-    
+
     let mut chars = format_str.chars().peekable();
     while let Some(ch) = chars.next() {
         if ch == '%' {
@@ -33,52 +33,52 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
                         regex_parts.push(r"(\d{4})".to_string());
                         format_code_groups.push(('Y', group_index));
                         group_index += 1;
-                    },
+                    }
                     'y' => {
                         regex_parts.push(r"(\d{2})".to_string());
                         format_code_groups.push(('y', group_index));
                         group_index += 1;
-                    },
+                    }
                     'm' => {
                         regex_parts.push(r"(\d{1,2})".to_string());
                         format_code_groups.push(('m', group_index));
                         group_index += 1;
-                    },
+                    }
                     'd' => {
                         regex_parts.push(r"(\d{1,2})".to_string());
                         format_code_groups.push(('d', group_index));
                         group_index += 1;
-                    },
+                    }
                     'H' => {
                         regex_parts.push(r"(\d{1,2})".to_string());
                         format_code_groups.push(('H', group_index));
                         group_index += 1;
-                    },
+                    }
                     'M' => {
                         regex_parts.push(r"(\d{1,2})".to_string());
                         format_code_groups.push(('M', group_index));
                         group_index += 1;
-                    },
+                    }
                     'S' => {
                         regex_parts.push(r"(\d{1,2})".to_string());
                         format_code_groups.push(('S', group_index));
                         group_index += 1;
-                    },
+                    }
                     'f' => {
                         regex_parts.push(r"(\d{1,6})".to_string());
                         format_code_groups.push(('f', group_index));
                         group_index += 1;
-                    },
+                    }
                     'b' | 'h' => {
                         regex_parts.push(r"([A-Za-z]{3})".to_string());
                         format_code_groups.push(('b', group_index));
                         group_index += 1;
-                    },
+                    }
                     'B' => {
                         regex_parts.push(r"([A-Za-z]+)".to_string());
                         format_code_groups.push(('B', group_index));
                         group_index += 1;
-                    },
+                    }
                     'a' | 'A' | 'w' | 'j' | 'U' | 'W' | 'c' | 'x' | 'X' | '%' => {
                         // These are matched but we don't need to extract them for datetime construction
                         let pattern = match next_ch {
@@ -92,7 +92,7 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
                             _ => ".+?",
                         };
                         regex_parts.push(pattern.to_string());
-                    },
+                    }
                     _ => {
                         regex_parts.push(r".+?".to_string());
                     }
@@ -102,14 +102,19 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
             regex_parts.push(regex::escape(&ch.to_string()));
         }
     }
-    
+
     let full_regex = format!("^{}$", regex_parts.join(""));
-    let re = Regex::new(&full_regex)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid regex: {}", e)))?;
-    
-    let captures = re.captures(value)
-        .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Value '{}' does not match format '{}'", value, format_str)))?;
-    
+    let re = Regex::new(&full_regex).map_err(|e| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid regex: {}", e))
+    })?;
+
+    let captures = re.captures(value).ok_or_else(|| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "Value '{}' does not match format '{}'",
+            value, format_str
+        ))
+    })?;
+
     // Extract datetime components
     let mut year: Option<i32> = None;
     let mut month: Option<u8> = None;
@@ -118,34 +123,48 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
     let mut minute: Option<u8> = None;
     let mut second: Option<u8> = None;
     let mut microsecond: Option<u32> = None;
-    
+
     for (code, group_idx) in format_code_groups {
         if let Some(cap) = captures.get(group_idx) {
             let val_str = cap.as_str();
             match code {
                 'Y' => {
-                    year = Some(val_str.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?);
-                },
+                    year = Some(val_str.parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year")
+                    })?);
+                }
                 'y' => {
-                    let yy: i32 = val_str.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+                    let yy: i32 = val_str.parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year")
+                    })?;
                     // Convert 2-digit year to 4-digit (assume 2000s for 00-68, 1900s for 69-99)
                     year = Some(if yy <= 68 { 2000 + yy } else { 1900 + yy });
-                },
+                }
                 'm' => {
-                    month = Some(val_str.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?);
-                },
+                    month = Some(val_str.parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month")
+                    })?);
+                }
                 'd' => {
-                    day = Some(val_str.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?);
-                },
+                    day = Some(val_str.parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day")
+                    })?);
+                }
                 'H' => {
-                    hour = Some(val_str.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?);
-                },
+                    hour = Some(val_str.parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour")
+                    })?);
+                }
                 'M' => {
-                    minute = Some(val_str.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?);
-                },
+                    minute = Some(val_str.parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute")
+                    })?);
+                }
                 'S' => {
-                    second = Some(val_str.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?);
-                },
+                    second = Some(val_str.parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second")
+                    })?);
+                }
                 'f' => {
                     // Pad microseconds to 6 digits
                     let micros_str = if val_str.len() > 6 {
@@ -154,27 +173,29 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
                         val_str
                     };
                     let padded = format!("{:0<6}", micros_str);
-                    microsecond = Some(padded.parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid microsecond"))?);
-                },
+                    microsecond = Some(padded.parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid microsecond")
+                    })?);
+                }
                 'b' | 'B' => {
                     month = month_map.get(val_str).copied();
-                },
+                }
                 _ => {}
             }
         }
     }
-    
+
     // Determine what to return based on what components we have
     let has_time = hour.is_some() || minute.is_some() || second.is_some() || microsecond.is_some();
     let has_date = year.is_some() || month.is_some() || day.is_some();
-    
+
     if has_time && !has_date {
         // Time only
         let time_obj = time_class.call1((
             hour.unwrap_or(0),
             minute.unwrap_or(0),
             second.unwrap_or(0),
-            microsecond.unwrap_or(0)
+            microsecond.unwrap_or(0),
         ))?;
         Ok(time_obj.to_object(py))
     } else if has_date && !has_time {
@@ -197,7 +218,7 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
             minute.unwrap_or(0),
             second.unwrap_or(0),
             microsecond.unwrap_or(0),
-            py.None()
+            py.None(),
         ))?;
         Ok(dt.to_object(py))
     }
@@ -205,15 +226,22 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
 
 /// Parse strftime-style datetime using Python's strptime
 pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
     let date_class = datetime_module.getattr("date")?;
     let time_class = datetime_module.getattr("time")?;
-    
+
     // Determine if format contains time components
-    let has_time = format_str.contains("%H") || format_str.contains("%M") || format_str.contains("%S") || format_str.contains("%f");
-    let has_date = format_str.contains("%Y") || format_str.contains("%y") || format_str.contains("%m") || format_str.contains("%d") || format_str.contains("%j");
-    
+    let has_time = format_str.contains("%H")
+        || format_str.contains("%M")
+        || format_str.contains("%S")
+        || format_str.contains("%f");
+    let has_date = format_str.contains("%Y")
+        || format_str.contains("%y")
+        || format_str.contains("%m")
+        || format_str.contains("%d")
+        || format_str.contains("%j");
+
     // Handle time-only patterns
     if has_time && !has_date {
         // Time-only: parse and return time object
@@ -221,7 +249,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
         // Handle %f (microseconds) specially - it needs a dot, not colon
         let mut adjusted_format = format_str.to_string();
         let mut adjusted_value = value.to_string();
-        
+
         // If format has %f but value uses colon separator, convert colon to dot before %f
         if format_str.contains("%f") && value.contains(':') {
             // Find the position of %f in format
@@ -239,31 +267,33 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                         }
                     }
                     if last_colon_pos > 0 {
-                        adjusted_value.replace_range(last_colon_pos..last_colon_pos+1, ".");
+                        adjusted_value.replace_range(last_colon_pos..last_colon_pos + 1, ".");
                         // Also update format if needed
                         if let Some(format_colon_pos) = adjusted_format[..f_pos].rfind(':') {
-                            adjusted_format.replace_range(format_colon_pos..format_colon_pos+1, ".");
+                            adjusted_format
+                                .replace_range(format_colon_pos..format_colon_pos + 1, ".");
                         }
                     }
                 }
             }
         }
-        
+
         let dummy_format = if adjusted_format.contains("%H") {
             adjusted_format.clone()
         } else {
             format!("%H:{}", adjusted_format) // Add hour if missing (defaults to 0)
         };
-        let dummy_value = if adjusted_value.matches(':').count() < 2 && !adjusted_format.contains("%H") {
-            format!("0:{}", adjusted_value) // Add hour 0 if missing
-        } else {
-            adjusted_value
-        };
-        
+        let dummy_value =
+            if adjusted_value.matches(':').count() < 2 && !adjusted_format.contains("%H") {
+                format!("0:{}", adjusted_value) // Add hour 0 if missing
+            } else {
+                adjusted_value
+            };
+
         // Add dummy date prefix for strptime
         let full_format = format!("1970-01-01 {}", dummy_format);
         let full_value = format!("1970-01-01 {}", dummy_value);
-        
+
         let strptime = datetime_class.getattr("strptime")?;
         match strptime.call1((full_value.as_str(), full_format.as_str())) {
             Ok(dt) => {
@@ -273,7 +303,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                 let microsecond: u32 = dt.getattr("microsecond")?.extract().unwrap_or(0);
                 let time_obj = time_class.call1((hour, minute, second, microsecond))?;
                 Ok(time_obj.to_object(py))
-            },
+            }
             Err(e) => {
                 // Check if this is a regex group redefinition error
                 if is_regex_group_redefinition_error(&e) {
@@ -291,8 +321,12 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
             // Parse day of year format
             if let Ok(re) = Regex::new(r"^(\d{4})/(\d{1,3})$") {
                 if let Some(caps) = re.captures(value) {
-                    let year: i32 = caps.get(1).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-                    let day_of_year: u16 = caps.get(2).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day of year"))?;
+                    let year: i32 = caps.get(1).unwrap().as_str().parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year")
+                    })?;
+                    let day_of_year: u16 = caps.get(2).unwrap().as_str().parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day of year")
+                    })?;
                     // Create date from year and day of year
                     let jan1 = date_class.call1((year, 1, 1))?;
                     let timedelta = datetime_module.getattr("timedelta")?;
@@ -307,7 +341,9 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                 if let Some(caps) = re.captures(value) {
                     let today = datetime_class.call_method0("today")?;
                     let year: i32 = today.getattr("year")?.extract()?;
-                    let day_of_year: u16 = caps.get(1).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day of year"))?;
+                    let day_of_year: u16 = caps.get(1).unwrap().as_str().parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day of year")
+                    })?;
                     let jan1 = date_class.call1((year, 1, 1))?;
                     let timedelta = datetime_module.getattr("timedelta")?;
                     let days = timedelta.call1((day_of_year as i32 - 1,))?;
@@ -317,7 +353,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                 }
             }
         }
-        
+
         // Use datetime.strptime for parsing dates
         // Try with the original format first
         let strptime = datetime_class.getattr("strptime")?;
@@ -329,7 +365,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                 let day: u8 = dt.getattr("day")?.extract()?;
                 let date = date_class.call1((year, month, day))?;
                 Ok(date.to_object(py))
-            },
+            }
             Err(e) => {
                 // Check if this is a regex group redefinition error
                 if is_regex_group_redefinition_error(&e) {
@@ -339,23 +375,47 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                 // If strptime fails for other reasons, try to parse manually for flexible formats
                 // Handle single-digit months/days by trying flexible parsing
                 // For formats like %Y/%m/%d, try to parse with regex
-                if format_str.contains("%Y") && format_str.contains("%m") && format_str.contains("%d") {
+                if format_str.contains("%Y")
+                    && format_str.contains("%m")
+                    && format_str.contains("%d")
+                {
                     // Try to parse YYYY/MM/DD or YYYY/M/D format (flexible separators)
                     // Match the separator used in format_str
-                    let sep = if format_str.contains('/') { "/" } else if format_str.contains('-') { "-" } else { "/" };
-                    let pattern = format!(r"^(\d{{4}})\{}(\d{{1,2}})\{}(\d{{1,2}})$", regex::escape(sep), regex::escape(sep));
+                    let sep = if format_str.contains('/') {
+                        "/"
+                    } else if format_str.contains('-') {
+                        "-"
+                    } else {
+                        "/"
+                    };
+                    let pattern = format!(
+                        r"^(\d{{4}})\{}(\d{{1,2}})\{}(\d{{1,2}})$",
+                        regex::escape(sep),
+                        regex::escape(sep)
+                    );
                     if let Ok(re) = Regex::new(&pattern) {
                         if let Some(caps) = re.captures(value) {
-                            let year: i32 = caps.get(1).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-                            let month: u8 = caps.get(2).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
-                            let day: u8 = caps.get(3).unwrap().as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+                            let year: i32 =
+                                caps.get(1).unwrap().as_str().parse().map_err(|_| {
+                                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year")
+                                })?;
+                            let month: u8 =
+                                caps.get(2).unwrap().as_str().parse().map_err(|_| {
+                                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month")
+                                })?;
+                            let day: u8 = caps.get(3).unwrap().as_str().parse().map_err(|_| {
+                                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day")
+                            })?;
                             let date = date_class.call1((year, month, day))?;
                             return Ok(date.to_object(py));
                         }
                     }
                 }
                 // If all else fails, return the original error
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid date format: {} with format {}", value, format_str)))
+                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid date format: {} with format {}",
+                    value, format_str
+                )))
             }
         }
     } else {
@@ -375,4 +435,3 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
         }
     }
 }
-

--- a/formatparse-pyo3/src/datetime/system.rs
+++ b/formatparse-pyo3/src/datetime/system.rs
@@ -1,7 +1,7 @@
+use crate::datetime::common::get_abbreviated_month_map;
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
-use crate::datetime::common::get_abbreviated_month_map;
 
 // Cached regex pattern for system datetime parsing
 static RE_SYSTEM_DATETIME: Lazy<Regex> = Lazy::new(|| {
@@ -10,29 +10,69 @@ static RE_SYSTEM_DATETIME: Lazy<Regex> = Lazy::new(|| {
 
 /// Parse Linux system log format: Nov 21 10:21:36 (year is current year)
 pub fn parse_system_datetime(py: Python, value: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
     let today = datetime_class.call_method0("today")?;
     let current_year: i32 = today.getattr("year")?.extract()?;
-    
+
     let month_map = get_abbreviated_month_map();
-    
+
     // Nov 21 10:21:36 or Nov  1 10:21:36 (note the double space)
     if let Some(caps) = RE_SYSTEM_DATETIME.captures(value) {
-        if let (Some(month_match), Some(day_match), Some(hour_match), Some(minute_match), Some(second_match)) = 
-            (caps.get(1), caps.get(2), caps.get(3), caps.get(4), caps.get(5)) {
+        if let (
+            Some(month_match),
+            Some(day_match),
+            Some(hour_match),
+            Some(minute_match),
+            Some(second_match),
+        ) = (
+            caps.get(1),
+            caps.get(2),
+            caps.get(3),
+            caps.get(4),
+            caps.get(5),
+        ) {
             let month_name = month_match.as_str();
-            let month = *month_map.get(month_name).ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid month: {}", month_name)))?;
-            let day: u8 = day_match.as_str().trim().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-            let hour: u8 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
-            let minute: u8 = minute_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
-            let second: u8 = second_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
-            
-            let dt = datetime_class.call1((current_year, month, day, hour, minute, second, 0, py.None()))?;
+            let month = *month_map.get(month_name).ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid month: {}",
+                    month_name
+                ))
+            })?;
+            let day: u8 = day_match
+                .as_str()
+                .trim()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let hour: u8 = hour_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid hour"))?;
+            let minute: u8 = minute_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid minute"))?;
+            let second: u8 = second_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid second"))?;
+
+            let dt = datetime_class.call1((
+                current_year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                0,
+                py.None(),
+            ))?;
             return Ok(dt.to_object(py));
         }
     }
-    
-    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid system datetime: {}", value)))
-}
 
+    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+        "Invalid system datetime: {}",
+        value
+    )))
+}

--- a/formatparse-pyo3/src/datetime/time.rs
+++ b/formatparse-pyo3/src/datetime/time.rs
@@ -1,23 +1,25 @@
+use crate::datetime::common::{create_fixed_tz, parse_time_with_ampm, RE_TZ_COLON};
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
-use crate::datetime::common::{create_fixed_tz, parse_time_with_ampm, RE_TZ_COLON};
 
 // Cached regex pattern for timezone in time string
-static RE_TIME_TZ: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"\s+([+-]\d{1,2}:?\d{2,4})$").unwrap()
-});
+static RE_TIME_TZ: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+([+-]\d{1,2}:?\d{2,4})$").unwrap());
 
 /// Parse time format: 10:21:36, 10:21:36 AM, 10:21:36 PM, 10:21 - returns time object
 pub fn parse_time(py: Python, value: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let time_class = datetime_module.getattr("time")?;
-    
+
     let parse_tz = |tz_str: &str| -> PyResult<PyObject> {
         if let Some(caps) = RE_TZ_COLON.captures(tz_str) {
-            if let (Some(sign_match), Some(hour_match), Some(min_match)) = (caps.get(1), caps.get(2), caps.get(3)) {
+            if let (Some(sign_match), Some(hour_match), Some(min_match)) =
+                (caps.get(1), caps.get(2), caps.get(3))
+            {
                 let sign = if sign_match.as_str() == "+" { 1 } else { -1 };
-                let hour: i32 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone"))?;
+                let hour: i32 = hour_match.as_str().parse().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone")
+                })?;
                 let min: i32 = min_match.as_str().parse().unwrap_or(0);
                 let offset_minutes = sign * (hour * 60 + min);
                 return create_fixed_tz(py, offset_minutes, "");
@@ -25,19 +27,19 @@ pub fn parse_time(py: Python, value: &str) -> PyResult<PyObject> {
         }
         Ok(py.None())
     };
-    
+
     // Check for timezone at the end
-    let (time_str, tzinfo) = if let Some(tz_match) = RE_TIME_TZ.captures(value).and_then(|c| c.get(1)) {
-        let tz_str = tz_match.as_str();
-        let time_only = value[..value.len() - tz_str.len()].trim();
-        (time_only, parse_tz(tz_str)?)
-    } else {
-        (value.trim(), py.None())
-    };
-    
+    let (time_str, tzinfo) =
+        if let Some(tz_match) = RE_TIME_TZ.captures(value).and_then(|c| c.get(1)) {
+            let tz_str = tz_match.as_str();
+            let time_only = value[..value.len() - tz_str.len()].trim();
+            (time_only, parse_tz(tz_str)?)
+        } else {
+            (value.trim(), py.None())
+        };
+
     let (hour, minute, second) = parse_time_with_ampm(time_str)?;
-    
+
     let time_obj = time_class.call1((hour, minute, second, 0, tzinfo))?;
     Ok(time_obj.to_object(py))
 }
-

--- a/formatparse-pyo3/src/datetime/us.rs
+++ b/formatparse-pyo3/src/datetime/us.rs
@@ -1,12 +1,13 @@
+use crate::datetime::common::{
+    create_fixed_tz, get_month_map, RE_TZ_4DIGIT, RE_TZ_COLON, RE_TZ_IN_STRING_EXTENDED,
+};
+use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use regex::Regex;
-use once_cell::sync::Lazy;
-use crate::datetime::common::{get_month_map, create_fixed_tz, RE_TZ_COLON, RE_TZ_4DIGIT, RE_TZ_IN_STRING_EXTENDED};
 
 // Cached regex patterns for US datetime parsing
-static RE_US_NUMERIC: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^(\d{1,2})[-/](\d{1,2})[-/](\d{4})(?:\s+(.+))?$").unwrap()
-});
+static RE_US_NUMERIC: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(\d{1,2})[-/](\d{1,2})[-/](\d{4})(?:\s+(.+))?$").unwrap());
 
 static RE_US_NAMED: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)[-/](\d{1,2})[-/](\d{4})(?:\s+(.+))?$").unwrap()
@@ -14,17 +15,21 @@ static RE_US_NAMED: Lazy<Regex> = Lazy::new(|| {
 
 /// Parse US (month/day) datetime format - similar to global but different order
 pub fn parse_us_datetime(py: Python, value: &str) -> PyResult<PyObject> {
-    let datetime_module = py.import_bound("datetime")?;
+    let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
-    
+
     let month_map = get_month_map();
-    
+
     let parse_tz = |tz_str: &str| -> PyResult<PyObject> {
         // Handle formats: +1000, +10:00, +10:30, etc.
         if let Some(caps) = RE_TZ_COLON.captures(tz_str) {
-            if let (Some(sign_match), Some(hour_match), Some(min_match)) = (caps.get(1), caps.get(2), caps.get(3)) {
+            if let (Some(sign_match), Some(hour_match), Some(min_match)) =
+                (caps.get(1), caps.get(2), caps.get(3))
+            {
                 let sign = if sign_match.as_str() == "+" { 1 } else { -1 };
-                let hour: i32 = hour_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone"))?;
+                let hour: i32 = hour_match.as_str().parse().map_err(|_| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone")
+                })?;
                 let min: i32 = min_match.as_str().parse().unwrap_or(0);
                 let offset_minutes = sign * (hour * 60 + min);
                 return create_fixed_tz(py, offset_minutes, "");
@@ -37,8 +42,12 @@ pub fn parse_us_datetime(py: Python, value: &str) -> PyResult<PyObject> {
                 let tz_str = tz_match.as_str();
                 // Regex ensures exactly 4 digits, but add defensive check
                 if tz_str.len() >= 4 {
-                    let hour: i32 = tz_str[..2].parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone"))?;
-                    let min: i32 = tz_str[2..4].parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone"))?;
+                    let hour: i32 = tz_str[..2].parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone")
+                    })?;
+                    let min: i32 = tz_str[2..4].parse().map_err(|_| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid timezone")
+                    })?;
                     let offset_minutes = sign * (hour * 60 + min);
                     return create_fixed_tz(py, offset_minutes, "");
                 }
@@ -46,70 +55,102 @@ pub fn parse_us_datetime(py: Python, value: &str) -> PyResult<PyObject> {
         }
         Ok(py.None())
     };
-    
+
     let parse_time_with_ampm = |time_str: &str| -> Result<(u8, u8, u8), PyErr> {
         crate::datetime::common::parse_time_with_ampm(time_str)
     };
-    
+
     // Numeric format: 11/21/2011 or 11-21-2011 (month/day/year)
     if let Some(caps) = RE_US_NUMERIC.captures(value) {
-        if let (Some(month_match), Some(day_match), Some(year_match)) = (caps.get(1), caps.get(2), caps.get(3)) {
-                let month: u8 = month_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
-                let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-                let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-                
-                let (hour, minute, second, tzinfo) = if let Some(time_part) = caps.get(4) {
-                    let time_str = time_part.as_str().trim();
-                    // Try to match timezone: +1000, +10:00, +10:30, etc.
-                    if let Some(tz_match) = RE_TZ_IN_STRING_EXTENDED.captures(time_str).and_then(|c| c.get(1)) {
-                        let tz_str = tz_match.as_str();
-                        let time_only = time_str[..time_str.len() - tz_str.len()].trim();
-                        let (h, m, s) = parse_time_with_ampm(time_only)?;
-                        let tz = parse_tz(tz_str)?;
-                        (h, m, s, tz)
-                    } else {
-                        let (h, m, s) = parse_time_with_ampm(time_str)?;
-                        (h, m, s, py.None())
-                    }
+        if let (Some(month_match), Some(day_match), Some(year_match)) =
+            (caps.get(1), caps.get(2), caps.get(3))
+        {
+            let month: u8 = month_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid month"))?;
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+
+            let (hour, minute, second, tzinfo) = if let Some(time_part) = caps.get(4) {
+                let time_str = time_part.as_str().trim();
+                // Try to match timezone: +1000, +10:00, +10:30, etc.
+                if let Some(tz_match) = RE_TZ_IN_STRING_EXTENDED
+                    .captures(time_str)
+                    .and_then(|c| c.get(1))
+                {
+                    let tz_str = tz_match.as_str();
+                    let time_only = time_str[..time_str.len() - tz_str.len()].trim();
+                    let (h, m, s) = parse_time_with_ampm(time_only)?;
+                    let tz = parse_tz(tz_str)?;
+                    (h, m, s, tz)
                 } else {
-                    (0, 0, 0, py.None())
-                };
-                
-                let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-                return Ok(dt.to_object(py));
+                    let (h, m, s) = parse_time_with_ampm(time_str)?;
+                    (h, m, s, py.None())
+                }
+            } else {
+                (0, 0, 0, py.None())
+            };
+
+            let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
+            return Ok(dt.to_object(py));
         }
     }
-    
+
     // Named month format: Nov-21-2011 or November-21-2011 (month-day-year)
     if let Some(caps) = RE_US_NAMED.captures(value) {
-        if let (Some(month_match), Some(day_match), Some(year_match)) = (caps.get(1), caps.get(2), caps.get(3)) {
-                let month_name = month_match.as_str();
-                let month = *month_map.get(month_name).ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid month: {}", month_name)))?;
-                let day: u8 = day_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
-                let year: i32 = year_match.as_str().parse().map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
-                
-                let (hour, minute, second, tzinfo) = if let Some(time_part) = caps.get(4) {
-                    let time_str = time_part.as_str().trim();
-                    // Try to match timezone: +1000, +10:00, +10:30, etc.
-                    if let Some(tz_match) = RE_TZ_IN_STRING_EXTENDED.captures(time_str).and_then(|c| c.get(1)) {
-                        let tz_str = tz_match.as_str();
-                        let time_only = time_str[..time_str.len() - tz_str.len()].trim();
-                        let (h, m, s) = parse_time_with_ampm(time_only)?;
-                        let tz = parse_tz(tz_str)?;
-                        (h, m, s, tz)
-                    } else {
-                        let (h, m, s) = parse_time_with_ampm(time_str)?;
-                        (h, m, s, py.None())
-                    }
+        if let (Some(month_match), Some(day_match), Some(year_match)) =
+            (caps.get(1), caps.get(2), caps.get(3))
+        {
+            let month_name = month_match.as_str();
+            let month = *month_map.get(month_name).ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid month: {}",
+                    month_name
+                ))
+            })?;
+            let day: u8 = day_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
+            let year: i32 = year_match
+                .as_str()
+                .parse()
+                .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid year"))?;
+
+            let (hour, minute, second, tzinfo) = if let Some(time_part) = caps.get(4) {
+                let time_str = time_part.as_str().trim();
+                // Try to match timezone: +1000, +10:00, +10:30, etc.
+                if let Some(tz_match) = RE_TZ_IN_STRING_EXTENDED
+                    .captures(time_str)
+                    .and_then(|c| c.get(1))
+                {
+                    let tz_str = tz_match.as_str();
+                    let time_only = time_str[..time_str.len() - tz_str.len()].trim();
+                    let (h, m, s) = parse_time_with_ampm(time_only)?;
+                    let tz = parse_tz(tz_str)?;
+                    (h, m, s, tz)
                 } else {
-                    (0, 0, 0, py.None())
-                };
-                
-                let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-                return Ok(dt.to_object(py));
+                    let (h, m, s) = parse_time_with_ampm(time_str)?;
+                    (h, m, s, py.None())
+                }
+            } else {
+                (0, 0, 0, py.None())
+            };
+
+            let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
+            return Ok(dt.to_object(py));
         }
     }
-    
-    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid US datetime: {}", value)))
-}
 
+    Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+        "Invalid US datetime: {}",
+        value
+    )))
+}

--- a/formatparse-pyo3/src/error.rs
+++ b/formatparse-pyo3/src/error.rs
@@ -1,51 +1,52 @@
-use pyo3::prelude::*;
 use formatparse_core::error::FormatParseError;
+use pyo3::prelude::*;
 
-/// Error types for formatparse PyO3 bindings
-/// 
-/// This module bridges formatparse-core errors to PyO3 errors
-
-/// Convert a formatparse-core error to a PyO3 error
+/// Convert a formatparse-core error to a PyO3 error.
+///
+/// Error types for formatparse PyO3 bindings; bridges formatparse-core errors to PyO3.
 pub fn core_error_to_py_err(err: FormatParseError) -> PyErr {
     match err {
         FormatParseError::PatternError(msg) => {
             PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Pattern error: {}", msg))
         }
-        FormatParseError::RegexError(msg) => {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid regex pattern: {}", msg))
-        }
+        FormatParseError::RegexError(msg) => PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            format!("Invalid regex pattern: {}", msg),
+        ),
         FormatParseError::ConversionError(value, target_type) => {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                format!("Invalid {}: {}", target_type, value)
-            )
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Invalid {}: {}",
+                target_type, value
+            ))
         }
         FormatParseError::RepeatedNameError(name) => {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                format!("Repeated name '{}' with mismatched types", name)
-            )
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Repeated name '{}' with mismatched types",
+                name
+            ))
         }
         FormatParseError::CustomTypeError(type_name, msg) => {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                format!("Custom type '{}' error: {}", type_name, msg)
-            )
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Custom type '{}' error: {}",
+                type_name, msg
+            ))
         }
         FormatParseError::RegexGroupIndexError(type_name, actual, expected) => {
-            PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!(
-                    "Custom type '{}' pattern has {} capturing groups but regex_group_count is {}",
-                    type_name, actual, expected
-                )
-            )
+            PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Custom type '{}' pattern has {} capturing groups but regex_group_count is {}",
+                type_name, actual, expected
+            ))
         }
         FormatParseError::NotImplementedError(feature) => {
-            PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
-                format!("{} is not supported", feature)
-            )
+            PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(format!(
+                "{} is not supported",
+                feature
+            ))
         }
         FormatParseError::MissingFieldError(field) => {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                format!("Missing required field: {}", field)
-            )
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Missing required field: {}",
+                field
+            ))
         }
     }
 }
@@ -66,47 +67,50 @@ pub mod errors {
 
     /// Create a type conversion error
     pub fn conversion_error(value: &str, target_type: &str) -> PyErr {
-        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            format!("Invalid {}: {}", target_type, value)
-        )
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "Invalid {}: {}",
+            target_type, value
+        ))
     }
 
     /// Create a repeated name error with type mismatch
     pub fn repeated_name_error(name: &str) -> PyErr {
-        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            format!("Repeated name '{}' with mismatched types", name)
-        )
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "Repeated name '{}' with mismatched types",
+            name
+        ))
     }
 
     /// Create a custom type validation error
     pub fn custom_type_error(type_name: &str, msg: &str) -> PyErr {
-        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            format!("Custom type '{}' error: {}", type_name, msg)
-        )
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "Custom type '{}' error: {}",
+            type_name, msg
+        ))
     }
 
     /// Create an index error for regex group access
     pub fn regex_group_index_error(type_name: &str, actual: usize, expected: i64) -> PyErr {
-        PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-            format!(
-                "Custom type '{}' pattern has {} capturing groups but regex_group_count is {}",
-                type_name, actual, expected
-            )
-        )
+        PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+            "Custom type '{}' pattern has {} capturing groups but regex_group_count is {}",
+            type_name, actual, expected
+        ))
     }
 
     /// Create a not implemented error
     pub fn not_implemented_error(feature: &str) -> PyErr {
-        PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
-            format!("{} is not supported", feature)
-        )
+        PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(format!(
+            "{} is not supported",
+            feature
+        ))
     }
 
     /// Create a missing field error
     pub fn missing_field_error(field: &str) -> PyErr {
-        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            format!("Missing required field: {}", field)
-        )
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "Missing required field: {}",
+            field
+        ))
     }
 
     /// Create a validation error (used to signal invalid alignment+precision combinations)

--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -1,45 +1,52 @@
 //! formatparse-pyo3: PyO3 bindings for formatparse
 //!
-//! This crate provides Python bindings for the formatparse-core library.
+//! formatparse-pyo3 provides Python bindings for the formatparse-core library.
 
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
-use pyo3::types::{PyDict, PyList};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use once_cell::sync::Lazy;
+#![allow(deprecated)] // PyO3: ToPyObject::to_object pending migration to IntoPyObject
+#![allow(dead_code)] // Public / reserved helpers (e.g. error constructors, datetime parsers)
+#![allow(clippy::if_same_then_else)] // Parser mirrors symmetric branches intentionally
+#![allow(clippy::manual_strip)] // Signed numeric parsing keeps explicit slice paths
+#![allow(clippy::too_many_arguments)] // PyO3 entry points and format spec plumbing
+#![allow(clippy::type_complexity)] // PyO3-heavy signatures
+#![allow(clippy::wrong_self_convention)] // `to_py_object` mirrors Python naming
+
 use lru::LruCache;
-use std::num::NonZeroUsize;
-use std::hash::{Hash, Hasher};
+use once_cell::sync::Lazy;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
 
 // Use formatparse-core for pure Rust types (imported below via pub use)
 
 mod datetime;
 mod error;
+mod match_rs;
 mod parser;
 mod result;
 mod results;
 mod types;
-mod match_rs;
 
 pub use datetime::FixedTzOffset;
-pub use parser::{FormatParser, Format};
+pub use parser::{Format, FormatParser};
 pub use result::*;
 pub use results::Results;
 pub use types::conversion::*;
 // Core types come from formatparse-core
-pub use formatparse_core::{FieldType, FieldSpec};
 pub use formatparse_core::strftime_to_regex;
+pub use formatparse_core::{FieldSpec, FieldType};
 pub use match_rs::Match;
 
 // Pattern cache for compiled FormatParser instances
 // Cache size: 1000 patterns
 // Using u64 hash as key for faster lookups
 // Using Arc to avoid expensive clones
-static PATTERN_CACHE: Lazy<Mutex<LruCache<u64, Arc<FormatParser>>>> = Lazy::new(|| {
-    Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap()))
-});
+static PATTERN_CACHE: Lazy<Mutex<LruCache<u64, Arc<FormatParser>>>> =
+    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap())));
 
 /// Create a cache key hash from pattern and extra_types
 fn create_cache_key_hash(pattern: &str, extra_types: &Option<HashMap<String, PyObject>>) -> u64 {
@@ -62,26 +69,26 @@ fn get_or_create_parser(
     extra_types: Option<HashMap<String, PyObject>>,
 ) -> PyResult<Arc<FormatParser>> {
     let cache_key = create_cache_key_hash(pattern, &extra_types);
-    
+
     // Try to get from cache (minimize lock scope)
     let cached = {
         let mut cache = PATTERN_CACHE.lock().unwrap();
         cache.get(&cache_key).cloned()
     };
-    
+
     if let Some(cached_parser) = cached {
         return Ok(cached_parser);
     }
-    
+
     // Not in cache, create new parser
     let parser = Arc::new(FormatParser::new_with_extra_types(pattern, extra_types)?);
-    
+
     // Store in cache (minimize lock scope)
     {
         let mut cache = PATTERN_CACHE.lock().unwrap();
         cache.put(cache_key, parser.clone());
     }
-    
+
     Ok(parser)
 }
 
@@ -97,22 +104,28 @@ fn parse(
 ) -> PyResult<Option<PyObject>> {
     // Validate input lengths
     formatparse_core::validate_pattern_length(pattern)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
     formatparse_core::validate_input_length(string)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
-    
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
+
     // Check for null bytes in inputs
     if pattern.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err("Pattern contains null byte"));
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Pattern contains null byte",
+        ));
     }
     if string.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err("Input string contains null byte"));
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Input string contains null byte",
+        ));
     }
-    
+
     // Use cached parser if available
     let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
         extra_types.as_ref().map(|et| {
-            et.iter().map(|(k, v)| (k.clone(), v.clone_ref(py).into())).collect()
+            et.iter()
+                .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                .collect()
         })
     });
     match get_or_create_parser(pattern, extra_types_cloned) {
@@ -149,7 +162,7 @@ fn search(
     if pos > string.len() {
         return Ok(None);
     }
-    
+
     // Validate endpos parameter
     let end = endpos.unwrap_or(string.len());
     if end > string.len() {
@@ -158,30 +171,38 @@ fn search(
     if end < pos {
         return Ok(None);
     }
-    
+
     // Validate input lengths
     formatparse_core::validate_pattern_length(pattern)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
     formatparse_core::validate_input_length(string)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
-    
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
+
     // Check for null bytes in inputs
     if pattern.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err("Pattern contains null byte"));
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Pattern contains null byte",
+        ));
     }
     if string.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err("Input string contains null byte"));
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Input string contains null byte",
+        ));
     }
-    
+
     let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
         extra_types.as_ref().map(|et| {
-            et.iter().map(|(k, v)| (k.clone(), v.clone_ref(py).into())).collect()
+            et.iter()
+                .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                .collect()
         })
     });
     let parser = get_or_create_parser(pattern, extra_types_cloned)?;
     let search_string = &string[pos..end];
-    
-    if let Some(result) = parser.search_pattern(search_string, case_sensitive, extra_types, evaluate_result)? {
+
+    if let Some(result) =
+        parser.search_pattern(search_string, case_sensitive, extra_types, evaluate_result)?
+    {
         // Adjust positions if it's a ParseResult (not Match)
         Python::with_gil(|py| {
             if let Ok(parse_result) = result.bind(py).downcast::<ParseResult>() {
@@ -212,48 +233,57 @@ fn findall(
 ) -> PyResult<PyObject> {
     // Validate input lengths
     formatparse_core::validate_pattern_length(pattern)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
     formatparse_core::validate_input_length(string)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
-    
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
+
     // Check for null bytes in inputs
     if pattern.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err("Pattern contains null byte"));
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Pattern contains null byte",
+        ));
     }
     if string.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err("Input string contains null byte"));
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Input string contains null byte",
+        ));
     }
-    
+
     let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
         extra_types.as_ref().map(|et| {
-            et.iter().map(|(k, v)| (k.clone(), v.clone_ref(py).into())).collect()
+            et.iter()
+                .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                .collect()
         })
     });
     let parser = get_or_create_parser(pattern, extra_types_cloned)?;
-    
+
     // Fast path: if no custom converters and evaluate_result=True, use raw matching
     // This defers all Python object creation until the end (batch conversion)
     // CRITICAL: Do ALL regex matching OUTSIDE GIL, then batch convert inside GIL
-    let has_custom_converters = extra_types.as_ref().map(|et| !et.is_empty()).unwrap_or(false);
+    let has_custom_converters = extra_types
+        .as_ref()
+        .map(|et| !et.is_empty())
+        .unwrap_or(false);
     let has_nested_dicts = parser.has_nested_dict_fields.iter().any(|&b| b);
-    
+
     if !has_custom_converters && evaluate_result && !has_nested_dicts {
         // Use raw matching path: collect all raw data first (NO GIL), then batch convert
         let mut raw_results = Vec::new();
         let search_regex = parser.get_search_regex(case_sensitive);
         let mut last_end = 0;
-        
+
         // Collect all raw matches OUTSIDE GIL (no Python objects created yet)
         // This is the key optimization: all CPU work happens without GIL
         for captures in search_regex.captures_iter(string) {
             let full_match = captures.get(0).unwrap();
             let match_start = full_match.start();
             let match_end = full_match.end();
-            
+
             if match_start < last_end {
                 continue;
             }
-            
+
             // Try raw matching (no Python objects, no GIL needed)
             if let Ok(Some(raw_data)) = crate::parser::matching::match_with_captures_raw(
                 &captures,
@@ -267,13 +297,13 @@ fn findall(
             ) {
                 raw_results.push(raw_data);
                 last_end = match_end;
-                
+
                 if match_start == match_end {
                     last_end += 1;
                 }
             }
         }
-        
+
         // Return Results object with raw data (lazy conversion)
         // This avoids creating all ParseResult objects upfront
         // The Results object is lightweight - just stores raw data
@@ -282,9 +312,9 @@ fn findall(
             Ok(Py::new(py, results)?.into_py(py))
         });
     }
-    
-        // Fallback: use Python path (for custom converters or evaluate_result=False)
-        // Optimized: Collect results first, then create PyList with items directly
+
+    // Fallback: use Python path (for custom converters or evaluate_result=False)
+    // Optimized: Collect results first, then create PyList with items directly
     Python::with_gil(|py| -> PyResult<PyObject> {
         let search_regex = parser.get_search_regex(case_sensitive);
         let mut results = Vec::new();
@@ -294,18 +324,18 @@ fn findall(
         } else {
             &HashMap::new()
         };
-        
+
         for captures in search_regex.captures_iter(string) {
             let full_match = captures.get(0).unwrap();
             let match_start = full_match.start();
             let match_end = full_match.end();
-            
+
             if match_start < last_end {
                 continue;
             }
-            
+
             let extra_types_ref = &extra_types_for_matching;
-            
+
             if let Some(result) = crate::parser::matching::match_with_captures(
                 &captures,
                 string,
@@ -322,18 +352,16 @@ fn findall(
             )? {
                 results.push(result);
                 last_end = match_end;
-                
+
                 if match_start == match_end {
                     last_end += 1;
                 }
             }
         }
-        
+
         // Create PyList with items directly (more efficient than empty + append)
         // Convert PyObject to Bound<PyAny> for PyList::new
-        let items: Vec<_> = results.iter()
-            .map(|obj| obj.bind(py))
-            .collect();
+        let items: Vec<_> = results.iter().map(|obj| obj.bind(py)).collect();
         let results_list = PyList::new(py, items)?;
         Ok(results_list.into())
     })
@@ -347,14 +375,13 @@ fn compile(
     extra_types: Option<HashMap<String, PyObject>>,
 ) -> PyResult<FormatParser> {
     // Validate pattern length
-    formatparse_core::validate_pattern_length(pattern)
-        .map_err(|e| PyValueError::new_err(e))?;
-    
+    formatparse_core::validate_pattern_length(pattern).map_err(PyValueError::new_err)?;
+
     // Check for null bytes in pattern
     if pattern.contains('\0') {
         return Err(PyValueError::new_err("Pattern contains null byte"));
     }
-    
+
     FormatParser::new_with_extra_types(pattern, extra_types)
 }
 
@@ -366,11 +393,11 @@ fn extract_format(
     _match_dict: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<PyObject> {
     use crate::types::FieldSpec;
-    
+
     // Parse the format spec string
     let mut spec = FieldSpec::new();
     crate::parser::pattern::parse_format_spec(format_string, &mut spec, None);
-    
+
     // Extract type from the original format_string (preserve original type chars like 'o', 'x', 'b')
     // Parse the format spec to extract the type characters that come after width/precision/alignment
     let type_str: String = if format_string == "%" {
@@ -381,43 +408,45 @@ fn extract_format(
         let chars: Vec<char> = format_string.chars().collect();
         let mut i = 0;
         let len = chars.len();
-        
+
         // Skip fill and align
         if i < len && (chars[i] == '<' || chars[i] == '>' || chars[i] == '^' || chars[i] == '=') {
             i += 1;
         } else if i + 1 < len {
             let ch = chars[i];
             let next_ch = chars[i + 1];
-            if (next_ch == '<' || next_ch == '>' || next_ch == '^' || next_ch == '=') && ch != next_ch {
+            if (next_ch == '<' || next_ch == '>' || next_ch == '^' || next_ch == '=')
+                && ch != next_ch
+            {
                 i += 2; // Skip fill + align
             }
         }
-        
+
         // Skip sign
         if i < len && (chars[i] == '+' || chars[i] == '-' || chars[i] == ' ') {
             i += 1;
         }
-        
+
         // Skip #
         if i < len && chars[i] == '#' {
             i += 1;
         }
-        
+
         // Skip 0
         if i < len && chars[i] == '0' {
             i += 1;
         }
-        
+
         // Skip width (digits)
         while i < len && chars[i].is_ascii_digit() {
             i += 1;
         }
-        
+
         // Skip comma
         if i < len && chars[i] == ',' {
             i += 1;
         }
-        
+
         // Skip precision (.digits)
         if i < len && chars[i] == '.' {
             i += 1;
@@ -425,7 +454,7 @@ fn extract_format(
                 i += 1;
             }
         }
-        
+
         // Type is the rest
         if i < len {
             format_string[i..].to_string()
@@ -433,41 +462,40 @@ fn extract_format(
             "s".to_string() // Default
         }
     };
-    
+
     // Build result dictionary
     Python::with_gil(|py| {
         let result = PyDict::new(py);
         result.set_item("type", type_str)?;
-        
+
         // Extract width
         if let Some(width) = spec.width {
             result.set_item("width", width.to_string())?;
         }
-        
+
         // Extract precision
         if let Some(precision) = spec.precision {
             result.set_item("precision", precision.to_string())?;
         }
-        
+
         // Extract alignment
         if let Some(align) = spec.alignment {
             result.set_item("align", align.to_string())?;
         }
-        
+
         // Extract fill
         if let Some(fill) = spec.fill {
             result.set_item("fill", fill.to_string())?;
         }
-        
+
         // Extract zero padding
         if spec.zero_pad {
             result.set_item("zero", true)?;
         }
-        
+
         Ok(result.into_py(py))
     })
 }
-
 
 /// Python module definition
 #[pymodule]
@@ -485,4 +513,3 @@ fn _formatparse(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Results>()?;
     Ok(())
 }
-

--- a/formatparse-pyo3/src/match_rs.rs
+++ b/formatparse-pyo3/src/match_rs.rs
@@ -11,46 +11,66 @@ pub struct Match {
     field_specs: Vec<FieldSpec>,
     field_names: Vec<Option<String>>,
     normalized_names: Vec<Option<String>>,
-    captures: Vec<Option<String>>,  // Raw captured strings
-    named_captures: HashMap<String, String>,  // Raw captured strings by normalized name
+    captures: Vec<Option<String>>,           // Raw captured strings
+    named_captures: HashMap<String, String>, // Raw captured strings by normalized name
     #[pyo3(get)]
     pub span: (usize, usize),
-    field_spans: HashMap<String, (usize, usize)>,  // Spans by original field name
+    field_spans: HashMap<String, (usize, usize)>, // Spans by original field name
 }
 
 #[pymethods]
 impl Match {
     /// Evaluate the match to convert captured values to their types
     #[pyo3(signature = (*, extra_types=None))]
-    fn evaluate_result(&self, py: Python, extra_types: Option<HashMap<String, PyObject>>) -> PyResult<PyObject> {
+    fn evaluate_result(
+        &self,
+        py: Python,
+        extra_types: Option<HashMap<String, PyObject>>,
+    ) -> PyResult<PyObject> {
         let custom_converters = extra_types.unwrap_or_default();
         let mut fixed = Vec::new();
         let mut named: HashMap<String, PyObject> = HashMap::new();
-        
+
         // Apply type conversions using stored field specs
         for (i, spec) in self.field_specs.iter().enumerate() {
-            let value_str = if let Some(ref norm_name) = self.normalized_names.get(i).and_then(|n| n.as_ref()) {
-                self.named_captures.get(norm_name.as_str()).map(|s| s.as_str())
-            } else {
-                self.captures.get(i).and_then(|s| s.as_ref()).map(|s| s.as_str())
-            };
-            
+            let value_str =
+                if let Some(norm_name) = self.normalized_names.get(i).and_then(|n| n.as_ref()) {
+                    self.named_captures
+                        .get(norm_name.as_str())
+                        .map(|s| s.as_str())
+                } else {
+                    self.captures
+                        .get(i)
+                        .and_then(|s| s.as_ref())
+                        .map(|s| s.as_str())
+                };
+
             if let Some(value_str) = value_str {
-                let converted = crate::types::conversion::convert_value(spec, value_str, py, &custom_converters)?;
-                
+                let converted = crate::types::conversion::convert_value(
+                    spec,
+                    value_str,
+                    py,
+                    &custom_converters,
+                )?;
+
                 if let Some(original_name) = self.field_names.get(i).and_then(|n| n.as_ref()) {
                     // Check if this is a dict-style field name (contains [])
                     if original_name.contains('[') {
                         // Parse the path and insert into nested dict structure
                         let path = crate::parser::parse_field_path(original_name);
-                        crate::parser::matching::insert_nested_dict(&mut named, &path, converted, py)?;
+                        crate::parser::matching::insert_nested_dict(
+                            &mut named, &path, converted, py,
+                        )?;
                     } else {
                         // Regular flat field name
                         // Check for repeated field names - values must match
                         if let Some(existing_value) = named.get(original_name.as_str()) {
                             let existing_obj = existing_value.to_object(py);
                             let converted_obj = converted.to_object(py);
-                            let are_equal: bool = existing_obj.bind(py).eq(converted_obj.bind(py)).unwrap_or(false);
+                            let are_equal: bool = existing_obj
+                                .bind(py)
+                                .eq(converted_obj.bind(py))
+                                .unwrap_or(false);
                             if !are_equal {
                                 return Err(error::repeated_name_error(original_name));
                             }
@@ -62,8 +82,9 @@ impl Match {
                 }
             }
         }
-        
-        let parse_result = ParseResult::new_with_spans(fixed, named, self.span, self.field_spans.clone());
+
+        let parse_result =
+            ParseResult::new_with_spans(fixed, named, self.span, self.field_spans.clone());
         // Py::new() is already optimized when GIL is held
         Ok(Py::new(py, parse_result)?.to_object(py))
     }
@@ -92,4 +113,3 @@ impl Match {
         }
     }
 }
-

--- a/formatparse-pyo3/src/parser.rs
+++ b/formatparse-pyo3/src/parser.rs
@@ -8,10 +8,9 @@
 
 pub mod pattern;
 // regex module is in formatparse-core
-pub mod matching;
 pub mod format_parser;
+pub mod matching;
 pub mod raw_match;
 
-pub use format_parser::{FormatParser, Format};
+pub use format_parser::{Format, FormatParser};
 pub use pattern::parse_field_path;
-

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -1,8 +1,8 @@
 use crate::error;
+use formatparse_core::parser::{validate_input_length, validate_pattern_length, MAX_FIELDS};
 use formatparse_core::FieldSpec;
-use formatparse_core::parser::{validate_pattern_length, validate_input_length, MAX_FIELDS};
-use pyo3::prelude::*;
 use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 use pyo3::types::{PyString, PyTuple};
 use regex::Regex;
 use std::collections::HashMap;
@@ -14,19 +14,19 @@ pub struct FormatParser {
     // The dead_code warning is a false positive - the compiler doesn't recognize PyO3 getter usage.
     pub pattern: String,
     regex: Regex,
-    regex_str: String,  // Store the regex string for _expression property
+    regex_str: String, // Store the regex string for _expression property
     regex_case_insensitive: Option<Regex>,
-    search_regex: Regex,  // Pre-compiled search regex (case-sensitive, no anchors)
-    search_regex_case_insensitive: Option<Regex>,  // Pre-compiled search regex (case-insensitive, no anchors)
+    search_regex: Regex, // Pre-compiled search regex (case-sensitive, no anchors)
+    search_regex_case_insensitive: Option<Regex>, // Pre-compiled search regex (case-insensitive, no anchors)
     pub(crate) field_specs: Vec<FieldSpec>,
-    pub(crate) field_names: Vec<Option<String>>,  // Original field names (with hyphens/dots)
-    pub(crate) normalized_names: Vec<Option<String>>,  // Normalized names for regex groups (hyphens->underscores)
+    pub(crate) field_names: Vec<Option<String>>, // Original field names (with hyphens/dots)
+    pub(crate) normalized_names: Vec<Option<String>>, // Normalized names for regex groups (hyphens->underscores)
     #[allow(dead_code)]
-    name_mapping: std::collections::HashMap<String, String>,  // Map normalized -> original
-    stored_extra_types: Option<HashMap<String, PyObject>>,  // Store extra_types for use during conversion
-    pub(crate) custom_type_groups: Vec<usize>,  // Cached pattern_groups per field (for custom types)
-    pub(crate) field_count: usize,  // Cached field count for fast path optimizations
-    pub(crate) has_nested_dict_fields: Vec<bool>,  // Cached flags: does field name contain '[' (nested dict)?
+    name_mapping: std::collections::HashMap<String, String>, // Map normalized -> original
+    stored_extra_types: Option<HashMap<String, PyObject>>, // Store extra_types for use during conversion
+    pub(crate) custom_type_groups: Vec<usize>, // Cached pattern_groups per field (for custom types)
+    pub(crate) field_count: usize,             // Cached field count for fast path optimizations
+    pub(crate) has_nested_dict_fields: Vec<bool>, // Cached flags: does field name contain '[' (nested dict)?
 }
 
 impl FormatParser {
@@ -34,16 +34,18 @@ impl FormatParser {
         Self::new_with_extra_types(pattern, None)
     }
 
-    pub fn new_with_extra_types(pattern: &str, extra_types: Option<HashMap<String, PyObject>>) -> PyResult<Self> {
+    pub fn new_with_extra_types(
+        pattern: &str,
+        extra_types: Option<HashMap<String, PyObject>>,
+    ) -> PyResult<Self> {
         // Validate pattern length
-        validate_pattern_length(pattern)
-            .map_err(|e| PyValueError::new_err(e))?;
-        
+        validate_pattern_length(pattern).map_err(PyValueError::new_err)?;
+
         // Check for null bytes in pattern
         if pattern.contains('\0') {
             return Err(PyValueError::new_err("Pattern contains null byte"));
         }
-        
+
         // Extract patterns from converter functions and build custom_patterns map
         let custom_patterns = Python::with_gil(|py| -> PyResult<HashMap<String, String>> {
             let mut patterns = HashMap::new();
@@ -60,9 +62,16 @@ impl FormatParser {
             }
             Ok(patterns)
         })?;
-        
-        let (regex_str_with_anchors, regex_str, field_specs, field_names, normalized_names, name_mapping) = crate::parser::pattern::parse_pattern(pattern, extra_types.as_ref(), &custom_patterns)?;
-        
+
+        let (
+            regex_str_with_anchors,
+            regex_str,
+            field_specs,
+            field_names,
+            normalized_names,
+            name_mapping,
+        ) = crate::parser::pattern::parse_pattern(pattern, extra_types.as_ref(), &custom_patterns)?;
+
         // Validate field count
         if field_specs.len() > MAX_FIELDS {
             return Err(PyValueError::new_err(format!(
@@ -71,17 +80,24 @@ impl FormatParser {
                 MAX_FIELDS
             )));
         }
-        
+
         // Pre-compute custom type validation results (pattern_groups per field)
         // This avoids calling validate_custom_type_pattern for every match
         let custom_type_groups = Python::with_gil(|py| -> PyResult<Vec<usize>> {
             let mut groups = Vec::with_capacity(field_specs.len());
             let empty_map = std::collections::HashMap::new();
-            let custom_converters = extra_types.as_ref().map(|et| et as &HashMap<String, PyObject>).unwrap_or(&empty_map);
-            
+            let custom_converters = extra_types
+                .as_ref()
+                .map(|et| et as &HashMap<String, PyObject>)
+                .unwrap_or(&empty_map);
+
             for spec in &field_specs {
                 if !custom_converters.is_empty() {
-                    let pattern_groups = crate::parser::matching::validate_custom_type_pattern(spec, custom_converters, py)?;
+                    let pattern_groups = crate::parser::matching::validate_custom_type_pattern(
+                        spec,
+                        custom_converters,
+                        py,
+                    )?;
                     groups.push(pattern_groups);
                 } else {
                     groups.push(0);
@@ -89,25 +105,27 @@ impl FormatParser {
             }
             Ok(groups)
         })?;
-        
+
         // Pre-compute which fields have nested dict names (contain '[')
         // This avoids checking original_name.contains('[') in the hot path
-        let has_nested_dict_fields: Vec<bool> = field_names.iter()
+        let has_nested_dict_fields: Vec<bool> = field_names
+            .iter()
             .map(|name_opt| name_opt.as_ref().map(|n| n.contains('[')).unwrap_or(false))
             .collect();
-        
+
         // Build regex with DOTALL flag
         let regex = formatparse_core::build_regex(&regex_str_with_anchors)
-            .map_err(|e| crate::error::core_error_to_py_err(e))?;
+            .map_err(crate::error::core_error_to_py_err)?;
 
         // Build case-insensitive regex
-        let regex_case_insensitive = formatparse_core::build_case_insensitive_regex(&regex_str_with_anchors);
+        let regex_case_insensitive =
+            formatparse_core::build_case_insensitive_regex(&regex_str_with_anchors);
 
         // Pre-compile search regex variants (without anchors)
         let search_regex = formatparse_core::build_search_regex(regex.as_str(), true)
-            .map_err(|e| crate::error::core_error_to_py_err(e))?;
-        let search_regex_case_insensitive = formatparse_core::build_search_regex(regex.as_str(), false)
-            .ok();
+            .map_err(crate::error::core_error_to_py_err)?;
+        let search_regex_case_insensitive =
+            formatparse_core::build_search_regex(regex.as_str(), false).ok();
 
         Ok(Self {
             pattern: pattern.to_string(),
@@ -122,8 +140,8 @@ impl FormatParser {
             name_mapping,
             stored_extra_types: extra_types,
             custom_type_groups,
-            field_count: field_specs.len(),  // Cache field count for fast path
-            has_nested_dict_fields,  // Cache nested dict flags
+            field_count: field_specs.len(), // Cache field count for fast path
+            has_nested_dict_fields,         // Cache nested dict flags
         })
     }
 
@@ -138,9 +156,11 @@ impl FormatParser {
         let search_regex = if case_sensitive {
             &self.search_regex
         } else {
-            self.search_regex_case_insensitive.as_ref().unwrap_or(&self.search_regex)
+            self.search_regex_case_insensitive
+                .as_ref()
+                .unwrap_or(&self.search_regex)
         };
-        
+
         Python::with_gil(|py| {
             if search_regex.captures(string).is_some() {
                 let extra_types_ref = if let Some(ref et) = extra_types {
@@ -197,28 +217,30 @@ impl FormatParser {
             )
         })
     }
-    
+
     #[allow(dead_code)]
     pub(crate) fn get_field_specs(&self) -> &Vec<FieldSpec> {
         &self.field_specs
     }
-    
+
     #[allow(dead_code)]
     pub(crate) fn get_field_names(&self) -> &Vec<Option<String>> {
         &self.field_names
     }
-    
+
     #[allow(dead_code)]
     pub(crate) fn get_normalized_names(&self) -> &Vec<Option<String>> {
         &self.normalized_names
     }
-    
+
     /// Get the search regex for a given case sensitivity
     pub(crate) fn get_search_regex(&self, case_sensitive: bool) -> &Regex {
         if case_sensitive {
             &self.search_regex
         } else {
-            self.search_regex_case_insensitive.as_ref().unwrap_or(&self.search_regex)
+            self.search_regex_case_insensitive
+                .as_ref()
+                .unwrap_or(&self.search_regex)
         }
     }
 }
@@ -227,18 +249,22 @@ impl FormatParser {
 impl FormatParser {
     #[new]
     #[pyo3(signature = (pattern=None, extra_types=None))]
-    fn new_py(pattern: Option<&str>, extra_types: Option<HashMap<String, PyObject>>) -> PyResult<Self> {
+    fn new_py(
+        pattern: Option<&str>,
+        extra_types: Option<HashMap<String, PyObject>>,
+    ) -> PyResult<Self> {
         match pattern {
             Some(p) => {
                 // Validate pattern length if provided
-                validate_pattern_length(p)
-                    .map_err(|e| PyValueError::new_err(e))?;
+                validate_pattern_length(p).map_err(PyValueError::new_err)?;
                 Self::new_with_extra_types(p, extra_types)
-            },
+            }
             None => {
                 // Create a dummy instance for unpickling - __setstate__ will initialize it properly
                 // We need to create a valid but minimal instance
-                let empty_regex = Regex::new("^$").map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid regex: {}", e)))?;
+                let empty_regex = Regex::new("^$").map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid regex: {}", e))
+                })?;
                 Ok(Self {
                     pattern: String::new(),
                     regex: empty_regex.clone(),
@@ -269,27 +295,30 @@ impl FormatParser {
         evaluate_result: bool,
     ) -> PyResult<Option<PyObject>> {
         // Validate input length
-        validate_input_length(string)
-            .map_err(|e| PyValueError::new_err(e))?;
-        
+        validate_input_length(string).map_err(PyValueError::new_err)?;
+
         // Check for null bytes
         if string.contains('\0') {
             return Err(PyValueError::new_err("Input string contains null byte"));
         }
         // Merge stored extra_types with provided extra_types (provided takes precedence)
-        let merged_extra_types = Python::with_gil(|py| -> PyResult<Option<HashMap<String, PyObject>>> {
-            let mut merged = if let Some(ref stored) = self.stored_extra_types {
-                stored.iter().map(|(k, v)| (k.clone(), v.clone_ref(py).into())).collect()
-            } else {
-                HashMap::new()
-            };
-            if let Some(ref provided) = extra_types {
-                for (k, v) in provided {
-                    merged.insert(k.clone(), v.clone_ref(py).into());
+        let merged_extra_types =
+            Python::with_gil(|py| -> PyResult<Option<HashMap<String, PyObject>>> {
+                let mut merged = if let Some(ref stored) = self.stored_extra_types {
+                    stored
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                        .collect()
+                } else {
+                    HashMap::new()
+                };
+                if let Some(ref provided) = extra_types {
+                    for (k, v) in provided {
+                        merged.insert(k.clone(), v.clone_ref(py));
+                    }
                 }
-            }
-            Ok(Some(merged))
-        })?;
+                Ok(Some(merged))
+            })?;
         self.parse_internal(string, case_sensitive, merged_extra_types, evaluate_result)
     }
 
@@ -297,7 +326,8 @@ impl FormatParser {
     #[getter]
     fn named_fields(&self) -> Vec<String> {
         // Return normalized names (without hyphens/dots) for compatibility with original parse library
-        self.normalized_names.iter()
+        self.normalized_names
+            .iter()
             .filter_map(|n| n.clone())
             .collect()
     }
@@ -307,34 +337,34 @@ impl FormatParser {
     #[getter]
     fn _expression(&self) -> String {
         let mut result = self.regex_str.clone();
-        
+
         // Replace \s+ between capturing groups with literal spaces for canonical format
         // This matches the original parse library's _expression format
         result = result.replace(r")\s+(", ") (");
         // Also replace )\s*( with ) ( for backward compatibility
         result = result.replace(r")\s*(", ") (");
-        
+
         // Simplify float patterns to match expected format
         // Our pattern: ([+-]?(?:\d+\.\d+|\.\d+|\d+\.)(?:[eE][+-]?\d+)?)
         // Expected: ([-+ ]?\d*\.\d+)
         // Replace the complex float pattern with the simpler one
         result = result.replace(
             r"([+-]?(?:\d+\.\d+|\.\d+|\d+\.)(?:[eE][+-]?\d+)?)",
-            r"([-+ ]?\d*\.\d+)"
+            r"([-+ ]?\d*\.\d+)",
         );
-        
+
         // For alignment patterns like {:>} that produce "( *(.+?))", we need to unwrap
         // the outer capturing group to get " *(.+?)" (no outer wrapper)
         // Only do this for patterns that start with "(" and end with ")" and contain nested groups
         if result.starts_with("(") && result.ends_with(")") {
-            let inner = &result[1..result.len()-1];
+            let inner = &result[1..result.len() - 1];
             // Check if inner already starts with a space and contains a capturing group
             if inner.starts_with(" *(") && inner.ends_with(")") {
                 // This is a simple wrapper, unwrap it
                 result = inner.to_string();
             }
         }
-        
+
         result
     }
 
@@ -356,21 +386,20 @@ impl FormatParser {
         evaluate_result: bool,
     ) -> PyResult<Option<PyObject>> {
         // Validate input length
-        validate_input_length(string)
-            .map_err(|e| PyValueError::new_err(e))?;
-        
+        validate_input_length(string).map_err(PyValueError::new_err)?;
+
         // Check for null bytes
         if string.contains('\0') {
             return Err(PyValueError::new_err("Input string contains null byte"));
         }
-        
+
         self.search_pattern(string, case_sensitive, extra_types, evaluate_result)
     }
 
     /// Pickle support: rebuild with `compile(pattern)` so unpickling never relies on
     /// `FormatParser.__new__` argument conventions across PyO3 / pickle versions.
     fn __reduce__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let m = py.import_bound("_formatparse")?;
+        let m = py.import("_formatparse")?;
         let compile_fn = m.getattr("compile")?;
         let args = PyTuple::new_bound(py, [&self.pattern]);
         Ok(PyTuple::new_bound(py, [compile_fn.as_any(), args.as_any()]).into_py(py))
@@ -388,11 +417,14 @@ impl FormatParser {
     fn __setstate__(&mut self, _py: Python, state: &Bound<'_, PyAny>) -> PyResult<()> {
         use pyo3::types::PyDict;
         let dict = state.downcast::<PyDict>()?;
-        let pattern: String = dict.get_item("pattern")?.ok_or_else(|| error::missing_field_error("pattern"))?.extract()?;
-        
+        let pattern: String = dict
+            .get_item("pattern")?
+            .ok_or_else(|| error::missing_field_error("pattern"))?
+            .extract()?;
+
         // Reconstruct the parser from the pattern
         let reconstructed = Self::new_with_extra_types(&pattern, None)?;
-        
+
         // Copy all fields from reconstructed parser
         self.pattern = reconstructed.pattern;
         self.regex_str = reconstructed.regex_str;
@@ -425,7 +457,7 @@ impl Format {
         // Use Python's string format method to format values into the pattern
         let pattern_obj = PyString::new_bound(py, &self.pattern);
         let format_method = pattern_obj.getattr("format")?;
-        
+
         // Call format with the args (can be a single value, tuple, or *args)
         let result = if let Ok(tuple) = args.downcast::<PyTuple>() {
             format_method.call1(tuple)?
@@ -436,4 +468,3 @@ impl Format {
         result.extract()
     }
 }
-

--- a/formatparse-pyo3/src/parser/matching.rs
+++ b/formatparse-pyo3/src/parser/matching.rs
@@ -1,12 +1,11 @@
 use crate::error;
-use crate::result::ParseResult;
-use formatparse_core::FieldSpec;
-use crate::parser::raw_match::convert_value_raw;
 use crate::match_rs::Match;
 use crate::parser::raw_match::{RawMatchData, RawValue};
+use crate::result::ParseResult;
+use formatparse_core::FieldSpec;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use regex::{Regex, Captures};
+use regex::{Captures, Regex};
 use std::collections::HashMap;
 
 /// Count the number of capturing groups in a regex pattern
@@ -14,7 +13,7 @@ pub fn count_capturing_groups(pattern: &str) -> usize {
     let mut count = 0;
     let mut i = 0;
     let chars: Vec<char> = pattern.chars().collect();
-    
+
     while i < chars.len() {
         if chars[i] == '\\' {
             // Skip escaped character
@@ -29,17 +28,23 @@ pub fn count_capturing_groups(pattern: &str) -> usize {
             if i + 1 < chars.len() && chars[i + 1] == '?' {
                 // Non-capturing group: (?: ...), (?= ...), (?! ...), etc.
                 i += 2;
-                if i < chars.len() && (chars[i] == ':' || chars[i] == '=' || chars[i] == '!' || 
-                                       chars[i] == '<' || (i > 0 && chars[i-1] == '?' && chars[i] == 'P')) {
-                    if chars[i] == 'P' && i + 1 < chars.len() && chars[i + 1] == '<' {
-                        // Named group (?P<name>...), skip the name
-                        i += 2;
-                        while i < chars.len() && chars[i] != '>' {
-                            i += 1;
-                        }
-                        if i < chars.len() {
-                            i += 1;
-                        }
+                if i < chars.len()
+                    && (chars[i] == ':'
+                        || chars[i] == '='
+                        || chars[i] == '!'
+                        || chars[i] == '<'
+                        || (i > 0 && chars[i - 1] == '?' && chars[i] == 'P'))
+                    && chars[i] == 'P'
+                    && i + 1 < chars.len()
+                    && chars[i + 1] == '<'
+                {
+                    // Named group (?P<name>...), skip the name
+                    i += 2;
+                    while i < chars.len() && chars[i] != '>' {
+                        i += 1;
+                    }
+                    if i < chars.len() {
+                        i += 1;
                     }
                 }
                 continue;
@@ -62,34 +67,34 @@ pub fn get_nested_dict_value(
     if path.is_empty() {
         return Ok(None);
     }
-    
+
     if path.len() == 1 {
         // Simple case - just get directly
-        return Ok(named.get(&path[0]).map(|obj| obj.clone_ref(py).into()));
+        return Ok(named.get(&path[0]).map(|obj| obj.clone_ref(py)));
     }
-    
+
     // Navigate through nested dicts
     let first_key = &path[0];
     let mut current_obj: PyObject = match named.get(first_key) {
-        Some(v) => v.clone_ref(py).into(),
+        Some(v) => v.clone_ref(py),
         None => return Ok(None),
     };
-    
+
     for key in path.iter().skip(1) {
         let current_dict = match current_obj.bind(py).downcast::<PyDict>() {
             Ok(d) => d,
             Err(_) => return Ok(None), // Not a dict, path doesn't exist
         };
-        
+
         match current_dict.get_item(key.as_str())? {
             Some(v) => {
                 // Get the PyObject to continue navigation
                 current_obj = v.into();
-            },
+            }
             None => return Ok(None), // Path doesn't exist
         }
     }
-    
+
     Ok(Some(current_obj))
 }
 
@@ -103,16 +108,16 @@ pub fn insert_nested_dict(
     if path.is_empty() {
         return Ok(());
     }
-    
+
     if path.len() == 1 {
         // Simple case - just insert directly
         named.insert(path[0].clone(), value);
         return Ok(());
     }
-    
+
     // Need to create nested dicts
     let first_key = &path[0];
-    
+
     // Get or create the top-level dict
     let top_dict = if let Some(existing) = named.get(first_key) {
         // Check if it's already a dict
@@ -132,7 +137,7 @@ pub fn insert_nested_dict(
         named.insert(first_key.clone(), new_dict_obj);
         new_dict
     };
-    
+
     // Navigate/create nested dicts
     let mut current_dict = top_dict;
     for key in path.iter().skip(1).take(path.len() - 2) {
@@ -154,11 +159,11 @@ pub fn insert_nested_dict(
         };
         current_dict = nested_dict;
     }
-    
+
     // Set the final value
     let final_key = &path[path.len() - 1];
     current_dict.set_item(final_key.as_str(), value)?;
-    
+
     Ok(())
 }
 
@@ -180,7 +185,9 @@ pub fn extract_capture<'a>(
         let capture_group_index = actual_capture_index + group_offset;
         if field_spec.alignment.is_some() {
             // For alignment patterns, try innermost group first, then outer
-            captures.get(capture_group_index + 1).or_else(|| captures.get(capture_group_index))
+            captures
+                .get(capture_group_index + 1)
+                .or_else(|| captures.get(capture_group_index))
         } else {
             captures.get(capture_group_index)
         }
@@ -194,7 +201,7 @@ pub fn validate_custom_type_pattern(
     py: Python,
 ) -> PyResult<usize> {
     let mut pattern_groups = 0;
-    
+
     if let formatparse_core::FieldType::Custom(type_name) = &field_spec.field_type {
         if let Some(converter_obj) = custom_converters.get(type_name) {
             let converter_ref = converter_obj.bind(py);
@@ -202,13 +209,13 @@ pub fn validate_custom_type_pattern(
                 if let Ok(pattern_str) = pattern_attr.extract::<String>() {
                     let actual_groups = count_capturing_groups(&pattern_str);
                     pattern_groups = actual_groups;
-                    
+
                     if let Ok(group_count_attr) = converter_ref.getattr("regex_group_count") {
                         // Try to extract as int first
                         if let Ok(group_count) = group_count_attr.extract::<i64>() {
                             if group_count < 0 {
                                 return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                                    format!("regex_group_count must be >= 0, got {}", group_count)
+                                    format!("regex_group_count must be >= 0, got {}", group_count),
                                 ));
                             }
                             if group_count == 0 && actual_groups > 0 {
@@ -217,31 +224,35 @@ pub fn validate_custom_type_pattern(
                                 ));
                             }
                             if group_count > actual_groups as i64 {
-                                return Err(error::regex_group_index_error(type_name, actual_groups, group_count));
+                                return Err(error::regex_group_index_error(
+                                    type_name,
+                                    actual_groups,
+                                    group_count,
+                                ));
                             }
                         } else {
-                                    // regex_group_count is None
-                                    if actual_groups > 0 {
-                                        return Err(error::custom_type_error(
+                            // regex_group_count is None
+                            if actual_groups > 0 {
+                                return Err(error::custom_type_error(
                                             type_name,
                                             &format!("pattern has {} capturing groups but regex_group_count is None", actual_groups)
                                         ));
-                                    }
+                            }
                         }
-                                } else {
-                                    // No regex_group_count attribute - must have 0 groups
-                                    if actual_groups > 0 {
-                                        return Err(error::custom_type_error(
+                    } else {
+                        // No regex_group_count attribute - must have 0 groups
+                        if actual_groups > 0 {
+                            return Err(error::custom_type_error(
                                             type_name,
                                             &format!("pattern has {} capturing groups but regex_group_count is not set", actual_groups)
                                         ));
-                                    }
-                                }
+                        }
+                    }
                 }
             }
         }
     }
-    
+
     Ok(pattern_groups)
 }
 
@@ -261,17 +272,17 @@ pub fn match_with_captures_raw(
     let full_match = captures.get(0).unwrap();
     let start = full_match.start();
     let end = full_match.end();
-    
+
     let field_count = field_specs.len();
     let mut raw_data = RawMatchData::with_capacity(field_count);
     raw_data.span = (start, end);
-    
+
     let mut group_offset = 0;
     let mut actual_capture_index = 1;
-    
+
     for (i, spec) in field_specs.iter().enumerate() {
         let pattern_groups = custom_type_groups.get(i).copied().unwrap_or(0);
-        
+
         let cap = extract_capture(
             captures,
             i,
@@ -280,18 +291,18 @@ pub fn match_with_captures_raw(
             actual_capture_index,
             group_offset,
         );
-        
+
         if normalized_names.get(i).and_then(|n| n.as_ref()).is_none() {
             actual_capture_index += 1;
         } else {
             actual_capture_index += 1;
         }
-        
+
         if let Some(cap) = cap {
             let value_str = cap.as_str();
             let field_start = cap.start();
             let field_end = cap.end();
-            
+
             // Try to convert to raw value (fails for custom types and datetime)
             match crate::parser::raw_match::convert_value_raw(spec, value_str) {
                 Ok(raw_value) => {
@@ -305,13 +316,15 @@ pub fn match_with_captures_raw(
                             if let Some(existing) = raw_data.named.get(original_name) {
                                 // Check if values match (for repeated names)
                                 if !values_equal(existing, &raw_value) {
-                                    return Ok(None);  // Values don't match
+                                    return Ok(None); // Values don't match
                                 }
                             } else {
                                 raw_data.named.insert(original_name.clone(), raw_value);
                             }
                         }
-                        raw_data.field_spans.insert(original_name.clone(), (field_start, field_end));
+                        raw_data
+                            .field_spans
+                            .insert(original_name.clone(), (field_start, field_end));
                     } else {
                         raw_data.fixed.push(raw_value);
                     }
@@ -322,7 +335,7 @@ pub fn match_with_captures_raw(
                 }
             }
         }
-        
+
         if spec.alignment.is_some() {
             group_offset += 1;
         }
@@ -330,7 +343,7 @@ pub fn match_with_captures_raw(
             group_offset += pattern_groups;
         }
     }
-    
+
     Ok(Some(raw_data))
 }
 
@@ -356,32 +369,33 @@ pub fn match_with_captures(
     field_specs: &[FieldSpec],
     field_names: &[Option<String>],
     normalized_names: &[Option<String>],
-    custom_type_groups: &[usize],  // Pre-computed pattern_groups per field
-    has_nested_dict_fields: &[bool],  // Pre-computed flags: does field name contain '['?
+    custom_type_groups: &[usize], // Pre-computed pattern_groups per field
+    has_nested_dict_fields: &[bool], // Pre-computed flags: does field name contain '['?
     py: Python,
     custom_converters: &HashMap<String, PyObject>,
     evaluate_result: bool,
 ) -> PyResult<Option<PyObject>> {
     let full_match = captures.get(0).unwrap();
-    let start = full_match.start();  // Already absolute position in full string
-    let end = full_match.end();      // Already absolute position in full string
-    
+    let start = full_match.start(); // Already absolute position in full string
+    let end = full_match.end(); // Already absolute position in full string
+
     // Pre-allocate with capacity based on expected field count
     let field_count = field_specs.len();
     // Fast path: for single-field patterns, use optimized allocation
     let mut fixed = Vec::with_capacity(field_count);
     let mut named: HashMap<String, PyObject> = HashMap::with_capacity(field_count.max(1));
-    let mut field_spans: HashMap<String, (usize, usize)> = HashMap::with_capacity(field_count.max(1));
-    let mut captures_vec = Vec::with_capacity(field_count);  // For Match object when evaluate_result=False
-    let mut named_captures = HashMap::with_capacity(field_count);  // For Match object when evaluate_result=False
+    let mut field_spans: HashMap<String, (usize, usize)> =
+        HashMap::with_capacity(field_count.max(1));
+    let mut captures_vec = Vec::with_capacity(field_count); // For Match object when evaluate_result=False
+    let mut named_captures = HashMap::with_capacity(field_count); // For Match object when evaluate_result=False
     let mut group_offset = 0;
     // Track the actual capture group index (accounts for both named and unnamed groups)
-    let mut actual_capture_index = 1;  // Start at 1 (group 0 is full match)
-    
+    let mut actual_capture_index = 1; // Start at 1 (group 0 is full match)
+
     for (i, spec) in field_specs.iter().enumerate() {
         // Use pre-computed pattern_groups (cached during FormatParser creation)
         let pattern_groups = custom_type_groups.get(i).copied().unwrap_or(0);
-        
+
         // Extract capture group
         let cap = extract_capture(
             captures,
@@ -391,7 +405,7 @@ pub fn match_with_captures(
             actual_capture_index,
             group_offset,
         );
-        
+
         // Increment actual_capture_index for the next field (both named and unnamed groups consume an index)
         // But only increment if we actually used a positional group (not a named group)
         if normalized_names.get(i).and_then(|n| n.as_ref()).is_none() {
@@ -400,12 +414,12 @@ pub fn match_with_captures(
             // Named groups still consume an index in the regex, so increment
             actual_capture_index += 1;
         }
-        
+
         if let Some(cap) = cap {
             let value_str = cap.as_str();
             let field_start = cap.start();
             let field_end = cap.end();
-            
+
             // Store raw capture for Match object (only if needed)
             // Only allocate strings when evaluate_result=False (Match objects need owned strings)
             if !evaluate_result {
@@ -415,15 +429,20 @@ pub fn match_with_captures(
                 }
             }
             // For evaluate_result=True, we don't need to store raw captures, saving allocations
-            
+
             if evaluate_result {
                 // Validate alignment+precision constraints (issue #3)
                 // This prevents invalid cases where fill characters are in wrong positions
                 if !crate::types::conversion::validate_alignment_precision(spec, value_str) {
                     return Ok(None);
                 }
-                
-                let converted = crate::types::conversion::convert_value(spec, value_str, py, &custom_converters)?;
+
+                let converted = crate::types::conversion::convert_value(
+                    spec,
+                    value_str,
+                    py,
+                    custom_converters,
+                )?;
 
                 // Use original field name (with hyphens/dots) for the result
                 if let Some(ref original_name) = field_names[i] {
@@ -455,20 +474,23 @@ pub fn match_with_captures(
                                 let are_equal: bool = {
                                     let existing_obj = existing_value.to_object(py);
                                     let converted_obj = converted.to_object(py);
-                                    existing_obj.bind(py).eq(converted_obj.bind(py)).unwrap_or(false)
+                                    existing_obj
+                                        .bind(py)
+                                        .eq(converted_obj.bind(py))
+                                        .unwrap_or(false)
                                 };
                                 if !are_equal {
                                     // Values don't match for repeated name
                                     return Ok(None);
                                 }
-                            },
+                            }
                             None => {
                                 // New field - insert it
                                 named.insert(original_name.clone(), converted);
                             }
                         }
                     }
-                    
+
                     // Store field span (already absolute position in original string)
                     field_spans.insert(original_name.clone(), (field_start, field_end));
                 } else {
@@ -477,7 +499,7 @@ pub fn match_with_captures(
                 }
             }
         }
-        
+
         // Increment group offset for alignment patterns (they add an extra group)
         if spec.alignment.is_some() {
             group_offset += 1;
@@ -529,8 +551,8 @@ pub fn match_with_regex(
         let mut fixed = Vec::with_capacity(field_count);
         let mut named: HashMap<String, PyObject> = HashMap::with_capacity(field_count);
         let mut field_spans: HashMap<String, (usize, usize)> = HashMap::with_capacity(field_count);
-        let mut captures_vec = Vec::with_capacity(field_count);  // For Match object when evaluate_result=False
-        let mut named_captures = HashMap::with_capacity(field_count);  // For Match object when evaluate_result=False
+        let mut captures_vec = Vec::with_capacity(field_count); // For Match object when evaluate_result=False
+        let mut named_captures = HashMap::with_capacity(field_count); // For Match object when evaluate_result=False
 
         let full_match = captures.get(0).unwrap();
         let start = full_match.start();
@@ -539,16 +561,16 @@ pub fn match_with_regex(
         let mut fixed_index = 0;
         let mut group_offset = 0;
         // Track the actual capture group index (accounts for both named and unnamed groups)
-        let mut actual_capture_index = 1;  // Start at 1 (group 0 is full match)
-        
+        let mut actual_capture_index = 1; // Start at 1 (group 0 is full match)
+
         for (i, spec) in field_specs.iter().enumerate() {
             // Validate regex_group_count for custom types with capturing groups (only if custom types exist)
             let pattern_groups = if !custom_converters.is_empty() {
-                validate_custom_type_pattern(spec, &custom_converters, py)?
+                validate_custom_type_pattern(spec, custom_converters, py)?
             } else {
                 0
             };
-            
+
             // Extract capture group
             let cap = extract_capture(
                 &captures,
@@ -558,7 +580,7 @@ pub fn match_with_regex(
                 actual_capture_index,
                 group_offset,
             );
-            
+
             // Increment actual_capture_index for the next field (both named and unnamed groups consume an index)
             // But only increment if we actually used a positional group (not a named group)
             if normalized_names.get(i).and_then(|n| n.as_ref()).is_none() {
@@ -567,12 +589,12 @@ pub fn match_with_regex(
                 // Named groups still consume an index in the regex, so increment
                 actual_capture_index += 1;
             }
-            
+
             if let Some(cap) = cap {
                 let value_str = cap.as_str();
                 let field_start = cap.start();
                 let field_end = cap.end();
-                
+
                 // Store raw capture for Match object (only if needed)
                 if !evaluate_result {
                     captures_vec.push(Some(value_str.to_string()));
@@ -580,15 +602,20 @@ pub fn match_with_regex(
                         named_captures.insert(norm_name.clone(), value_str.to_string());
                     }
                 }
-                
+
                 if evaluate_result {
                     // Validate alignment+precision constraints (issue #3)
                     // This prevents invalid cases where fill characters are in wrong positions
                     if !crate::types::conversion::validate_alignment_precision(spec, value_str) {
                         return Ok(None);
                     }
-                    
-                    let converted = crate::types::conversion::convert_value(spec, value_str, py, &custom_converters)?;
+
+                    let converted = crate::types::conversion::convert_value(
+                        spec,
+                        value_str,
+                        py,
+                        custom_converters,
+                    )?;
 
                     // Use original field name (with hyphens/dots) for the result
                     if let Some(ref original_name) = field_names[i] {
@@ -597,7 +624,8 @@ pub fn match_with_regex(
                             // Parse the path and insert into nested dict structure
                             let path = crate::parser::pattern::parse_field_path(original_name);
                             // Check for repeated field names - compare values if path already exists
-                            if let Some(existing_value) = get_nested_dict_value(&named, &path, py)? {
+                            if let Some(existing_value) = get_nested_dict_value(&named, &path, py)?
+                            {
                                 // Compare values using Python's equality (batch GIL operation)
                                 let are_equal: bool = {
                                     let existing_obj = existing_value.bind(py);
@@ -621,14 +649,18 @@ pub fn match_with_regex(
                                     let are_equal: bool = {
                                         let existing_obj = existing_value.to_object(py);
                                         let converted_obj = converted.to_object(py);
-                                        existing_obj.bind(py).eq(converted_obj.bind(py)).unwrap_or(false)
+                                        existing_obj
+                                            .bind(py)
+                                            .eq(converted_obj.bind(py))
+                                            .unwrap_or(false)
                                     };
                                     if !are_equal {
                                         // Values don't match for repeated name
                                         return Ok(None);
                                     }
                                     // Store span for repeated name
-                                    field_spans.insert(original_name.clone(), (field_start, field_end));
+                                    field_spans
+                                        .insert(original_name.clone(), (field_start, field_end));
                                 }
                                 None => {
                                     // First occurrence - just insert (common case)
@@ -659,7 +691,7 @@ pub fn match_with_regex(
             } else {
                 captures_vec.push(None);
             }
-            
+
             // Increment group offset for alignment patterns (they add an extra group)
             if spec.alignment.is_some() {
                 group_offset += 1;
@@ -694,4 +726,3 @@ pub fn match_with_regex(
         Ok(None)
     }
 }
-

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -1,5 +1,5 @@
-use formatparse_core::{FieldSpec, FieldType};
 use crate::error;
+use formatparse_core::{FieldSpec, FieldType};
 use pyo3::prelude::*;
 use regex;
 use std::collections::HashMap;
@@ -9,15 +9,22 @@ pub fn parse_pattern(
     pattern: &str,
     extra_types: Option<&HashMap<String, PyObject>>,
     custom_patterns: &HashMap<String, String>,
-) -> PyResult<(String, String, Vec<FieldSpec>, Vec<Option<String>>, Vec<Option<String>>, HashMap<String, String>)> {
+) -> PyResult<(
+    String,
+    String,
+    Vec<FieldSpec>,
+    Vec<Option<String>>,
+    Vec<Option<String>>,
+    HashMap<String, String>,
+)> {
     // Pre-allocate with estimated capacity based on pattern length
     let estimated_fields = pattern.matches('{').count();
     let mut regex_parts = Vec::with_capacity(estimated_fields * 2);
     let mut field_specs = Vec::with_capacity(estimated_fields);
-    let mut field_names = Vec::with_capacity(estimated_fields);  // Original names
-    let mut normalized_names = Vec::with_capacity(estimated_fields);  // Normalized for regex
-    let mut name_mapping = HashMap::with_capacity(estimated_fields);  // normalized -> original
-    let mut field_name_types = HashMap::with_capacity(estimated_fields);  // Track field name -> FieldType for validation
+    let mut field_names = Vec::with_capacity(estimated_fields); // Original names
+    let mut normalized_names = Vec::with_capacity(estimated_fields); // Normalized for regex
+    let mut name_mapping = HashMap::with_capacity(estimated_fields); // normalized -> original
+    let mut field_name_types = HashMap::with_capacity(estimated_fields); // Track field name -> FieldType for validation
     let mut chars: std::iter::Peekable<std::str::Chars> = pattern.chars().peekable();
     let mut literal = String::new();
 
@@ -52,7 +59,7 @@ pub fn parse_pattern(
 
                 // Parse field specification
                 let (spec, name) = parse_field(&mut chars, extra_types)?;
-                
+
                 // Check if the next field (if any) is empty {} (non-greedy)
                 // This affects width-only string patterns: exact when followed by {}, greedy otherwise
                 let mut peek_chars = chars.clone();
@@ -63,7 +70,7 @@ pub fn parse_pattern(
                         if ch.is_whitespace() {
                             peek_chars.next();
                         } else if ch == '}' {
-                            peek_chars.next();  // Consume the closing brace
+                            peek_chars.next(); // Consume the closing brace
                             found_closing = true;
                             break;
                         } else {
@@ -71,7 +78,7 @@ pub fn parse_pattern(
                         }
                     }
                     if !found_closing {
-                        break None;  // No more fields
+                        break None; // No more fields
                     }
                     // Skip any whitespace after the closing brace
                     while let Some(&ch) = peek_chars.peek() {
@@ -87,7 +94,7 @@ pub fn parse_pattern(
                         // Check if it's escaped
                         if peek_chars.peek() == Some(&'{') {
                             peek_chars.next();
-                            continue;  // Escaped brace, continue
+                            continue; // Escaped brace, continue
                         }
                         // Found a field - check if it's empty {} or has precision
                         if peek_chars.peek() == Some(&'}') {
@@ -127,9 +134,9 @@ pub fn parse_pattern(
                         break None;
                     }
                 };
-                
+
                 let pattern = spec.to_regex_pattern(custom_patterns, next_field_is_greedy);
-                
+
                 // Validate repeated field names have same type
                 if let Some(ref original_name) = name {
                     if let Some(existing_type) = field_name_types.get(original_name) {
@@ -141,26 +148,30 @@ pub fn parse_pattern(
                         field_name_types.insert(original_name.clone(), spec.field_type.clone());
                     }
                 }
-                
+
                 // Handle name normalization for regex groups
                 if let Some(ref original_name) = name {
                     // Check if field name is numeric (numbered field like {0}, {1}) - these should be positional
                     let is_numeric = original_name.chars().all(|c| c.is_ascii_digit());
-                    
+
                     if is_numeric {
                         // Numbered fields are positional (unnamed groups), not named groups
                         let group_pattern = format!("({})", pattern);
                         regex_parts.push(group_pattern);
-                        field_names.push(None);  // Store as None (positional)
+                        field_names.push(None); // Store as None (positional)
                         normalized_names.push(None);
                     } else {
                         // Normalize name: replace hyphens/dots with underscores, handle collisions
-                        let normalized = normalize_field_name(original_name, &mut name_mapping, &normalized_names);
+                        let normalized = normalize_field_name(
+                            original_name,
+                            &mut name_mapping,
+                            &normalized_names,
+                        );
                         let group_pattern = format!("(?P<{}>{})", normalized, pattern);
                         regex_parts.push(group_pattern);
-                        field_names.push(Some(original_name.clone()));  // Store original
-                        normalized_names.push(Some(normalized.clone()));  // Store normalized
-                        name_mapping.insert(normalized, original_name.clone());  // Map normalized -> original
+                        field_names.push(Some(original_name.clone())); // Store original
+                        normalized_names.push(Some(normalized.clone())); // Store normalized
+                        name_mapping.insert(normalized, original_name.clone()); // Map normalized -> original
                     }
                 } else {
                     let group_pattern = format!("({})", pattern);
@@ -172,7 +183,9 @@ pub fn parse_pattern(
 
                 // Expect closing brace
                 if chars.next() != Some('}') {
-                    return Err(error::pattern_error("Expected '}' after field specification"));
+                    return Err(error::pattern_error(
+                        "Expected '}' after field specification",
+                    ));
                 }
             }
             '}' => {
@@ -206,23 +219,40 @@ pub fn parse_pattern(
 
     let regex_str = regex_parts.join("");
     let regex_str_with_anchors = format!("^{}$", regex_str);
-    Ok((regex_str_with_anchors, regex_str, field_specs, field_names, normalized_names, name_mapping))
+    Ok((
+        regex_str_with_anchors,
+        regex_str,
+        field_specs,
+        field_names,
+        normalized_names,
+        name_mapping,
+    ))
 }
 
 /// Normalize field name (hyphens/dots -> underscores) and handle collisions
-pub fn normalize_field_name(name: &str, _name_mapping: &mut HashMap<String, String>, existing_normalized: &[Option<String>]) -> String {
+pub fn normalize_field_name(
+    name: &str,
+    _name_mapping: &mut HashMap<String, String>,
+    existing_normalized: &[Option<String>],
+) -> String {
     // Normalize: replace hyphens and dots with underscores
-    let base_normalized: String = name.chars().map(|c| if c == '-' || c == '.' { '_' } else { c }).collect();
-    
+    let base_normalized: String = name
+        .chars()
+        .map(|c| if c == '-' || c == '.' { '_' } else { c })
+        .collect();
+
     // Check for collisions with existing normalized names
     let mut normalized = base_normalized.clone();
-    
+
     // Find the position of the first underscore to insert additional underscores there
     let underscore_pos = normalized.find('_');
-    
+
     // Check if this exact normalized name already exists
     let mut collision_count = 0;
-    while existing_normalized.iter().any(|n| n.as_ref().map(|s| s == &normalized).unwrap_or(false)) {
+    while existing_normalized
+        .iter()
+        .any(|n| n.as_ref().map(|s| s == &normalized).unwrap_or(false))
+    {
         collision_count += 1;
         // Insert additional underscores at the first underscore position
         // For "a_b", collisions become "a__b", "a___b", etc.
@@ -236,7 +266,7 @@ pub fn normalize_field_name(name: &str, _name_mapping: &mut HashMap<String, Stri
             normalized = format!("{}{}", base_normalized, "_".repeat(collision_count));
         }
     }
-    
+
     normalized
 }
 
@@ -251,7 +281,7 @@ pub fn parse_field_path(field_name: &str) -> Vec<String> {
     let mut path = Vec::new();
     let mut current = String::new();
     let mut in_brackets = false;
-    
+
     for ch in field_name.chars() {
         match ch {
             '[' => {
@@ -277,16 +307,19 @@ pub fn parse_field_path(field_name: &str) -> Vec<String> {
             }
         }
     }
-    
+
     if !current.is_empty() {
         path.push(current);
     }
-    
+
     path
 }
 
 /// Parse a single field specification from the pattern
-pub fn parse_field(chars: &mut std::iter::Peekable<std::str::Chars>, extra_types: Option<&HashMap<String, PyObject>>) -> PyResult<(FieldSpec, Option<String>)> {
+pub fn parse_field(
+    chars: &mut std::iter::Peekable<std::str::Chars>,
+    extra_types: Option<&HashMap<String, PyObject>>,
+) -> PyResult<(FieldSpec, Option<String>)> {
     let mut spec = FieldSpec::new();
     let mut field_name = String::new();
     let mut format_spec = String::new();
@@ -369,12 +402,16 @@ pub fn parse_field(chars: &mut std::iter::Peekable<std::str::Chars>, extra_types
 }
 
 /// Parse format specifier string into FieldSpec
-pub fn parse_format_spec(format_spec: &str, spec: &mut FieldSpec, _extra_types: Option<&HashMap<String, PyObject>>) {
+pub fn parse_format_spec(
+    format_spec: &str,
+    spec: &mut FieldSpec,
+    _extra_types: Option<&HashMap<String, PyObject>>,
+) {
     // Format spec: [[fill]align][sign][#][0][width][,][.precision][type]
     // Examples: "<10", ">", "^5.2f", "+d", "03d", ".2f"
-    
+
     let mut chars = format_spec.chars().peekable();
-    
+
     // Parse fill and align (optional)
     // align can be: '<', '>', '^', '='
     if let Some(&ch) = chars.peek() {
@@ -395,7 +432,7 @@ pub fn parse_format_spec(format_spec: &str, spec: &mut FieldSpec, _extra_types: 
             }
         }
     }
-    
+
     // Parse sign (optional): '+', '-', ' '
     if let Some(&ch) = chars.peek() {
         if ch == '+' || ch == '-' || ch == ' ' {
@@ -403,18 +440,18 @@ pub fn parse_format_spec(format_spec: &str, spec: &mut FieldSpec, _extra_types: 
             chars.next();
         }
     }
-    
+
     // Parse # (alternate form) - skip for now
     if chars.peek() == Some(&'#') {
         chars.next();
     }
-    
+
     // Parse 0 (zero padding)
     if chars.peek() == Some(&'0') {
         spec.zero_pad = true;
         chars.next();
     }
-    
+
     // Parse width (digits)
     let mut width_str = String::new();
     while let Some(&ch) = chars.peek() {
@@ -428,12 +465,12 @@ pub fn parse_format_spec(format_spec: &str, spec: &mut FieldSpec, _extra_types: 
     if !width_str.is_empty() {
         spec.width = width_str.parse::<usize>().ok();
     }
-    
+
     // Parse comma (thousands separator) - skip for now
     if chars.peek() == Some(&',') {
         chars.next();
     }
-    
+
     // Parse precision (.digits)
     if chars.peek() == Some(&'.') {
         chars.next();
@@ -450,14 +487,14 @@ pub fn parse_format_spec(format_spec: &str, spec: &mut FieldSpec, _extra_types: 
             spec.precision = precision_str.parse::<usize>().ok();
         }
     }
-    
+
     // Parse type (all alphabetic characters at the end, plus %)
     // Collect all remaining characters as the type string
     let mut type_str = String::new();
     for ch in chars {
         type_str.push(ch);
     }
-    
+
     // Handle % specially (it's not alphabetic)
     if type_str == "%" {
         spec.field_type = FieldType::Percentage;
@@ -468,7 +505,7 @@ pub fn parse_format_spec(format_spec: &str, spec: &mut FieldSpec, _extra_types: 
     } else {
         // Extract type name (alphabetic characters only)
         let type_name: String = type_str.chars().filter(|c| c.is_alphabetic()).collect();
-        
+
         // If type_str is empty, default to String
         // Multi-character names are always custom types
         // Single character names can be built-in or custom (checked in convert_value)
@@ -515,4 +552,3 @@ pub fn parse_format_spec(format_spec: &str, spec: &mut FieldSpec, _extra_types: 
         };
     }
 }
-

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -58,8 +58,9 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
                     // Strip fill characters and whitespace based on alignment
                     let trimmed = match spec.alignment {
                         Some('<') => {
-                            // Left-aligned: strip trailing fill chars, then trailing spaces
-                            if let Some(fill_ch) = spec.fill {
+                            if spec.width.is_some() {
+                                value
+                            } else if let Some(fill_ch) = spec.fill {
                                 value.trim_end_matches(fill_ch).trim_end()
                             } else {
                                 value.trim_end()
@@ -309,7 +310,7 @@ mod tests {
             ..Default::default()
         };
         
-        // Left-aligned: strip trailing spaces
+        // Left-aligned without width: strip trailing spaces (parse parity)
         let result = convert_value_raw(&spec, "hello     ");
         assert!(matches!(result, Ok(RawValue::String(ref s)) if s == "hello"));
     }

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use pyo3::prelude::*;
 use formatparse_core::{FieldSpec, FieldType};
+use pyo3::prelude::*;
+use std::collections::HashMap;
 
 /// Raw match data without Python objects (for batch processing)
 /// This allows us to collect all matches first, then batch convert to Python objects
@@ -31,7 +31,7 @@ impl RawMatchData {
             field_spans: HashMap::new(),
         }
     }
-    
+
     pub fn with_capacity(field_count: usize) -> Self {
         Self {
             fixed: Vec::with_capacity(field_count),
@@ -45,185 +45,200 @@ impl RawMatchData {
 /// Convert a value string to RawValue (no Python objects created)
 /// This is used for batch processing to defer Python object creation
 pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, String> {
-        // Handle custom converters - for now, we'll need to handle this differently
-        // Custom converters require Python, so we'll need a hybrid approach
-        // For now, only handle built-in types
-        
-        match &spec.field_type {
-            FieldType::String => {
-                // Fast path: no alignment means no trimming needed
-                if spec.alignment.is_none() {
-                    Ok(RawValue::String(value.to_string()))
-                } else {
-                    // Strip fill characters and whitespace based on alignment
-                    let trimmed = match spec.alignment {
-                        Some('<') => {
-                            if spec.width.is_some() {
-                                value
-                            } else if let Some(fill_ch) = spec.fill {
-                                value.trim_end_matches(fill_ch).trim_end()
-                            } else {
-                                value.trim_end()
-                            }
-                        },
-                        Some('>') => {
-                            // Right-aligned: strip leading fill chars, then leading spaces
-                            if let Some(fill_ch) = spec.fill {
-                                value.trim_start_matches(fill_ch).trim_start()
-                            } else {
-                                value.trim_start()
-                            }
-                        },
-                        Some('^') => {
-                            // Center-aligned: strip both leading and trailing fill chars, then spaces
-                            if let Some(fill_ch) = spec.fill {
-                                value.trim_matches(fill_ch).trim()
-                            } else {
-                                value.trim()
-                            }
-                        },
-                        _ => value,  // No alignment: keep as-is
-                    };
-                    Ok(RawValue::String(trimmed.to_string()))
-                }
-            },
-            FieldType::Integer => {
-                // Fast path: common case - decimal integer, no special formatting
-                if spec.fill.is_none() && spec.alignment != Some('=') && spec.original_type_char.is_none() {
-                    // Try parsing directly first (most common case)
-                    if let Ok(n) = value.trim().parse::<i64>() {
-                        return Ok(RawValue::Integer(n));
-                    }
-                }
-                
-                // Full path: handle all cases
-                let mut trimmed_str = value.trim().to_string();
-                
-                // Strip fill characters if alignment is '='
-                if let (Some(fill_ch), Some('=')) = (spec.fill, spec.alignment) {
-                    if trimmed_str.starts_with('-') || trimmed_str.starts_with('+') {
-                        let sign_char = &trimmed_str[..1];
-                        let rest = &trimmed_str[1..];
-                        if rest.starts_with("0x") || rest.starts_with("0X") || 
-                           rest.starts_with("0o") || rest.starts_with("0O") ||
-                           rest.starts_with("0b") || rest.starts_with("0B") {
-                            let rest_trimmed = rest.trim_start_matches(fill_ch);
-                            trimmed_str = format!("{}{}", sign_char, rest_trimmed);
+    // Handle custom converters - for now, we'll need to handle this differently
+    // Custom converters require Python, so we'll need a hybrid approach
+    // For now, only handle built-in types
+
+    match &spec.field_type {
+        FieldType::String => {
+            // Fast path: no alignment means no trimming needed
+            if spec.alignment.is_none() {
+                Ok(RawValue::String(value.to_string()))
+            } else {
+                // Strip fill characters and whitespace based on alignment
+                let trimmed = match spec.alignment {
+                    Some('<') => {
+                        if spec.width.is_some() {
+                            value
+                        } else if let Some(fill_ch) = spec.fill {
+                            value.trim_end_matches(fill_ch).trim_end()
                         } else {
-                            let rest_trimmed = rest.trim_start_matches(fill_ch);
-                            trimmed_str = format!("{}{}", sign_char, rest_trimmed);
+                            value.trim_end()
                         }
-                    } else {
-                        trimmed_str = trimmed_str.trim_start_matches(fill_ch).to_string();
                     }
-                }
-                
-                let trimmed = trimmed_str.as_str();
-                let (is_negative, num_str) = if trimmed.starts_with('-') {
-                    (true, &trimmed[1..])
-                } else if trimmed.starts_with('+') {
-                    (false, &trimmed[1..])
-                } else {
-                    (false, trimmed)
+                    Some('>') => {
+                        // Right-aligned: strip leading fill chars, then leading spaces
+                        if let Some(fill_ch) = spec.fill {
+                            value.trim_start_matches(fill_ch).trim_start()
+                        } else {
+                            value.trim_start()
+                        }
+                    }
+                    Some('^') => {
+                        // Center-aligned: strip both leading and trailing fill chars, then spaces
+                        if let Some(fill_ch) = spec.fill {
+                            value.trim_matches(fill_ch).trim()
+                        } else {
+                            value.trim()
+                        }
+                    }
+                    _ => value, // No alignment: keep as-is
                 };
-                
-                let v = if num_str.starts_with("0x") || num_str.starts_with("0X") {
-                    i64::from_str_radix(&num_str[2..], 16).map(|n| if is_negative { -n } else { n })
-                } else if num_str.starts_with("0o") || num_str.starts_with("0O") {
-                    i64::from_str_radix(&num_str[2..], 8).map(|n| if is_negative { -n } else { n })
-                } else if num_str.starts_with("0b") || num_str.starts_with("0B") {
-                    let result = if spec.original_type_char == Some('x') || spec.original_type_char == Some('X') {
-                        if num_str == "0B" || num_str == "0b" {
-                            i64::from_str_radix("B", 16)
-                        } else if num_str.len() > 2 {
-                            i64::from_str_radix(&num_str[1..], 16)
-                        } else {
-                            i64::from_str_radix(&num_str[2..], 2)
-                        }
+                Ok(RawValue::String(trimmed.to_string()))
+            }
+        }
+        FieldType::Integer => {
+            // Fast path: common case - decimal integer, no special formatting
+            if spec.fill.is_none()
+                && spec.alignment != Some('=')
+                && spec.original_type_char.is_none()
+            {
+                // Try parsing directly first (most common case)
+                if let Ok(n) = value.trim().parse::<i64>() {
+                    return Ok(RawValue::Integer(n));
+                }
+            }
+
+            // Full path: handle all cases
+            let mut trimmed_str = value.trim().to_string();
+
+            // Strip fill characters if alignment is '='
+            if let (Some(fill_ch), Some('=')) = (spec.fill, spec.alignment) {
+                if trimmed_str.starts_with('-') || trimmed_str.starts_with('+') {
+                    let sign_char = &trimmed_str[..1];
+                    let rest = &trimmed_str[1..];
+                    if rest.starts_with("0x")
+                        || rest.starts_with("0X")
+                        || rest.starts_with("0o")
+                        || rest.starts_with("0O")
+                        || rest.starts_with("0b")
+                        || rest.starts_with("0B")
+                    {
+                        let rest_trimmed = rest.trim_start_matches(fill_ch);
+                        trimmed_str = format!("{}{}", sign_char, rest_trimmed);
+                    } else {
+                        let rest_trimmed = rest.trim_start_matches(fill_ch);
+                        trimmed_str = format!("{}{}", sign_char, rest_trimmed);
+                    }
+                } else {
+                    trimmed_str = trimmed_str.trim_start_matches(fill_ch).to_string();
+                }
+            }
+
+            let trimmed = trimmed_str.as_str();
+            let (is_negative, num_str) = if trimmed.starts_with('-') {
+                (true, &trimmed[1..])
+            } else if trimmed.starts_with('+') {
+                (false, &trimmed[1..])
+            } else {
+                (false, trimmed)
+            };
+
+            let v = if num_str.starts_with("0x") || num_str.starts_with("0X") {
+                i64::from_str_radix(&num_str[2..], 16).map(|n| if is_negative { -n } else { n })
+            } else if num_str.starts_with("0o") || num_str.starts_with("0O") {
+                i64::from_str_radix(&num_str[2..], 8).map(|n| if is_negative { -n } else { n })
+            } else if num_str.starts_with("0b") || num_str.starts_with("0B") {
+                let result = if spec.original_type_char == Some('x')
+                    || spec.original_type_char == Some('X')
+                {
+                    if num_str == "0B" || num_str == "0b" {
+                        i64::from_str_radix("B", 16)
+                    } else if num_str.len() > 2 {
+                        i64::from_str_radix(&num_str[1..], 16)
                     } else {
                         i64::from_str_radix(&num_str[2..], 2)
-                    };
-                    result.map(|n| if is_negative { -n } else { n })
+                    }
                 } else {
-                    let result = match spec.original_type_char {
-                        Some('b') => i64::from_str_radix(num_str, 2),
-                        Some('o') => i64::from_str_radix(num_str, 8),
-                        Some('x') | Some('X') => i64::from_str_radix(num_str, 16),
-                        _ => num_str.parse::<i64>(),
-                    };
-                    result.map(|n| if is_negative { -n } else { n })
+                    i64::from_str_radix(&num_str[2..], 2)
                 };
-                
-                match v {
-                    Ok(n) => Ok(RawValue::Integer(n)),
-                    Err(_) => Err(format!("Could not convert '{}' to integer", value)),
-                }
-            }
-            FieldType::Float => {
-                match value.parse::<f64>() {
-                    Ok(n) => Ok(RawValue::Float(n)),
-                    Err(_) => {
-                        let trimmed = value.trim();
-                        match trimmed.parse::<f64>() {
-                            Ok(n) => Ok(RawValue::Float(n)),
-                            Err(_) => Err(format!("Could not convert '{}' to float", value)),
-                        }
-                    }
-                }
-            }
-            FieldType::Boolean => {
-                let b = match value.len() {
-                    1 => value == "1",
-                    2 => matches!(value, "on" | "ON"),
-                    3 => matches!(value, "yes" | "YES"),
-                    4 => matches!(value, "true" | "TRUE"),
-                    _ => {
-                        let lower = value.to_lowercase();
-                        matches!(lower.as_str(), "true" | "1" | "yes" | "on")
-                    }
+                result.map(|n| if is_negative { -n } else { n })
+            } else {
+                let result = match spec.original_type_char {
+                    Some('b') => i64::from_str_radix(num_str, 2),
+                    Some('o') => i64::from_str_radix(num_str, 8),
+                    Some('x') | Some('X') => i64::from_str_radix(num_str, 16),
+                    _ => num_str.parse::<i64>(),
                 };
-                Ok(RawValue::Boolean(b))
+                result.map(|n| if is_negative { -n } else { n })
+            };
+
+            match v {
+                Ok(n) => Ok(RawValue::Integer(n)),
+                Err(_) => Err(format!("Could not convert '{}' to integer", value)),
             }
-            FieldType::Letters | FieldType::Word | FieldType::NonLetters | 
-            FieldType::NonWhitespace | FieldType::NonDigits => {
-                Ok(RawValue::String(value.to_string()))
-            }
-            FieldType::NumberWithThousands => {
+        }
+        FieldType::Float => match value.parse::<f64>() {
+            Ok(n) => Ok(RawValue::Float(n)),
+            Err(_) => {
                 let trimmed = value.trim();
-                let cleaned = trimmed.replace(",", "").replace(".", "");
-                match cleaned.parse::<i64>() {
-                    Ok(n) => Ok(RawValue::Integer(n)),
-                    Err(_) => Err(format!("Could not convert '{}' to number with thousands", value)),
-                }
-            }
-            FieldType::Scientific => {
-                match value.parse::<f64>() {
-                    Ok(n) => Ok(RawValue::Float(n)),
-                    Err(_) => Err(format!("Could not convert '{}' to scientific notation", value)),
-                }
-            }
-            FieldType::GeneralNumber => {
-                // Try integer first, then float
-                if let Ok(n) = value.trim().parse::<i64>() {
-                    Ok(RawValue::Integer(n))
-                } else if let Ok(n) = value.trim().parse::<f64>() {
-                    Ok(RawValue::Float(n))
-                } else {
-                    Err(format!("Could not convert '{}' to number", value))
-                }
-            }
-            FieldType::Percentage => {
-                let trimmed = value.trim_end_matches('%').trim();
                 match trimmed.parse::<f64>() {
-                    Ok(n) => Ok(RawValue::Float(n / 100.0)),
-                    Err(_) => Err(format!("Could not convert '{}' to percentage", value)),
+                    Ok(n) => Ok(RawValue::Float(n)),
+                    Err(_) => Err(format!("Could not convert '{}' to float", value)),
                 }
             }
-            // DateTime types and Custom types need Python, so we'll handle them differently
-            _ => {
-                // For types that require Python (datetime, custom), we can't convert to raw
-                // This will be handled by falling back to the Python path
-                Err(format!("Type {:?} requires Python conversion", spec.field_type))
+        },
+        FieldType::Boolean => {
+            let b = match value.len() {
+                1 => value == "1",
+                2 => matches!(value, "on" | "ON"),
+                3 => matches!(value, "yes" | "YES"),
+                4 => matches!(value, "true" | "TRUE"),
+                _ => {
+                    let lower = value.to_lowercase();
+                    matches!(lower.as_str(), "true" | "1" | "yes" | "on")
+                }
+            };
+            Ok(RawValue::Boolean(b))
+        }
+        FieldType::Letters
+        | FieldType::Word
+        | FieldType::NonLetters
+        | FieldType::NonWhitespace
+        | FieldType::NonDigits => Ok(RawValue::String(value.to_string())),
+        FieldType::NumberWithThousands => {
+            let trimmed = value.trim();
+            let cleaned = trimmed.replace(",", "").replace(".", "");
+            match cleaned.parse::<i64>() {
+                Ok(n) => Ok(RawValue::Integer(n)),
+                Err(_) => Err(format!(
+                    "Could not convert '{}' to number with thousands",
+                    value
+                )),
+            }
+        }
+        FieldType::Scientific => match value.parse::<f64>() {
+            Ok(n) => Ok(RawValue::Float(n)),
+            Err(_) => Err(format!(
+                "Could not convert '{}' to scientific notation",
+                value
+            )),
+        },
+        FieldType::GeneralNumber => {
+            // Try integer first, then float
+            if let Ok(n) = value.trim().parse::<i64>() {
+                Ok(RawValue::Integer(n))
+            } else if let Ok(n) = value.trim().parse::<f64>() {
+                Ok(RawValue::Float(n))
+            } else {
+                Err(format!("Could not convert '{}' to number", value))
+            }
+        }
+        FieldType::Percentage => {
+            let trimmed = value.trim_end_matches('%').trim();
+            match trimmed.parse::<f64>() {
+                Ok(n) => Ok(RawValue::Float(n / 100.0)),
+                Err(_) => Err(format!("Could not convert '{}' to percentage", value)),
+            }
+        }
+        // DateTime types and Custom types need Python, so we'll handle them differently
+        _ => {
+            // For types that require Python (datetime, custom), we can't convert to raw
+            // This will be handled by falling back to the Python path
+            Err(format!(
+                "Type {:?} requires Python conversion",
+                spec.field_type
+            ))
         }
     }
 }
@@ -245,27 +260,21 @@ impl RawValue {
 impl RawMatchData {
     pub fn to_parse_result(&self, py: Python) -> PyResult<pyo3::Py<crate::result::ParseResult>> {
         use crate::result::ParseResult;
-        
+
         // Pre-allocate vectors with known capacity for better performance
-        let fixed: Vec<PyObject> = self.fixed.iter()
-            .map(|v| v.to_py_object(py))
-            .collect();
-        
+        let fixed: Vec<PyObject> = self.fixed.iter().map(|v| v.to_py_object(py)).collect();
+
         // Pre-allocate HashMap with known capacity
         let mut named: HashMap<String, PyObject> = HashMap::with_capacity(self.named.len());
         for (k, v) in &self.named {
             named.insert(k.clone(), v.to_py_object(py));
         }
-        
-        let parse_result = ParseResult::new_with_spans(
-            fixed,
-            named,
-            self.span,
-            self.field_spans.clone(),
-        );
-        
+
+        let parse_result =
+            ParseResult::new_with_spans(fixed, named, self.span, self.field_spans.clone());
+
         // Py::new() is already optimized when GIL is held
-        Ok(Py::new(py, parse_result)?)
+        Py::new(py, parse_result)
     }
 }
 
@@ -296,7 +305,7 @@ mod tests {
             field_type: FieldType::String,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "hello");
         assert!(matches!(result, Ok(RawValue::String(ref s)) if s == "hello"));
     }
@@ -309,7 +318,7 @@ mod tests {
             fill: Some(' '),
             ..Default::default()
         };
-        
+
         // Left-aligned without width: strip trailing spaces (parse parity)
         let result = convert_value_raw(&spec, "hello     ");
         assert!(matches!(result, Ok(RawValue::String(ref s)) if s == "hello"));
@@ -323,7 +332,7 @@ mod tests {
             fill: Some(' '),
             ..Default::default()
         };
-        
+
         // Right-aligned: strip leading spaces
         let result = convert_value_raw(&spec, "     hello");
         assert!(matches!(result, Ok(RawValue::String(ref s)) if s == "hello"));
@@ -335,10 +344,10 @@ mod tests {
             field_type: FieldType::Integer,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "123");
         assert!(matches!(result, Ok(RawValue::Integer(123))));
-        
+
         let result_neg = convert_value_raw(&spec, "-456");
         assert!(matches!(result_neg, Ok(RawValue::Integer(-456))));
     }
@@ -349,10 +358,10 @@ mod tests {
             field_type: FieldType::Integer,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "0xff");
         assert!(matches!(result, Ok(RawValue::Integer(255))));
-        
+
         let result_upper = convert_value_raw(&spec, "0xFF");
         assert!(matches!(result_upper, Ok(RawValue::Integer(255))));
     }
@@ -363,7 +372,7 @@ mod tests {
             field_type: FieldType::Integer,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "0o777");
         assert!(matches!(result, Ok(RawValue::Integer(511))));
     }
@@ -374,7 +383,7 @@ mod tests {
             field_type: FieldType::Integer,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "0b1010");
         assert!(matches!(result, Ok(RawValue::Integer(10))));
     }
@@ -385,10 +394,11 @@ mod tests {
             field_type: FieldType::Float,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "3.14");
-        assert!(matches!(result, Ok(RawValue::Float(f)) if (f - 3.14).abs() < 0.001));
-        
+        let expected: f64 = "3.14".parse().unwrap();
+        assert!(matches!(result, Ok(RawValue::Float(f)) if (f - expected).abs() < 0.001));
+
         let result_neg = convert_value_raw(&spec, "-2.5");
         assert!(matches!(result_neg, Ok(RawValue::Float(f)) if (f - (-2.5)).abs() < 0.001));
     }
@@ -399,14 +409,35 @@ mod tests {
             field_type: FieldType::Boolean,
             ..Default::default()
         };
-        
-        assert!(matches!(convert_value_raw(&spec, "true"), Ok(RawValue::Boolean(true))));
-        assert!(matches!(convert_value_raw(&spec, "TRUE"), Ok(RawValue::Boolean(true))));
-        assert!(matches!(convert_value_raw(&spec, "1"), Ok(RawValue::Boolean(true))));
-        assert!(matches!(convert_value_raw(&spec, "yes"), Ok(RawValue::Boolean(true))));
-        assert!(matches!(convert_value_raw(&spec, "on"), Ok(RawValue::Boolean(true))));
-        assert!(matches!(convert_value_raw(&spec, "false"), Ok(RawValue::Boolean(false))));
-        assert!(matches!(convert_value_raw(&spec, "0"), Ok(RawValue::Boolean(false))));
+
+        assert!(matches!(
+            convert_value_raw(&spec, "true"),
+            Ok(RawValue::Boolean(true))
+        ));
+        assert!(matches!(
+            convert_value_raw(&spec, "TRUE"),
+            Ok(RawValue::Boolean(true))
+        ));
+        assert!(matches!(
+            convert_value_raw(&spec, "1"),
+            Ok(RawValue::Boolean(true))
+        ));
+        assert!(matches!(
+            convert_value_raw(&spec, "yes"),
+            Ok(RawValue::Boolean(true))
+        ));
+        assert!(matches!(
+            convert_value_raw(&spec, "on"),
+            Ok(RawValue::Boolean(true))
+        ));
+        assert!(matches!(
+            convert_value_raw(&spec, "false"),
+            Ok(RawValue::Boolean(false))
+        ));
+        assert!(matches!(
+            convert_value_raw(&spec, "0"),
+            Ok(RawValue::Boolean(false))
+        ));
     }
 
     #[test]
@@ -415,10 +446,10 @@ mod tests {
             field_type: FieldType::NumberWithThousands,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "1,000");
         assert!(matches!(result, Ok(RawValue::Integer(1000))));
-        
+
         let result_dot = convert_value_raw(&spec, "1.000");
         assert!(matches!(result_dot, Ok(RawValue::Integer(1000))));
     }
@@ -429,10 +460,10 @@ mod tests {
             field_type: FieldType::Percentage,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "50%");
         assert!(matches!(result, Ok(RawValue::Float(f)) if (f - 0.5).abs() < 0.001));
-        
+
         let result_no_space = convert_value_raw(&spec, "25%");
         assert!(matches!(result_no_space, Ok(RawValue::Float(f)) if (f - 0.25).abs() < 0.001));
     }
@@ -443,7 +474,7 @@ mod tests {
             field_type: FieldType::Scientific,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "1e10");
         assert!(matches!(result, Ok(RawValue::Float(f)) if (f - 1e10).abs() < 1.0));
     }
@@ -454,11 +485,11 @@ mod tests {
             field_type: FieldType::GeneralNumber,
             ..Default::default()
         };
-        
+
         // Should parse as integer
         let result_int = convert_value_raw(&spec, "42");
         assert!(matches!(result_int, Ok(RawValue::Integer(42))));
-        
+
         // Should parse as float
         let result_float = convert_value_raw(&spec, "3.14");
         assert!(matches!(result_float, Ok(RawValue::Float(_))));
@@ -470,7 +501,7 @@ mod tests {
             field_type: FieldType::Integer,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "not a number");
         assert!(result.is_err());
     }
@@ -481,7 +512,7 @@ mod tests {
             field_type: FieldType::Float,
             ..Default::default()
         };
-        
+
         let result = convert_value_raw(&spec, "not a float");
         assert!(result.is_err());
     }
@@ -497,23 +528,25 @@ mod tests {
             let string_val = RawValue::String("hello".to_string());
             let py_obj = string_val.to_py_object(py);
             assert_eq!(py_obj.extract::<String>(py).unwrap(), "hello");
-            
+
             let int_val = RawValue::Integer(42);
             let py_obj = int_val.to_py_object(py);
             assert_eq!(py_obj.extract::<i64>(py).unwrap(), 42);
-            
-            let float_val = RawValue::Float(3.14);
+
+            let float_val = RawValue::Float("3.14".parse().unwrap());
             let py_obj = float_val.to_py_object(py);
-            assert_eq!(py_obj.extract::<f64>(py).unwrap(), 3.14);
-            
+            assert_eq!(
+                py_obj.extract::<f64>(py).unwrap(),
+                "3.14".parse::<f64>().unwrap()
+            );
+
             let bool_val = RawValue::Boolean(true);
             let py_obj = bool_val.to_py_object(py);
-            assert_eq!(py_obj.extract::<bool>(py).unwrap(), true);
-            
+            assert!(py_obj.extract::<bool>(py).unwrap());
+
             let none_val = RawValue::None;
             let py_obj = none_val.to_py_object(py);
             assert!(py_obj.is_none(py));
         });
     }
 }
-

--- a/formatparse-pyo3/src/result.rs
+++ b/formatparse-pyo3/src/result.rs
@@ -1,5 +1,5 @@
 use pyo3::prelude::*;
-use pyo3::types::{PyTuple, PySlice};
+use pyo3::types::{PySlice, PyTuple};
 use std::collections::HashMap;
 
 #[pyclass]
@@ -8,41 +8,47 @@ pub struct ParseResult {
     #[pyo3(get)]
     pub named: HashMap<String, PyObject>,
     pub span: (usize, usize),
-    pub field_spans: HashMap<String, (usize, usize)>,  // Maps field index/name to (start, end)
+    pub field_spans: HashMap<String, (usize, usize)>, // Maps field index/name to (start, end)
 }
 
 impl Clone for ParseResult {
     fn clone(&self) -> Self {
-        Python::with_gil(|py| {
-            Self {
-                fixed: self.fixed.iter().map(|obj| obj.clone_ref(py).into()).collect(),
-                named: self.named.iter().map(|(k, v)| (k.clone(), v.clone_ref(py).into())).collect(),
-                span: self.span,
-                field_spans: self.field_spans.clone(),
-            }
+        Python::with_gil(|py| Self {
+            fixed: self.fixed.iter().map(|obj| obj.clone_ref(py)).collect(),
+            named: self
+                .named
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                .collect(),
+            span: self.span,
+            field_spans: self.field_spans.clone(),
         })
     }
 }
 
 impl ParseResult {
-    pub fn new(fixed: Vec<PyObject>, named: HashMap<String, PyObject>, span: (usize, usize)) -> Self {
-        Self { 
-            fixed, 
-            named, 
+    pub fn new(
+        fixed: Vec<PyObject>,
+        named: HashMap<String, PyObject>,
+        span: (usize, usize),
+    ) -> Self {
+        Self {
+            fixed,
+            named,
             span,
             field_spans: HashMap::new(),
         }
     }
 
     pub fn new_with_spans(
-        fixed: Vec<PyObject>, 
-        named: HashMap<String, PyObject>, 
+        fixed: Vec<PyObject>,
+        named: HashMap<String, PyObject>,
         span: (usize, usize),
-        field_spans: HashMap<String, (usize, usize)>
+        field_spans: HashMap<String, (usize, usize)>,
     ) -> Self {
-        Self { 
-            fixed, 
-            named, 
+        Self {
+            fixed,
+            named,
             span,
             field_spans,
         }
@@ -51,19 +57,24 @@ impl ParseResult {
     pub fn with_offset(mut self, offset: usize) -> Self {
         self.span = (self.span.0 + offset, self.span.1 + offset);
         // Adjust all field spans by offset
-        self.field_spans = self.field_spans.into_iter()
+        self.field_spans = self
+            .field_spans
+            .into_iter()
             .map(|(k, (start, end))| (k, (start + offset, end + offset)))
             .collect();
         self
     }
-
 }
 
 #[pymethods]
 impl ParseResult {
     #[new]
     #[pyo3(signature = (fixed, named, span=None))]
-    fn new_py(fixed: Vec<PyObject>, named: HashMap<String, PyObject>, span: Option<(usize, usize)>) -> Self {
+    fn new_py(
+        fixed: Vec<PyObject>,
+        named: HashMap<String, PyObject>,
+        span: Option<(usize, usize)>,
+    ) -> Self {
         Self::new(fixed, named, span.unwrap_or((0, 0)))
     }
 
@@ -105,7 +116,7 @@ impl ParseResult {
             if let Ok(slice) = key.downcast::<PySlice>() {
                 let len = self.fixed.len() as isize;
                 let indices = slice.indices(len)?;
-                
+
                 let mut result = Vec::new();
                 let mut idx = indices.start;
                 for _ in 0..indices.slicelength {
@@ -114,21 +125,30 @@ impl ParseResult {
                     }
                     idx += indices.step;
                 }
-                
+
                 let tuple = PyTuple::new(py, result)?;
                 Ok(tuple.into())
             } else if let Ok(idx) = key.extract::<usize>() {
                 self.fixed
                     .get(idx)
-                    .map(|obj| obj.clone_ref(py).into())
-                    .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyIndexError, _>("Index out of range"))
+                    .map(|obj| obj.clone_ref(py))
+                    .ok_or_else(|| {
+                        PyErr::new::<pyo3::exceptions::PyIndexError, _>("Index out of range")
+                    })
             } else if let Ok(name) = key.extract::<String>() {
                 self.named
                     .get(&name)
-                    .map(|obj| obj.clone_ref(py).into())
-                    .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!("Key '{}' not found", name)))
+                    .map(|obj| obj.clone_ref(py))
+                    .ok_or_else(|| {
+                        PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                            "Key '{}' not found",
+                            name
+                        ))
+                    })
             } else {
-                Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>("Key must be int, str, or slice"))
+                Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "Key must be int, str, or slice",
+                ))
             }
         })
     }
@@ -162,4 +182,3 @@ impl ParseResult {
         })
     }
 }
-

--- a/formatparse-pyo3/src/results.rs
+++ b/formatparse-pyo3/src/results.rs
@@ -1,7 +1,7 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::{PyIndexError, PyTypeError};
-use pyo3::types::PyList;
 use crate::parser::raw_match::RawMatchData;
+use pyo3::exceptions::{PyIndexError, PyTypeError};
+use pyo3::prelude::*;
+use pyo3::types::PyList;
 
 /// Results container that stores raw match data and lazily converts to ParseResult
 /// This avoids creating all ParseResult objects upfront, improving performance
@@ -20,36 +20,34 @@ impl Results {
             cached_results: None,
         }
     }
-    
+
     /// Convert all raw data to ParseResult objects (called lazily)
     fn convert_all(&mut self, py: Python) -> PyResult<PyObject> {
         if let Some(ref cached) = self.cached_results {
             return Ok(cached.clone_ref(py));
         }
-        
+
         let mut py_results: Vec<PyObject> = Vec::with_capacity(self.raw_data.len());
         for raw_data in &self.raw_data {
             let parse_result = raw_data.to_parse_result(py)?;
             py_results.push(parse_result.to_object(py));
         }
-        
-        let items: Vec<_> = py_results.iter()
-            .map(|obj| obj.bind(py))
-            .collect();
+
+        let items: Vec<_> = py_results.iter().map(|obj| obj.bind(py)).collect();
         let results_list = PyList::new_bound(py, items);
         let list_obj = results_list.to_object(py);
-        
+
         // Cache the result
         self.cached_results = Some(list_obj.clone_ref(py));
         Ok(list_obj)
     }
-    
+
     /// Convert a single raw data item to ParseResult (for lazy indexing)
     pub fn convert_item(&self, index: usize, py: Python) -> PyResult<PyObject> {
         if index >= self.raw_data.len() {
             return Err(PyIndexError::new_err("list index out of range"));
         }
-        
+
         let raw_data = &self.raw_data[index];
         let parse_result = raw_data.to_parse_result(py)?;
         Ok(parse_result.to_object(py))
@@ -62,7 +60,7 @@ impl Results {
     fn __len__(&self) -> usize {
         self.raw_data.len()
     }
-    
+
     /// Get an item by index (lazy conversion - only converts the requested item)
     fn __getitem__(&self, key: &Bound<'_, PyAny>, py: Python) -> PyResult<PyObject> {
         // Try to extract as usize first (positive index)
@@ -88,10 +86,12 @@ impl Results {
             let slice_result = list_bound.get_item(key)?;
             Ok(slice_result.to_object(py))
         } else {
-            Err(PyTypeError::new_err("list indices must be integers or slices"))
+            Err(PyTypeError::new_err(
+                "list indices must be integers or slices",
+            ))
         }
     }
-    
+
     /// Iterator support (batch converts on first iteration)
     fn __iter__(slf: PyRef<'_, Self>) -> PyResult<ResultsIterator> {
         Ok(ResultsIterator {
@@ -100,17 +100,17 @@ impl Results {
             index: 0,
         })
     }
-    
+
     /// Convert to list (forces conversion of all items)
     fn to_list(&mut self, py: Python) -> PyResult<PyObject> {
         self.convert_all(py)
     }
-    
+
     /// String representation
     fn __repr__(&self) -> String {
         format!("<Results {} matches>", self.raw_data.len())
     }
-    
+
     fn __str__(&self) -> String {
         self.__repr__()
     }
@@ -121,7 +121,7 @@ impl Results {
 #[pyclass]
 pub struct ResultsIterator {
     results: Py<Results>,
-    cached_list: Option<PyObject>,  // Cached list of converted items
+    cached_list: Option<PyObject>, // Cached list of converted items
     index: usize,
 }
 
@@ -130,7 +130,7 @@ impl ResultsIterator {
     fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf
     }
-    
+
     fn __next__(&mut self, py: Python) -> PyResult<Option<PyObject>> {
         // On first iteration, batch convert all items at once
         if self.cached_list.is_none() {
@@ -139,18 +139,22 @@ impl ResultsIterator {
             let list = results.call_method0("to_list")?;
             self.cached_list = Some(list.to_object(py));
         }
-        
+
         // Now iterate over the cached list (no FFI overhead)
-        let list_bound = self.cached_list.as_ref().unwrap().bind(py).downcast::<pyo3::types::PyList>()?;
+        let list_bound = self
+            .cached_list
+            .as_ref()
+            .unwrap()
+            .bind(py)
+            .downcast::<pyo3::types::PyList>()?;
         let len = list_bound.len();
-        
+
         if self.index >= len {
             return Ok(None);
         }
-        
+
         let item = list_bound.get_item(self.index)?;
         self.index += 1;
         Ok(Some(item.to_object(py)))
     }
 }
-

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -271,8 +271,12 @@ pub fn convert_value(spec: &FieldSpec, value: &str, py: Python, custom_converter
                     // Strip fill characters and whitespace based on alignment
                     let trimmed = match spec.alignment {
                         Some('<') => {
-                            // Left-aligned: strip trailing fill chars, then trailing spaces
-                            if let Some(fill_ch) = spec.fill {
+                            // With a fixed width, the capture includes intentional trailing
+                            // fill (often spaces); match parse and keep it (issue #39).
+                            // Without width, strip trailing fill / spaces like parse does.
+                            if spec.width.is_some() {
+                                value
+                            } else if let Some(fill_ch) = spec.fill {
                                 value.trim_end_matches(fill_ch).trim_end()
                             } else {
                                 value.trim_end()

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -4,6 +4,406 @@ use formatparse_core::{FieldSpec, FieldType};
 use pyo3::prelude::*;
 use std::collections::HashMap;
 
+/// Validate alignment+precision constraints for string fields
+/// Returns false if validation fails (should reject the match)
+///
+/// This validates the constraints described in issue #3 (parse#218):
+/// - Fill characters should only be in correct positions (left for right-align, right for left-align)
+/// - Total width (including fill chars) should not exceed specified width when width is specified
+/// - Content length (after removing fill chars) should not exceed precision
+pub fn validate_alignment_precision(spec: &FieldSpec, value: &str) -> bool {
+    if let FieldType::String = &spec.field_type {
+        if let (Some(prec), Some(align)) = (spec.precision, spec.alignment) {
+            let fill_ch = spec.fill.unwrap_or(' ');
+            let has_leading_fill = value.starts_with(fill_ch);
+            let has_trailing_fill = value.ends_with(fill_ch);
+
+            // Count leading and trailing fill characters
+            let leading_count = value.chars().take_while(|&c| c == fill_ch).count();
+            let trailing_count = value.chars().rev().take_while(|&c| c == fill_ch).count();
+            // Avoid underflow: if all chars are fill, content_len is 0
+            let content_len = if leading_count + trailing_count >= value.len() {
+                0
+            } else {
+                value.len() - leading_count - trailing_count
+            };
+
+            // Special case: if all chars are fill (content_len == 0), allow it if total length equals width
+            if content_len == 0 {
+                if let Some(width) = spec.width {
+                    if value.len() == width {
+                        return true; // Valid: empty content, all fill, total = width
+                    }
+                }
+                return false; // Invalid: all fill but doesn't match width
+            }
+
+            match align {
+                '>' => {
+                    // Right-aligned: fill chars should only be on the left
+                    // Reject if fill char on both sides (invalid) - but only if there's actual content
+                    if has_leading_fill && has_trailing_fill {
+                        return false;
+                    }
+                    // Reject if fill char on right (should only be on left)
+                    if has_trailing_fill {
+                        return false;
+                    }
+                    // Reject if content exceeds precision
+                    if content_len > prec {
+                        return false;
+                    }
+                    // Reject if width is specified and total width exceeds it
+                    // When width is specified with precision, total should not exceed width
+                    if let Some(width) = spec.width {
+                        if value.len() > width {
+                            return false;
+                        }
+                    } else {
+                        // No width specified, but precision is: reject if fill enables extra content
+                        if has_leading_fill && value.len() > prec {
+                            let leading_count = value.chars().take_while(|&c| c == fill_ch).count();
+                            let content_len = value.len() - leading_count;
+                            if content_len > prec {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                '<' => {
+                    // Left-aligned: fill chars should only be on the right
+                    // Reject if fill char on left (should only be on right)
+                    if has_leading_fill {
+                        return false;
+                    }
+                    // Reject if content exceeds precision
+                    if content_len > prec {
+                        return false;
+                    }
+                    // Reject if width is specified and total width exceeds it
+                    if let Some(width) = spec.width {
+                        if value.len() > width {
+                            return false;
+                        }
+                    } else {
+                        // No width specified, but precision is: reject if fill enables extra content
+                        if has_trailing_fill && value.len() > prec {
+                            let trailing_count =
+                                value.chars().rev().take_while(|&c| c == fill_ch).count();
+                            let content_len = value.len() - trailing_count;
+                            if content_len > prec {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                '^' => {
+                    // Center-aligned: reject if content exceeds precision
+                    if content_len > prec {
+                        return false;
+                    }
+                    // Reject if width is specified and total width exceeds it
+                    if let Some(width) = spec.width {
+                        if value.len() > width {
+                            return false;
+                        }
+                    } else {
+                        // No width specified, but precision is: reject if content exceeds precision
+                        if content_len > prec {
+                            return false;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    true
+}
+
+pub fn convert_value(
+    spec: &FieldSpec,
+    value: &str,
+    py: Python,
+    custom_converters: &HashMap<String, PyObject>,
+) -> PyResult<PyObject> {
+    // Fast path: if no custom converters, skip the lookup entirely
+    if !custom_converters.is_empty() {
+        // Check if this type has a custom converter (even if it's a built-in type name)
+        let type_name = match &spec.field_type {
+            FieldType::Custom(name) => name.as_str(),
+            FieldType::String => "s",
+            FieldType::Integer => "d",
+            FieldType::Float => "f",
+            FieldType::Boolean => "b",
+            FieldType::Letters => "l",
+            FieldType::Word => "w",
+            FieldType::NonLetters => "W",
+            FieldType::NonWhitespace => "S",
+            FieldType::NonDigits => "D",
+            FieldType::NumberWithThousands => "n",
+            FieldType::Scientific => "e",
+            FieldType::GeneralNumber => "g",
+            FieldType::Percentage => "%",
+            FieldType::DateTimeISO => "ti",
+            FieldType::DateTimeRFC2822 => "te",
+            FieldType::DateTimeGlobal => "tg",
+            FieldType::DateTimeUS => "ta",
+            FieldType::DateTimeCtime => "tc",
+            FieldType::DateTimeHTTP => "th",
+            FieldType::DateTimeTime => "tt",
+            FieldType::DateTimeSystem => "ts",
+            FieldType::DateTimeStrftime => "strftime",
+        };
+
+        // If there's a custom converter for this type name, use it instead of built-in
+        if let Some(converter) = custom_converters.get(type_name) {
+            let args = (value,);
+            return converter.call1(py, args);
+        }
+    }
+
+    // Use built-in conversion
+    match &spec.field_type {
+        FieldType::String => {
+            // Fast path: no alignment means no trimming needed
+            if spec.alignment.is_none() {
+                Ok(value.to_object(py))
+            } else {
+                // Strip fill characters and whitespace based on alignment
+                let trimmed = match spec.alignment {
+                    Some('<') => {
+                        // With a fixed width, the capture includes intentional trailing
+                        // fill (often spaces); match parse and keep it (issue #39).
+                        // Without width, strip trailing fill / spaces like parse does.
+                        if spec.width.is_some() {
+                            value
+                        } else if let Some(fill_ch) = spec.fill {
+                            value.trim_end_matches(fill_ch).trim_end()
+                        } else {
+                            value.trim_end()
+                        }
+                    }
+                    Some('>') => {
+                        // Right-aligned: strip leading fill chars, then leading spaces
+                        if let Some(fill_ch) = spec.fill {
+                            value.trim_start_matches(fill_ch).trim_start()
+                        } else {
+                            value.trim_start()
+                        }
+                    }
+                    Some('^') => {
+                        // Center-aligned: strip both leading and trailing fill chars, then spaces
+                        if let Some(fill_ch) = spec.fill {
+                            value.trim_matches(fill_ch).trim()
+                        } else {
+                            value.trim()
+                        }
+                    }
+                    _ => value, // No alignment: keep as-is
+                };
+                Ok(trimmed.to_object(py))
+            }
+        }
+        FieldType::Integer => {
+            // Fast path: common case - decimal integer, no special formatting
+            if spec.fill.is_none()
+                && spec.alignment != Some('=')
+                && spec.original_type_char.is_none()
+            {
+                // Try parsing directly first (most common case)
+                if let Ok(n) = value.trim().parse::<i64>() {
+                    return Ok(n.to_object(py));
+                }
+            }
+
+            // Full path: handle all cases
+            // Strip whitespace before parsing (width may include spaces)
+            let mut trimmed_str = value.trim().to_string();
+
+            // Strip fill characters if alignment is '=' with fill
+            // Fill characters appear between sign and digits (e.g., "-xxx12" or "+xxx12")
+            // But NOT between sign and prefix (e.g., "-0o10" should not strip '0')
+            if let (Some(fill_ch), Some('=')) = (spec.fill, spec.alignment) {
+                // Check if there's a sign first
+                if trimmed_str.starts_with('-') || trimmed_str.starts_with('+') {
+                    // Keep the sign, strip fill chars after it but before the number part
+                    let sign_char = &trimmed_str[..1];
+                    let rest = &trimmed_str[1..];
+                    // Only strip fill if it's not part of a prefix (0x, 0o, 0b)
+                    if rest.starts_with("0x")
+                        || rest.starts_with("0X")
+                        || rest.starts_with("0o")
+                        || rest.starts_with("0O")
+                        || rest.starts_with("0b")
+                        || rest.starts_with("0B")
+                    {
+                        // Has prefix, don't strip (fill shouldn't appear here)
+                        // Actually, fill can appear: "-xxx0o10" -> strip xxx
+                        let rest_trimmed = rest.trim_start_matches(fill_ch);
+                        trimmed_str = format!("{}{}", sign_char, rest_trimmed);
+                    } else {
+                        // No prefix, strip fill chars
+                        let rest_trimmed = rest.trim_start_matches(fill_ch);
+                        trimmed_str = format!("{}{}", sign_char, rest_trimmed);
+                    }
+                } else {
+                    // No sign, just strip leading fill chars
+                    trimmed_str = trimmed_str.trim_start_matches(fill_ch).to_string();
+                }
+            }
+
+            let trimmed = trimmed_str.as_str();
+            // Handle negative numbers with prefixes (e.g., "-0o10")
+            let (is_negative, num_str) = if trimmed.starts_with('-') {
+                (true, &trimmed[1..])
+            } else if trimmed.starts_with('+') {
+                (false, &trimmed[1..])
+            } else {
+                (false, trimmed)
+            };
+
+            let v = if num_str.starts_with("0x") || num_str.starts_with("0X") {
+                i64::from_str_radix(&num_str[2..], 16).map(|n| if is_negative { -n } else { n })
+            } else if num_str.starts_with("0o") || num_str.starts_with("0O") {
+                i64::from_str_radix(&num_str[2..], 8).map(|n| if is_negative { -n } else { n })
+            } else if num_str.starts_with("0b") || num_str.starts_with("0B") {
+                // Check if type is 'x' - if so, "0B" should be parsed as hex (0xB)
+                let result = if spec.original_type_char == Some('x')
+                    || spec.original_type_char == Some('X')
+                {
+                    // For hex type, "0B" means 0xB (hex), not binary
+                    if num_str == "0B" || num_str == "0b" {
+                        i64::from_str_radix("B", 16)
+                    } else if num_str.len() > 2 {
+                        // "0B1" should be parsed as "B1" in hex
+                        i64::from_str_radix(&num_str[1..], 16)
+                    } else {
+                        i64::from_str_radix(&num_str[2..], 2)
+                    }
+                } else {
+                    i64::from_str_radix(&num_str[2..], 2)
+                };
+                result.map(|n| if is_negative { -n } else { n })
+            } else {
+                // Check original type character to determine base if no prefix
+                let result = match spec.original_type_char {
+                    Some('b') => i64::from_str_radix(num_str, 2), // Binary without 0b prefix
+                    Some('o') => i64::from_str_radix(num_str, 8), // Octal without 0o prefix
+                    Some('x') | Some('X') => i64::from_str_radix(num_str, 16), // Hex without 0x prefix
+                    _ => num_str.parse::<i64>(),                               // Decimal
+                };
+                result.map(|n| if is_negative { -n } else { n })
+            };
+            match v {
+                Ok(n) => Ok(n.to_object(py)),
+                Err(_) => Err(error::conversion_error(value, "integer")),
+            }
+        }
+        FieldType::Float => {
+            // Fast path: try parsing directly first (most floats don't have leading/trailing spaces)
+            match value.parse::<f64>() {
+                Ok(n) => Ok(n.to_object(py)),
+                Err(_) => {
+                    // Fallback: strip whitespace and try again
+                    let trimmed = value.trim();
+                    match trimmed.parse::<f64>() {
+                        Ok(n) => Ok(n.to_object(py)),
+                        Err(_) => Err(error::conversion_error(value, "float")),
+                    }
+                }
+            }
+        }
+        FieldType::Boolean => {
+            // Fast path: check common cases without allocation
+            let b = match value.len() {
+                1 => value == "1",
+                2 => matches!(value, "on" | "ON"),
+                3 => matches!(value, "yes" | "YES"),
+                4 => matches!(value, "true" | "TRUE"),
+                _ => {
+                    // Fallback: lowercase comparison
+                    let lower = value.to_lowercase();
+                    matches!(lower.as_str(), "true" | "1" | "yes" | "on")
+                }
+            };
+            Ok(b.to_object(py))
+        }
+        FieldType::Letters => Ok(value.to_object(py)), // Letters are just strings
+        FieldType::Word => Ok(value.to_object(py)),    // Words are just strings
+        FieldType::NonLetters => Ok(value.to_object(py)), // Non-letters are just strings
+        FieldType::NonWhitespace => Ok(value.to_object(py)), // Non-whitespace are just strings
+        FieldType::NonDigits => Ok(value.to_object(py)), // Non-digits are just strings
+        FieldType::NumberWithThousands => {
+            // Strip thousands separators (comma or dot) and parse as integer
+            let trimmed = value.trim();
+            let cleaned = trimmed.replace(",", "").replace(".", "");
+            match cleaned.parse::<i64>() {
+                Ok(n) => Ok(n.to_object(py)),
+                Err(_) => Err(error::conversion_error(value, "number with thousands")),
+            }
+        }
+        FieldType::Scientific => {
+            // Parse as float (supports scientific notation)
+            let trimmed = value.trim();
+            match trimmed.parse::<f64>() {
+                Ok(n) => Ok(n.to_object(py)),
+                Err(_) => Err(error::conversion_error(value, "scientific notation")),
+            }
+        }
+        FieldType::GeneralNumber => {
+            // Parse as int if possible, otherwise float, or nan/inf
+            let trimmed = value.trim();
+            let lower = trimmed.to_lowercase();
+            // Check for nan/inf first
+            if lower == "nan" {
+                Ok(f64::NAN.to_object(py))
+            } else if lower == "inf" || lower == "+inf" {
+                Ok(f64::INFINITY.to_object(py))
+            } else if lower == "-inf" {
+                Ok(f64::NEG_INFINITY.to_object(py))
+            } else {
+                // Try int first
+                if let Ok(n) = trimmed.parse::<i64>() {
+                    Ok(n.to_object(py))
+                } else if let Ok(n) = trimmed.parse::<f64>() {
+                    Ok(n.to_object(py))
+                } else {
+                    Err(error::conversion_error(value, "number"))
+                }
+            }
+        }
+        FieldType::Percentage => {
+            // Parse number, remove %, divide by 100
+            let trimmed = value.trim();
+            let num_str = trimmed.trim_end_matches('%');
+            match num_str.parse::<f64>() {
+                Ok(n) => Ok((n / 100.0).to_object(py)),
+                Err(_) => Err(error::conversion_error(value, "percentage")),
+            }
+        }
+        FieldType::DateTimeISO => datetime::parse_iso_datetime(py, value),
+        FieldType::DateTimeRFC2822 => datetime::parse_rfc2822_datetime(py, value),
+        FieldType::DateTimeGlobal => datetime::parse_global_datetime(py, value),
+        FieldType::DateTimeUS => datetime::parse_us_datetime(py, value),
+        FieldType::DateTimeCtime => datetime::parse_ctime_datetime(py, value),
+        FieldType::DateTimeHTTP => datetime::parse_http_datetime(py, value),
+        FieldType::DateTimeTime => datetime::parse_time(py, value),
+        FieldType::DateTimeSystem => datetime::parse_system_datetime(py, value),
+        FieldType::DateTimeStrftime => {
+            if let Some(fmt) = &spec.strftime_format {
+                datetime::parse_strftime_datetime(py, value, fmt)
+            } else {
+                Ok(value.to_object(py))
+            }
+        }
+        FieldType::Custom(_) => {
+            // Already handled above
+            Ok(value.to_object(py))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -18,10 +418,10 @@ mod tests {
             fill: Some(' '),
             ..Default::default()
         };
-        
+
         // Right-aligned: fill chars on left only
         assert!(validate_alignment_precision(&spec, "     hello")); // 5 spaces + 5 chars = 10 total, 5 content
-        assert!(validate_alignment_precision(&spec, "hello"));      // No fill, just content
+        assert!(validate_alignment_precision(&spec, "hello")); // No fill, just content
         assert!(!validate_alignment_precision(&spec, "     hello ")); // Fill on right (invalid)
     }
 
@@ -35,10 +435,10 @@ mod tests {
             fill: Some(' '),
             ..Default::default()
         };
-        
+
         // Left-aligned: fill chars on right only
         assert!(validate_alignment_precision(&spec, "hello     ")); // 5 chars + 5 spaces = 10 total
-        assert!(validate_alignment_precision(&spec, "hello"));      // No fill, just content
+        assert!(validate_alignment_precision(&spec, "hello")); // No fill, just content
         assert!(!validate_alignment_precision(&spec, " hello     ")); // Fill on left (invalid)
     }
 
@@ -52,10 +452,10 @@ mod tests {
             fill: Some(' '),
             ..Default::default()
         };
-        
+
         // Center-aligned: fill chars on both sides
         assert!(validate_alignment_precision(&spec, "  hello   ")); // 2 spaces + 5 chars + 3 spaces = 10 total
-        assert!(validate_alignment_precision(&spec, "hello"));      // No fill, just content
+        assert!(validate_alignment_precision(&spec, "hello")); // No fill, just content
         assert!(!validate_alignment_precision(&spec, "  hello  x")); // Content exceeds precision (6 > 5)
     }
 
@@ -69,10 +469,10 @@ mod tests {
             fill: Some('x'),
             ..Default::default()
         };
-        
+
         // All fill chars, matches width - should be valid
         assert!(validate_alignment_precision(&spec, "xxxxx")); // 5 x's, matches width
-        
+
         // All fill chars, doesn't match width - should be invalid
         assert!(!validate_alignment_precision(&spec, "xxxx")); // 4 x's, doesn't match width 5
     }
@@ -86,7 +486,7 @@ mod tests {
             alignment: Some('>'),
             ..Default::default()
         };
-        
+
         // Non-string types should always return true (no validation)
         assert!(validate_alignment_precision(&spec, "12345"));
         assert!(validate_alignment_precision(&spec, "anything"));
@@ -101,410 +501,12 @@ mod tests {
             alignment: None,
             ..Default::default()
         };
-        
+
         // No precision or alignment means no validation
         assert!(validate_alignment_precision(&spec, "any string"));
-        assert!(validate_alignment_precision(&spec, "very long string that exceeds width"));
+        assert!(validate_alignment_precision(
+            &spec,
+            "very long string that exceeds width"
+        ));
     }
 }
-
-    /// Validate alignment+precision constraints for string fields
-    /// Returns false if validation fails (should reject the match)
-    /// 
-    /// This validates the constraints described in issue #3 (parse#218):
-    /// - Fill characters should only be in correct positions (left for right-align, right for left-align)
-    /// - Total width (including fill chars) should not exceed specified width when width is specified
-    /// - Content length (after removing fill chars) should not exceed precision
-pub fn validate_alignment_precision(spec: &FieldSpec, value: &str) -> bool {
-    if let FieldType::String = &spec.field_type {
-        if let (Some(prec), Some(align)) = (spec.precision, spec.alignment) {
-            let fill_ch = spec.fill.unwrap_or(' ');
-                let has_leading_fill = value.starts_with(fill_ch);
-                let has_trailing_fill = value.ends_with(fill_ch);
-                
-                // Count leading and trailing fill characters
-                let leading_count = value.chars().take_while(|&c| c == fill_ch).count();
-                let trailing_count = value.chars().rev().take_while(|&c| c == fill_ch).count();
-                // Avoid underflow: if all chars are fill, content_len is 0
-                let content_len = if leading_count + trailing_count >= value.len() {
-                    0
-                } else {
-                    value.len() - leading_count - trailing_count
-                };
-                
-                // Special case: if all chars are fill (content_len == 0), allow it if total length equals width
-                if content_len == 0 {
-                if let Some(width) = spec.width {
-                        if value.len() == width {
-                            return true;  // Valid: empty content, all fill, total = width
-                        }
-                    }
-                    return false;  // Invalid: all fill but doesn't match width
-                }
-                
-                match align {
-                    '>' => {
-                        // Right-aligned: fill chars should only be on the left
-                        // Reject if fill char on both sides (invalid) - but only if there's actual content
-                        if has_leading_fill && has_trailing_fill {
-                            return false;
-                        }
-                        // Reject if fill char on right (should only be on left)
-                        if has_trailing_fill {
-                            return false;
-                        }
-                        // Reject if content exceeds precision
-                        if content_len > prec {
-                            return false;
-                        }
-                        // Reject if width is specified and total width exceeds it
-                        // When width is specified with precision, total should not exceed width
-                    if let Some(width) = spec.width {
-                            if value.len() > width {
-                                return false;
-                            }
-                        } else {
-                            // No width specified, but precision is: reject if fill enables extra content
-                            if has_leading_fill && value.len() > prec {
-                                let leading_count = value.chars().take_while(|&c| c == fill_ch).count();
-                                let content_len = value.len() - leading_count;
-                                if content_len > prec {
-                                    return false;
-                                }
-                            }
-                        }
-                    },
-                    '<' => {
-                        // Left-aligned: fill chars should only be on the right
-                        // Reject if fill char on left (should only be on right)
-                        if has_leading_fill {
-                            return false;
-                        }
-                        // Reject if content exceeds precision
-                        if content_len > prec {
-                            return false;
-                        }
-                        // Reject if width is specified and total width exceeds it
-                    if let Some(width) = spec.width {
-                            if value.len() > width {
-                                return false;
-                            }
-                        } else {
-                            // No width specified, but precision is: reject if fill enables extra content
-                            if has_trailing_fill && value.len() > prec {
-                                let trailing_count = value.chars().rev().take_while(|&c| c == fill_ch).count();
-                                let content_len = value.len() - trailing_count;
-                                if content_len > prec {
-                                    return false;
-                                }
-                            }
-                        }
-                    },
-                    '^' => {
-                        // Center-aligned: reject if content exceeds precision
-                        if content_len > prec {
-                            return false;
-                        }
-                        // Reject if width is specified and total width exceeds it
-                    if let Some(width) = spec.width {
-                            if value.len() > width {
-                                return false;
-                            }
-                        } else {
-                            // No width specified, but precision is: reject if content exceeds precision
-                            if content_len > prec {
-                                return false;
-                            }
-                        }
-                    },
-                    _ => {}
-                }
-            }
-        }
-        true
-    }
-
-pub fn convert_value(spec: &FieldSpec, value: &str, py: Python, custom_converters: &HashMap<String, PyObject>) -> PyResult<PyObject> {
-        // Fast path: if no custom converters, skip the lookup entirely
-        if !custom_converters.is_empty() {
-            // Check if this type has a custom converter (even if it's a built-in type name)
-            let type_name = match &spec.field_type {
-                FieldType::Custom(name) => name.as_str(),
-                FieldType::String => "s",
-                FieldType::Integer => "d",
-                FieldType::Float => "f",
-                FieldType::Boolean => "b",
-                FieldType::Letters => "l",
-                FieldType::Word => "w",
-                FieldType::NonLetters => "W",
-                FieldType::NonWhitespace => "S",
-                FieldType::NonDigits => "D",
-                FieldType::NumberWithThousands => "n",
-                FieldType::Scientific => "e",
-                FieldType::GeneralNumber => "g",
-                FieldType::Percentage => "%",
-                FieldType::DateTimeISO => "ti",
-                FieldType::DateTimeRFC2822 => "te",
-                FieldType::DateTimeGlobal => "tg",
-                FieldType::DateTimeUS => "ta",
-                FieldType::DateTimeCtime => "tc",
-                FieldType::DateTimeHTTP => "th",
-                FieldType::DateTimeTime => "tt",
-                FieldType::DateTimeSystem => "ts",
-                FieldType::DateTimeStrftime => "strftime",
-            };
-            
-            // If there's a custom converter for this type name, use it instead of built-in
-            if let Some(converter) = custom_converters.get(type_name) {
-                let args = (value,);
-                return converter.call1(py, args);
-            }
-        }
-        
-        // Use built-in conversion
-        match &spec.field_type {
-            FieldType::String => {
-                // Fast path: no alignment means no trimming needed
-                if spec.alignment.is_none() {
-                    Ok(value.to_object(py))
-                } else {
-                    // Strip fill characters and whitespace based on alignment
-                    let trimmed = match spec.alignment {
-                        Some('<') => {
-                            // With a fixed width, the capture includes intentional trailing
-                            // fill (often spaces); match parse and keep it (issue #39).
-                            // Without width, strip trailing fill / spaces like parse does.
-                            if spec.width.is_some() {
-                                value
-                            } else if let Some(fill_ch) = spec.fill {
-                                value.trim_end_matches(fill_ch).trim_end()
-                            } else {
-                                value.trim_end()
-                            }
-                        },
-                        Some('>') => {
-                            // Right-aligned: strip leading fill chars, then leading spaces
-                            if let Some(fill_ch) = spec.fill {
-                                value.trim_start_matches(fill_ch).trim_start()
-                            } else {
-                                value.trim_start()
-                            }
-                        },
-                        Some('^') => {
-                            // Center-aligned: strip both leading and trailing fill chars, then spaces
-                            if let Some(fill_ch) = spec.fill {
-                                value.trim_matches(fill_ch).trim()
-                            } else {
-                                value.trim()
-                            }
-                        },
-                        _ => value,  // No alignment: keep as-is
-                    };
-                    Ok(trimmed.to_object(py))
-                }
-            },
-            FieldType::Integer => {
-                // Fast path: common case - decimal integer, no special formatting
-                if spec.fill.is_none() && spec.alignment != Some('=') && spec.original_type_char.is_none() {
-                    // Try parsing directly first (most common case)
-                    if let Ok(n) = value.trim().parse::<i64>() {
-                        return Ok(n.to_object(py));
-                    }
-                }
-                
-                // Full path: handle all cases
-                // Strip whitespace before parsing (width may include spaces)
-                let mut trimmed_str = value.trim().to_string();
-                
-                // Strip fill characters if alignment is '=' with fill
-                // Fill characters appear between sign and digits (e.g., "-xxx12" or "+xxx12")
-                // But NOT between sign and prefix (e.g., "-0o10" should not strip '0')
-                if let (Some(fill_ch), Some('=')) = (spec.fill, spec.alignment) {
-                    // Check if there's a sign first
-                    if trimmed_str.starts_with('-') || trimmed_str.starts_with('+') {
-                        // Keep the sign, strip fill chars after it but before the number part
-                        let sign_char = &trimmed_str[..1];
-                        let rest = &trimmed_str[1..];
-                        // Only strip fill if it's not part of a prefix (0x, 0o, 0b)
-                        if rest.starts_with("0x") || rest.starts_with("0X") || 
-                           rest.starts_with("0o") || rest.starts_with("0O") ||
-                           rest.starts_with("0b") || rest.starts_with("0B") {
-                            // Has prefix, don't strip (fill shouldn't appear here)
-                            // Actually, fill can appear: "-xxx0o10" -> strip xxx
-                            let rest_trimmed = rest.trim_start_matches(fill_ch);
-                            trimmed_str = format!("{}{}", sign_char, rest_trimmed);
-                        } else {
-                            // No prefix, strip fill chars
-                            let rest_trimmed = rest.trim_start_matches(fill_ch);
-                            trimmed_str = format!("{}{}", sign_char, rest_trimmed);
-                        }
-                    } else {
-                        // No sign, just strip leading fill chars
-                        trimmed_str = trimmed_str.trim_start_matches(fill_ch).to_string();
-                    }
-                }
-                
-                let trimmed = trimmed_str.as_str();
-                // Handle negative numbers with prefixes (e.g., "-0o10")
-                let (is_negative, num_str) = if trimmed.starts_with('-') {
-                    (true, &trimmed[1..])
-                } else if trimmed.starts_with('+') {
-                    (false, &trimmed[1..])
-                } else {
-                    (false, trimmed)
-                };
-                
-                let v = if num_str.starts_with("0x") || num_str.starts_with("0X") {
-                    i64::from_str_radix(&num_str[2..], 16).map(|n| if is_negative { -n } else { n })
-                } else if num_str.starts_with("0o") || num_str.starts_with("0O") {
-                    i64::from_str_radix(&num_str[2..], 8).map(|n| if is_negative { -n } else { n })
-                } else if num_str.starts_with("0b") || num_str.starts_with("0B") {
-                    // Check if type is 'x' - if so, "0B" should be parsed as hex (0xB)
-                    let result = if spec.original_type_char == Some('x') || spec.original_type_char == Some('X') {
-                        // For hex type, "0B" means 0xB (hex), not binary
-                        if num_str == "0B" || num_str == "0b" {
-                            i64::from_str_radix("B", 16)
-                        } else if num_str.len() > 2 {
-                            // "0B1" should be parsed as "B1" in hex
-                            i64::from_str_radix(&num_str[1..], 16)
-                        } else {
-                            i64::from_str_radix(&num_str[2..], 2)
-                        }
-                    } else {
-                        i64::from_str_radix(&num_str[2..], 2)
-                    };
-                    result.map(|n| if is_negative { -n } else { n })
-                } else {
-                    // Check original type character to determine base if no prefix
-                    let result = match spec.original_type_char {
-                        Some('b') => i64::from_str_radix(num_str, 2), // Binary without 0b prefix
-                        Some('o') => i64::from_str_radix(num_str, 8), // Octal without 0o prefix
-                        Some('x') | Some('X') => i64::from_str_radix(num_str, 16), // Hex without 0x prefix
-                        _ => num_str.parse::<i64>(), // Decimal
-                    };
-                    result.map(|n| if is_negative { -n } else { n })
-                };
-                match v {
-                    Ok(n) => Ok(n.to_object(py)),
-                    Err(_) => Err(error::conversion_error(value, "integer")),
-                }
-            }
-            FieldType::Float => {
-                // Fast path: try parsing directly first (most floats don't have leading/trailing spaces)
-                match value.parse::<f64>() {
-                    Ok(n) => Ok(n.to_object(py)),
-                    Err(_) => {
-                        // Fallback: strip whitespace and try again
-                        let trimmed = value.trim();
-                        match trimmed.parse::<f64>() {
-                            Ok(n) => Ok(n.to_object(py)),
-                            Err(_) => Err(error::conversion_error(value, "float")),
-                        }
-                    }
-                }
-            }
-            FieldType::Boolean => {
-                // Fast path: check common cases without allocation
-                let b = match value.len() {
-                    1 => value == "1",
-                    2 => matches!(value, "on" | "ON"),
-                    3 => matches!(value, "yes" | "YES"),
-                    4 => matches!(value, "true" | "TRUE"),
-                    _ => {
-                        // Fallback: lowercase comparison
-                        let lower = value.to_lowercase();
-                        matches!(lower.as_str(), "true" | "1" | "yes" | "on")
-                    }
-                };
-                Ok(b.to_object(py))
-            }
-            FieldType::Letters => Ok(value.to_object(py)),  // Letters are just strings
-            FieldType::Word => Ok(value.to_object(py)),     // Words are just strings
-            FieldType::NonLetters => Ok(value.to_object(py)), // Non-letters are just strings
-            FieldType::NonWhitespace => Ok(value.to_object(py)), // Non-whitespace are just strings
-            FieldType::NonDigits => Ok(value.to_object(py)), // Non-digits are just strings
-            FieldType::NumberWithThousands => {
-                // Strip thousands separators (comma or dot) and parse as integer
-                let trimmed = value.trim();
-                let cleaned = trimmed.replace(",", "").replace(".", "");
-                match cleaned.parse::<i64>() {
-                    Ok(n) => Ok(n.to_object(py)),
-                    Err(_) => Err(error::conversion_error(value, "number with thousands")),
-                }
-            },
-            FieldType::Scientific => {
-                // Parse as float (supports scientific notation)
-                let trimmed = value.trim();
-                match trimmed.parse::<f64>() {
-                    Ok(n) => Ok(n.to_object(py)),
-                    Err(_) => Err(error::conversion_error(value, "scientific notation")),
-                }
-            },
-            FieldType::GeneralNumber => {
-                // Parse as int if possible, otherwise float, or nan/inf
-                let trimmed = value.trim();
-                let lower = trimmed.to_lowercase();
-                // Check for nan/inf first
-                if lower == "nan" {
-                    Ok(f64::NAN.to_object(py))
-                } else if lower == "inf" || lower == "+inf" {
-                    Ok(f64::INFINITY.to_object(py))
-                } else if lower == "-inf" {
-                    Ok(f64::NEG_INFINITY.to_object(py))
-                } else {
-                    // Try int first
-                    if let Ok(n) = trimmed.parse::<i64>() {
-                        Ok(n.to_object(py))
-                    } else if let Ok(n) = trimmed.parse::<f64>() {
-                        Ok(n.to_object(py))
-                    } else {
-                        Err(error::conversion_error(value, "number"))
-                    }
-                }
-            },
-            FieldType::Percentage => {
-                // Parse number, remove %, divide by 100
-                let trimmed = value.trim();
-                let num_str = trimmed.trim_end_matches('%');
-                match num_str.parse::<f64>() {
-                    Ok(n) => Ok((n / 100.0).to_object(py)),
-                    Err(_) => Err(error::conversion_error(value, "percentage")),
-                }
-            },
-            FieldType::DateTimeISO => {
-                datetime::parse_iso_datetime(py, value)
-            },
-            FieldType::DateTimeRFC2822 => {
-                datetime::parse_rfc2822_datetime(py, value)
-            },
-            FieldType::DateTimeGlobal => {
-                datetime::parse_global_datetime(py, value)
-            },
-            FieldType::DateTimeUS => {
-                datetime::parse_us_datetime(py, value)
-            },
-            FieldType::DateTimeCtime => {
-                datetime::parse_ctime_datetime(py, value)
-            },
-            FieldType::DateTimeHTTP => {
-                datetime::parse_http_datetime(py, value)
-            },
-            FieldType::DateTimeTime => {
-                datetime::parse_time(py, value)
-            },
-            FieldType::DateTimeSystem => {
-                datetime::parse_system_datetime(py, value)
-            },
-            FieldType::DateTimeStrftime => {
-                if let Some(fmt) = &spec.strftime_format {
-                    datetime::parse_strftime_datetime(py, value, fmt)
-                } else {
-                    Ok(value.to_object(py))
-                }
-            },
-            FieldType::Custom(_) => {
-                // Already handled above
-                Ok(value.to_object(py))
-            }
-        }
-    }

--- a/formatparse-pyo3/src/types/mod.rs
+++ b/formatparse-pyo3/src/types/mod.rs
@@ -6,6 +6,4 @@
 pub mod conversion;
 
 // Re-export core types for convenience
-pub use formatparse_core::{FieldType, FieldSpec};
-pub use formatparse_core::strftime_to_regex;
-
+pub use formatparse_core::FieldSpec;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ test = [
     "hypothesis>=6.0",
     "pytest-cov>=4.0",
     "pytest-benchmark>=4.0",
+    "pytest-xdist>=3.0",
     "pympler>=0.9",
     "memory_profiler>=0.60",
 ]

--- a/tests/test_alignment_precision.py
+++ b/tests/test_alignment_precision.py
@@ -59,6 +59,14 @@ def test_left_aligned_precision_valid():
     # This is correctly rejected by validation
 
 
+def test_left_aligned_precision_preserves_trailing_spaces_issue_39():
+    """Trailing spaces inside width/precision are content, not padding (parse parity)."""
+    result = parse("{s:<15.15}", "xxxxxxxxxx     ")
+    assert result is not None
+    assert result.named["s"] == "xxxxxxxxxx     "
+    assert len(result.named["s"]) == 15
+
+
 def test_center_aligned_precision():
     """Test center-aligned precision validation"""
     # Valid: no padding, exactly precision chars (total = width = precision)
@@ -131,4 +139,4 @@ def test_alignment_without_precision():
 
     result = parse("{s:<10}", "hello     ")
     assert result is not None
-    assert result.named["s"] == "hello"
+    assert result.named["s"] == "hello     "

--- a/tests/test_fill_character.py
+++ b/tests/test_fill_character.py
@@ -27,17 +27,17 @@ def test_left_aligned_fill_character():
     # Dot fill character
     result = parse("{name:.<16.16}", "Joe.............")
     assert result is not None
-    assert result.named["name"] == "Joe"
+    assert result.named["name"] == "Joe............."
 
     # X fill character
     result = parse("{name:x<10.10}", "ABCxxxxxxx")
     assert result is not None
-    assert result.named["name"] == "ABC"
+    assert result.named["name"] == "ABCxxxxxxx"
 
     # Zero fill character
     result = parse("{name:0<8.8}", "XYZ00000")
     assert result is not None
-    assert result.named["name"] == "XYZ"
+    assert result.named["name"] == "XYZ00000"
 
 
 def test_center_aligned_fill_character():
@@ -150,17 +150,17 @@ def test_round_trip_different_fill_characters():
     formatted = pattern.format(value="test")
     result = parse(pattern, formatted)
     assert result is not None
-    assert result.named["value"] == "test"
+    assert result.named["value"] == "test--------"
 
 
 def test_all_alignment_types_with_fill():
     """Test all alignment types comprehensively"""
     test_cases = [
         ("{name:.>10.10}", ".......ABC", ">", "ABC"),
-        ("{name:.<10.10}", "ABC.......", "<", "ABC"),
+        ("{name:.<10.10}", "ABC.......", "<", "ABC......."),
         ("{name:.^10.10}", "...ABC....", "^", "ABC"),
         ("{name:x>8.8}", "xxxxxXYZ", ">", "XYZ"),
-        ("{name:x<8.8}", "XYZxxxxx", "<", "XYZ"),
+        ("{name:x<8.8}", "XYZxxxxx", "<", "XYZxxxxx"),
         ("{name:x^8.8}", "xxXYZxxx", "^", "XYZ"),
     ]
 
@@ -179,10 +179,10 @@ def test_empty_string_with_fill():
     assert result is not None
     assert result.named["name"] == ""
 
-    # Left-aligned empty
+    # Left-aligned empty (parse keeps the full width of fill characters)
     result = parse("{name:.<10.10}", "..........")
     assert result is not None
-    assert result.named["name"] == ""
+    assert result.named["name"] == ".........."
 
     # Center-aligned empty
     result = parse("{name:.^10.10}", "..........")

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -4,6 +4,8 @@ These tests use property-based testing to explore edge cases and verify
 invariants that should hold for all valid inputs.
 """
 
+from typing import Optional
+
 import pytest
 from hypothesis import given, assume, strategies as st, settings
 from formatparse import (
@@ -339,6 +341,29 @@ def test_scientific_notation_parsing(value):
 # ============================================================================
 
 
+def _expected_parsed_aligned_string(
+    value: str, alignment: str, width: int, fill_char: Optional[str]
+) -> str:
+    """Match FieldType::String post-capture trimming (issue #39: `<` + width keeps tail)."""
+    spec = (
+        f"{fill_char}{alignment}{width}"
+        if fill_char is not None
+        else f"{alignment}{width}"
+    )
+    s = format(value, spec)
+    if alignment == "<":
+        return s
+    if alignment == ">":
+        if fill_char is not None:
+            return s.lstrip(fill_char).lstrip()
+        return s.lstrip()
+    if alignment == "^":
+        if fill_char is not None:
+            return s.strip(fill_char).strip()
+        return s.strip()
+    return s
+
+
 @settings(max_examples=100)
 @given(
     alignment=st.sampled_from(["<", ">", "^"]),
@@ -355,12 +380,12 @@ def test_string_alignment_combinations(alignment, width, value):
     # Format
     formatted = formatter.format({"value": value})
 
-    # Parse back - should extract the value (without alignment padding)
+    # Parse back — expected capture follows alignment-specific trimming rules
     result = formatter.parse(formatted)
     if result is not None:
-        # The parsed value should be the original value (padding removed)
         parsed = result.named["value"]
-        assert parsed == value
+        expected = _expected_parsed_aligned_string(value, alignment, width, None)
+        assert parsed == expected
 
 
 @settings(max_examples=100)
@@ -388,12 +413,14 @@ def test_fill_char_combinations(fill_char, alignment, width, value):
     # Format
     formatted = formatter.format({"value": value})
 
-    # Parse back
+    # Parse back — expected capture follows alignment-specific trimming rules
     result = formatter.parse(formatted)
     if result is not None:
-        # Should extract the original value (padding removed)
         parsed = result.named["value"]
-        assert parsed == value
+        expected = _expected_parsed_aligned_string(
+            value, alignment, width, fill_char
+        )
+        assert parsed == expected
 
 
 @settings(max_examples=100)

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -417,9 +417,7 @@ def test_fill_char_combinations(fill_char, alignment, width, value):
     result = formatter.parse(formatted)
     if result is not None:
         parsed = result.named["value"]
-        expected = _expected_parsed_aligned_string(
-            value, alignment, width, fill_char
-        )
+        expected = _expected_parsed_aligned_string(value, alignment, width, fill_char)
         assert parsed == expected
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -388,7 +388,7 @@ def test_alignment_with_width():
     """Test alignment with width"""
     result = parse("value: {value:<10}", "value: hello     ")
     assert result is not None
-    assert result.named["value"] == "hello"
+    assert result.named["value"] == "hello     "
 
 
 def test_alignment_with_fill():


### PR DESCRIPTION
Fixes https://github.com/eddiethedean/formatparse/issues/39

For left-aligned string fields with a width in the format spec, keep the regex capture unchanged so trailing fill (e.g. spaces) stays in the parsed value, matching the original parse library.

When no width is present, previous stripping behavior is unchanged.

- Updated conversion.rs and raw_match.rs
- Added regression test test_left_aligned_precision_preserves_trailing_spaces_issue_39
- Adjusted alignment/fill/types tests to match parse for width-based left alignment

Closes https://github.com/eddiethedean/formatparse/issues/39