### PR TITLE
fix: zero-fill right-align width.precision parse parity (#40)

### DIFF
--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -295,8 +295,9 @@ mod tests {
     fn test_raw_match_data_with_capacity() {
         let data = RawMatchData::with_capacity(10);
         assert_eq!(data.fixed.capacity(), 10);
-        assert_eq!(data.named.capacity(), 10);
-        assert_eq!(data.field_spans.capacity(), 10);
+        // HashMap capacity is a lower bound; exact bucket capacity is implementation-defined.
+        assert!(data.named.capacity() >= 10);
+        assert!(data.field_spans.capacity() >= 10);
     }
 
     #[test]

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -14,6 +14,17 @@ use std::collections::HashMap;
 pub fn validate_alignment_precision(spec: &FieldSpec, value: &str) -> bool {
     if let FieldType::String = &spec.field_type {
         if let (Some(prec), Some(align)) = (spec.precision, spec.alignment) {
+            // When width == precision == captured length and the field is zero-filled
+            // right-aligned, leading/trailing '0' cannot be distinguished from content
+            // (GitHub issue #40; parse parity).
+            if align == '>'
+                && spec.fill == Some('0')
+                && spec.width == Some(prec)
+                && Some(value.len()) == spec.width
+            {
+                return true;
+            }
+
             let fill_ch = spec.fill.unwrap_or(' ');
             let has_leading_fill = value.starts_with(fill_ch);
             let has_trailing_fill = value.ends_with(fill_ch);
@@ -185,8 +196,13 @@ pub fn convert_value(
                         }
                     }
                     Some('>') => {
-                        // Right-aligned: strip leading fill chars, then leading spaces
-                        if let Some(fill_ch) = spec.fill {
+                        // Zero-filled right align, fixed cell: keep full capture (issue #40, parse parity).
+                        if spec.fill == Some('0')
+                            && spec.width == spec.precision
+                            && spec.width == Some(value.len())
+                        {
+                            value
+                        } else if let Some(fill_ch) = spec.fill {
                             value.trim_start_matches(fill_ch).trim_start()
                         } else {
                             value.trim_start()
@@ -490,6 +506,19 @@ mod tests {
         // Non-string types should always return true (no validation)
         assert!(validate_alignment_precision(&spec, "12345"));
         assert!(validate_alignment_precision(&spec, "anything"));
+    }
+
+    #[test]
+    fn validate_issue40_zero_fill_right_width_precision() {
+        let spec = FieldSpec {
+            field_type: FieldType::String,
+            fill: Some('0'),
+            alignment: Some('>'),
+            width: Some(18),
+            precision: Some(18),
+            ..Default::default()
+        };
+        assert!(validate_alignment_precision(&spec, "000000000000100000"));
     }
 
     #[test]

--- a/tests/test_alignment_precision.py
+++ b/tests/test_alignment_precision.py
@@ -1,21 +1,31 @@
 """Tests for field alignment with precision validation
 
-These tests verify that formatparse correctly rejects invalid cases where
-alignment with precision would cause incorrect parsing, as described in
-issue #3 (related to parse#218).
-
-formatparse is stricter than the original parse library and correctly
-rejects these cases, which is the desired behavior.
+These tests cover alignment + precision rules (issue #3 / parse#218) and
+parse parity for **zero-filled, right-aligned** string fields when width,
+precision, and the captured slice length are all equal (issue #40): ``0``
+padding cannot be distinguished from content, matching the original ``parse``
+library for those cases.
 """
 
 from formatparse import parse
 
 
+def test_issue40_zero_fill_right_align_width_precision():
+    """Regression: parse parity for {s:0>18.18} (GitHub issue #40)."""
+    result = parse("{s:0>18.18}", "000000000000100000")
+    assert result is not None
+    assert result.named["s"] == "000000000000100000"
+
+    # Shorter pattern: capture must stay zero-padded (not stripped to "xx")
+    result = parse("{s:0>4.4}", "00xx")
+    assert result is not None
+    assert result.named["s"] == "00xx"
+
+
 def test_right_aligned_precision_invalid_both_sides():
-    """Test that right-aligned precision rejects fill chars on both sides"""
-    # Should fail: has fill character (space) on both sides
+    """Over-long input still does not match the anchored pattern."""
     result = parse("{s:>4.4}", " aaa ")
-    assert result is None, "Should reject fill character on both sides"
+    assert result is None
 
 
 def test_right_aligned_precision_invalid_extra_char():
@@ -43,9 +53,7 @@ def test_right_aligned_precision_valid():
     assert result is not None
     assert result.named["s"] == "aaaa"
 
-    # Note: "{s:>4.4}" with " aaa" (4 chars: 1 space + 3 content) doesn't match
-    # because the regex pattern requires exactly 4 chars after optional spaces
-    # This is correct behavior - when width==precision, no fill chars are allowed
+    # Note: "{s:>4.4}" with " aaa" (4 chars: 1 space + 3 content) matches as a full 4-char cell
 
 
 def test_left_aligned_precision_valid():
@@ -92,8 +100,7 @@ def test_alignment_precision_with_fill_character():
     assert result is not None
     assert result.named["s"] == "aaaa"
 
-    # Invalid: fill char on both sides - formatparse correctly rejects this
-    # Note: The original parse library incorrectly accepts this, but formatparse is stricter
+    # Invalid: fill char on both sides - formatparse rejects (parse accepts; we stay stricter here)
     result = parse("{s:.>4.4}", ".aa.")
     assert result is None, "Should reject fill character on both sides"
 

--- a/tests/test_fill_character.py
+++ b/tests/test_fill_character.py
@@ -16,10 +16,10 @@ def test_right_aligned_fill_character():
     assert result is not None
     assert result.named["name"] == "ABC"
 
-    # Zero fill character
+    # Zero fill character — width==precision==len: match parse (full padded capture, issue #40)
     result = parse("{name:0>8.8}", "00000XYZ")
     assert result is not None
-    assert result.named["name"] == "XYZ"
+    assert result.named["name"] == "00000XYZ"
 
 
 def test_left_aligned_fill_character():
@@ -136,7 +136,7 @@ def test_round_trip_different_fill_characters():
     formatted = pattern.format(id="123")
     result = parse(pattern, formatted)
     assert result is not None
-    assert result.named["id"] == "123"
+    assert result.named["id"] == "00000123"
 
     # X fill
     pattern = "Code: {code:x>10.10}"


### PR DESCRIPTION
## Summary
Fixes [issue #40](https://github.com/eddiethedean/formatparse/issues/40): `formatparse.parse` now agrees with the original `parse` library for patterns such as `{s:0>18.18}` on inputs like `000000000000100000`.

## Cause
For zero-filled right-aligned strings with **width == precision == capture length**, trailing (and leading) `0` characters are indistinguishable from content, so strict fill validation incorrectly rejected matches and `convert_value` stripped padding away from the captured slice.

## Changes
- **`validate_alignment_precision`**: accept without ambiguous fill checks when `align == '>'`, `fill == '0'`, and `width == precision == len(value)`.
- **`convert_value` (string, `>`)**: in that same situation, return the full capture (parse parity). Other fills and alignments unchanged.

## Tests
- Regression for the #40 reproducer plus `{s:0>4.4}` / `00xx`.
- Adjust zero-fill fill-character expectations to match `parse` (full padded string for `0>8.8`).

Fixes #40.