### PR TITLE
Richer ParseResult __repr__ for REPL debugging

### DIFF
--- a/formatparse-pyo3/src/result.rs
+++ b/formatparse-pyo3/src/result.rs
@@ -26,6 +26,19 @@ impl Clone for ParseResult {
     }
 }
 
+/// Truncate by Unicode scalar values so we never split inside a codepoint.
+fn repr_trunc(s: &str, max_chars: usize) -> String {
+    if max_chars < 3 {
+        return "...".to_string();
+    }
+    let n = s.chars().count();
+    if n <= max_chars {
+        return s.to_string();
+    }
+    let take = max_chars.saturating_sub(3);
+    s.chars().take(take).collect::<String>() + "..."
+}
+
 impl ParseResult {
     pub fn new(
         fixed: Vec<PyObject>,
@@ -63,6 +76,52 @@ impl ParseResult {
             .map(|(k, (start, end))| (k, (start + offset, end + offset)))
             .collect();
         self
+    }
+
+    /// Rich but bounded string for `__repr__` / `__str__` (sorted `named` keys for stability).
+    fn format_display(&self, py: Python<'_>) -> PyResult<String> {
+        const MAX_KEYS: usize = 12;
+        const MAX_VAL_CHARS: usize = 120;
+        const MAX_FIXED: usize = 8;
+
+        let mut keys: Vec<_> = self.named.keys().cloned().collect();
+        keys.sort();
+
+        let mut named_parts = Vec::new();
+        for k in keys.iter().take(MAX_KEYS) {
+            let v = self.named.get(k).expect("key from sorted vec");
+            let r: String = v.bind(py).repr()?.extract()?;
+            named_parts.push(format!("{k:?}: {}", repr_trunc(&r, MAX_VAL_CHARS)));
+        }
+        let mut named_body = named_parts.join(", ");
+        if keys.len() > MAX_KEYS {
+            named_body.push_str(&format!(", ... (+{} more)", keys.len() - MAX_KEYS));
+        }
+        let named_display = format!("{{{}}}", named_body);
+
+        let fixed_display = if self.fixed.is_empty() {
+            "()".to_string()
+        } else {
+            let mut fp = Vec::new();
+            for obj in self.fixed.iter().take(MAX_FIXED) {
+                let r: String = obj.bind(py).repr()?.extract()?;
+                fp.push(repr_trunc(&r, MAX_VAL_CHARS));
+            }
+            if self.fixed.len() > MAX_FIXED {
+                format!(
+                    "({}, ... (+{} more))",
+                    fp.join(", "),
+                    self.fixed.len() - MAX_FIXED
+                )
+            } else {
+                format!("({})", fp.join(", "))
+            }
+        };
+
+        Ok(format!(
+            "<ParseResult span={:?} named={} fixed={}>",
+            self.span, named_display, fixed_display
+        ))
     }
 }
 
@@ -102,12 +161,12 @@ impl ParseResult {
         self.span.1
     }
 
-    fn __repr__(&self) -> String {
-        format!("<Result {} {}>", self.fixed.len(), self.named.len())
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        self.format_display(py)
     }
 
-    fn __str__(&self) -> String {
-        self.__repr__()
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
+        self.format_display(py)
     }
 
     fn __getitem__(&self, key: &Bound<'_, PyAny>) -> PyResult<PyObject> {

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -97,6 +97,49 @@ def test_result_indexing():
     assert result2[1] == "World"
 
 
+def test_parse_result_repr_named_and_fixed():
+    """ParseResult repr surfaces named/fixed/span for REPL debugging (issue #41)."""
+    r = parse("{name}: {age:d}", "Alice: 30")
+    assert r is not None
+    s = repr(r)
+    assert s.startswith("<ParseResult ")
+    assert "span=(0, 9)" in s
+    assert '"age": 30' in s
+    assert "'Alice'" in s
+    assert "fixed=()" in s
+    assert str(r) == s
+
+    r2 = parse("{}, {}", "Hello, World")
+    assert r2 is not None
+    s2 = repr(r2)
+    assert "named={}" in s2
+    assert "('Hello', 'World')" in s2
+
+
+def test_parse_result_repr_truncates_many_named():
+    pattern = " ".join("{%s}" % chr(97 + i) for i in range(15))
+    text = " ".join(chr(97 + i) for i in range(15))
+    r = parse(pattern, text)
+    assert r is not None
+    assert "(+3 more)" in repr(r)
+
+
+def test_parse_result_repr_truncates_many_fixed():
+    pattern = " ".join("{}") * 10
+    text = " ".join(str(i) for i in range(10))
+    r = parse(pattern, text)
+    assert r is not None
+    assert "(+2 more)" in repr(r)
+
+
+def test_parse_result_repr_truncates_long_value():
+    long = "x" * 200
+    r = parse("{}", long)
+    assert r is not None
+    assert "..." in repr(r)
+    assert len(repr(r)) < 250
+
+
 def test_result_contains():
     """Test ParseResult __contains__"""
     result = parse("{name}: {age:d}", "Alice: 30")


### PR DESCRIPTION
Fixes #41.

## Summary
- `ParseResult.__repr__` / `__str__` now include `span`, a bounded `named={...}` summary (keys sorted for stable output, values via Python `repr()`), and `fixed=(...)`.
- Long value reprs and large `named` / `fixed` lists are truncated so REPL output stays readable.

## Tests
- Added assertions in `tests/test_basic.py` for named/fixed/span content, multi-key/multi-fixed truncation, and long-string bounds.