### PR TITLE
perf: route compile() through pattern LRU cache (#29)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -398,7 +398,11 @@ fn findall(
     })
 }
 
-/// Compile a pattern into a FormatParser for reuse
+/// Compile a pattern into a FormatParser for reuse.
+///
+/// Uses the same LRU cache as the `parse`, `search`, and `findall` bindings:
+/// `compile` with the same pattern and equivalent `extra_types` keys avoids
+/// rebuilding compiled regexes (see GitHub issue #29).
 #[pyfunction]
 #[pyo3(signature = (pattern, extra_types=None))]
 fn compile(
@@ -413,7 +417,15 @@ fn compile(
         return Err(PyValueError::new_err("Pattern contains null byte"));
     }
 
-    FormatParser::new_with_extra_types(pattern, extra_types)
+    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+        extra_types.as_ref().map(|et| {
+            et.iter()
+                .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                .collect()
+        })
+    });
+    let arc = get_or_create_parser(pattern, extra_types_cloned)?;
+    Ok((*arc).clone())
 }
 
 /// Extract format specification components from a format string

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -250,6 +250,31 @@ impl FormatParser {
     }
 }
 
+impl Clone for FormatParser {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| Self {
+            pattern: self.pattern.clone(),
+            regex: self.regex.clone(),
+            regex_str: self.regex_str.clone(),
+            regex_case_insensitive: self.regex_case_insensitive.clone(),
+            search_regex: self.search_regex.clone(),
+            search_regex_case_insensitive: self.search_regex_case_insensitive.clone(),
+            field_specs: self.field_specs.clone(),
+            field_names: self.field_names.clone(),
+            normalized_names: self.normalized_names.clone(),
+            name_mapping: self.name_mapping.clone(),
+            stored_extra_types: self.stored_extra_types.as_ref().map(|m| {
+                m.iter()
+                    .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                    .collect()
+            }),
+            custom_type_groups: self.custom_type_groups.clone(),
+            field_count: self.field_count,
+            has_nested_dict_fields: self.has_nested_dict_fields.clone(),
+        })
+    }
+}
+
 #[pymethods]
 impl FormatParser {
     #[new]

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -104,6 +104,13 @@ def compile(pattern: str, extra_types: Optional[ExtraTypes] = None) -> FormatPar
     without recompiling the regex, which improves performance for repeated
     parsing operations.
 
+    Repeated ``compile`` calls with the same *pattern* and equivalent
+    ``extra_types`` (same converter ``pattern`` and ``regex_group_count`` per
+    name) share the same internal compiled-regex cache as :func:`parse`,
+    :func:`search`, and :func:`findall`, so hot loops that call ``compile`` do
+    not pay full pattern-to-regex compilation on every iteration (see
+    `issue #29 <https://github.com/eddiethedean/formatparse/issues/29>`_).
+
     :param pattern: Format specification pattern (e.g., ``"{name}: {age:d}"``)
     :type pattern: str
     :param extra_types: Optional dictionary of custom type converters

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -120,7 +120,9 @@ def test_pickle_formatparser_does_not_restore_extra_types():
     del called[:]
     q = pickle.loads(pickle.dumps(p))
     q.parse("42")
-    assert called == [], "unpickled parser must not invoke original extra_types converter"
+    assert called == [], (
+        "unpickled parser must not invoke original extra_types converter"
+    )
 
 
 def test_unused_centered_alignment_bug():

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -1,0 +1,15 @@
+"""Tests for compile() sharing the pattern LRU cache (issue #29)."""
+
+from __future__ import annotations
+
+import formatparse
+
+
+def test_compile_twice_same_pattern_both_parse() -> None:
+    """Two compile() calls with the same pattern should yield usable parsers."""
+    p1 = formatparse.compile("{x}")
+    p2 = formatparse.compile("{x}")
+    r1 = p1.parse("hello")
+    r2 = p2.parse("world")
+    assert r1 is not None and r1.named["x"] == "hello"
+    assert r2 is not None and r2.named["x"] == "world"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -238,7 +238,9 @@ def test_error_message_sanitization():
         error_msg = str(e)
         # Should not contain the full pattern
         assert len(error_msg) < 500, "Error message too long, may contain full pattern"
-        assert "a" * 80 not in error_msg, "Error message may contain a large slice of the pattern"
+        assert "a" * 80 not in error_msg, (
+            "Error message may contain a large slice of the pattern"
+        )
         lower = error_msg.lower()
         assert "target/debug" not in lower, "Error message may contain build path"
         assert ".rs:" not in lower, "Error message may contain Rust source path"


### PR DESCRIPTION
## Summary
Implements the high-impact caching gap from [#29](https://github.com/eddiethedean/formatparse/issues/29): `parse` / `search` / `findall` already used `get_or_create_parser`, but `compile()` called `FormatParser::new_with_extra_types` directly and bypassed the LRU.

## Changes
- **`compile()`** now clones `extra_types` like `parse`, calls `get_or_create_parser`, and returns `(*arc).clone()` (Option A from the plan).
- **`Clone` for `FormatParser`** implemented manually (GIL + `clone_ref` on stored `PyObject`s; `Py` does not implement `#[derive(Clone)]`).
- **Docs:** `compile()` docstring in [formatparse/__init__.py](formatparse/__init__.py) notes shared cache with `parse` / `search` / `findall`.
- **Tests:** [tests/test_compile_cache.py](tests/test_compile_cache.py).

## Notes
- In-crate Rust tests that link the PyO3 test binary were skipped (local/CI often only runs `cargo test -p formatparse-core`); Python test covers behavior.
- Follow-up Option B (Arc inner handle) remains possible if profiling shows `Regex` clone cost matters.

Closes the **pattern compilation caching** bullet for `compile()` on #29.