### PR TITLE
fix: allow empty-string matches for default string fields (#16)

### DIFF
--- a/formatparse-core/src/types/definitions.rs
+++ b/formatparse-core/src/types/definitions.rs
@@ -62,6 +62,16 @@ impl FieldSpec {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// True for `{}` / `{name}` with no width, precision, or alignment (the plain
+    /// string branch in the regex builder). Used for empty-input `parse`
+    /// handling (formatparse#16) without changing search/findall semantics.
+    pub fn is_default_unconstrained_string(&self) -> bool {
+        matches!(self.field_type, FieldType::String)
+            && self.width.is_none()
+            && self.precision.is_none()
+            && self.alignment.is_none()
+    }
 }
 
 #[cfg(test)]

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -32,6 +32,7 @@ pub struct FormatParser {
     pub(crate) custom_type_groups: Vec<usize>, // Cached pattern_groups per field (for custom types)
     pub(crate) field_count: usize,             // Cached field count for fast path optimizations
     pub(crate) has_nested_dict_fields: Vec<bool>, // Cached flags: does field name contain '[' (nested dict)?
+    allows_empty_default_string_match: bool, // True iff parse("") can use empty-field fast path (issue #16)
 }
 
 impl FormatParser {
@@ -75,6 +76,7 @@ impl FormatParser {
             field_names,
             normalized_names,
             name_mapping,
+            allows_empty_default_string_match,
         ) = crate::parser::pattern::parse_pattern(pattern, extra_types.as_ref(), &custom_patterns)?;
 
         // Validate field count
@@ -147,6 +149,7 @@ impl FormatParser {
             custom_type_groups,
             field_count: field_specs.len(), // Cache field count for fast path
             has_nested_dict_fields,         // Cache nested dict flags
+            allows_empty_default_string_match,
         })
     }
 
@@ -209,6 +212,24 @@ impl FormatParser {
             } else {
                 &HashMap::new()
             };
+
+            if string.is_empty()
+                && self.allows_empty_default_string_match
+                && !self.field_specs.is_empty()
+            {
+                if let Some(obj) = crate::parser::matching::match_empty_default_string_parse(
+                    &self.pattern,
+                    &self.field_specs,
+                    &self.field_names,
+                    &self.normalized_names,
+                    py,
+                    extra_types_ref,
+                    evaluate_result,
+                )? {
+                    return Ok(Some(obj));
+                }
+            }
+
             crate::parser::matching::match_with_regex(
                 regex,
                 string,
@@ -271,6 +292,7 @@ impl Clone for FormatParser {
             custom_type_groups: self.custom_type_groups.clone(),
             field_count: self.field_count,
             has_nested_dict_fields: self.has_nested_dict_fields.clone(),
+            allows_empty_default_string_match: self.allows_empty_default_string_match,
         })
     }
 }
@@ -310,6 +332,7 @@ impl FormatParser {
                     custom_type_groups: Vec::new(),
                     field_count: 0,
                     has_nested_dict_fields: Vec::new(),
+                    allows_empty_default_string_match: false,
                 })
             }
         }
@@ -472,6 +495,7 @@ impl FormatParser {
         self.custom_type_groups = reconstructed.custom_type_groups;
         self.field_count = reconstructed.field_count;
         self.has_nested_dict_fields = reconstructed.has_nested_dict_fields;
+        self.allows_empty_default_string_match = reconstructed.allows_empty_default_string_match;
         Ok(())
     }
 }

--- a/formatparse-pyo3/src/parser/matching.rs
+++ b/formatparse-pyo3/src/parser/matching.rs
@@ -677,3 +677,117 @@ pub fn match_with_regex(
         Ok(None)
     }
 }
+
+/// Full parse of `""` when the pattern has no non-empty literals and every field is a
+/// default unconstrained string (`parse_pattern` sets `allows_empty_default_string_match`).
+pub fn match_empty_default_string_parse(
+    pattern: &str,
+    field_specs: &[FieldSpec],
+    field_names: &[Option<String>],
+    normalized_names: &[Option<String>],
+    py: Python<'_>,
+    custom_converters: &HashMap<String, PyObject>,
+    evaluate_result: bool,
+) -> PyResult<Option<PyObject>> {
+    let value_str = "";
+    let field_start: usize = 0;
+    let field_end: usize = 0;
+    let field_count = field_specs.len();
+    let mut fixed: Vec<PyObject> = Vec::with_capacity(field_count);
+    let mut named: HashMap<String, PyObject> = HashMap::with_capacity(field_count);
+    let mut field_spans: HashMap<String, (usize, usize)> = HashMap::with_capacity(field_count);
+    let mut captures_vec: Vec<Option<String>> = Vec::with_capacity(field_count);
+    let mut named_captures: HashMap<String, String> = HashMap::with_capacity(field_count);
+
+    let start = 0usize;
+    let end = 0usize;
+    let mut fixed_index = 0usize;
+
+    for (i, spec) in field_specs.iter().enumerate() {
+        if !custom_converters.is_empty() {
+            let _pattern_groups = validate_custom_type_pattern(spec, custom_converters, py)?;
+        }
+
+        if !evaluate_result {
+            captures_vec.push(Some(value_str.to_string()));
+            if let Some(norm_name) = normalized_names.get(i).and_then(|n| n.as_ref()) {
+                named_captures.insert(norm_name.clone(), value_str.to_string());
+            }
+        }
+
+        if evaluate_result {
+            if !crate::types::conversion::validate_alignment_precision(spec, value_str) {
+                return Ok(None);
+            }
+
+            let converted =
+                crate::types::conversion::convert_value(spec, value_str, py, custom_converters)?;
+
+            if let Some(ref original_name) = field_names[i] {
+                if original_name.contains('[') {
+                    let path = crate::parser::pattern::parse_field_path(original_name);
+                    if let Some(existing_value) = get_nested_dict_value(&named, &path, py)? {
+                        let are_equal: bool = {
+                            let existing_obj = existing_value.bind(py);
+                            let converted_obj = converted.bind(py);
+                            existing_obj.eq(converted_obj).unwrap_or(false)
+                        };
+                        if !are_equal {
+                            return Ok(None);
+                        }
+                    }
+                    insert_nested_dict(&mut named, &path, converted, py)?;
+                } else {
+                    match named.get(original_name) {
+                        Some(existing_value) => {
+                            let are_equal: bool = {
+                                let existing_obj = existing_value.to_object(py);
+                                let converted_obj = converted.to_object(py);
+                                existing_obj
+                                    .bind(py)
+                                    .eq(converted_obj.bind(py))
+                                    .unwrap_or(false)
+                            };
+                            if !are_equal {
+                                return Ok(None);
+                            }
+                            field_spans.insert(original_name.clone(), (field_start, field_end));
+                        }
+                        None => {
+                            let name_for_named = original_name.clone();
+                            named.insert(name_for_named.clone(), converted);
+                            field_spans.insert(name_for_named, (field_start, field_end));
+                        }
+                    }
+                }
+            } else {
+                fixed.push(converted);
+                field_spans.insert(fixed_index.to_string(), (field_start, field_end));
+                fixed_index += 1;
+            }
+        } else if let Some(ref original_name) = field_names[i] {
+            field_spans.insert(original_name.clone(), (field_start, field_end));
+        } else {
+            let index_str = fixed_index.to_string();
+            field_spans.insert(index_str, (field_start, field_end));
+            fixed_index += 1;
+        }
+    }
+
+    if evaluate_result {
+        let parse_result = ParseResult::new_with_spans(fixed, named, (start, end), field_spans);
+        Ok(Some(Py::new(py, parse_result)?.to_object(py)))
+    } else {
+        let match_obj = Match::new(
+            pattern.to_string(),
+            field_specs.to_vec(),
+            field_names.to_vec(),
+            normalized_names.to_vec(),
+            captures_vec,
+            named_captures,
+            (start, end),
+            field_spans,
+        );
+        Ok(Some(Py::new(py, match_obj)?.to_object(py)))
+    }
+}

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -16,6 +16,7 @@ pub fn parse_pattern(
     Vec<Option<String>>,
     Vec<Option<String>>,
     HashMap<String, String>,
+    bool,
 )> {
     // Pre-allocate with estimated capacity based on pattern length
     let estimated_fields = pattern.matches('{').count();
@@ -27,6 +28,7 @@ pub fn parse_pattern(
     let mut field_name_types = HashMap::with_capacity(estimated_fields); // Track field name -> FieldType for validation
     let mut chars: std::iter::Peekable<std::str::Chars> = pattern.chars().peekable();
     let mut literal = String::new();
+    let mut allows_empty_default_string_match = true;
 
     while let Some(ch) = chars.next() {
         match ch {
@@ -40,6 +42,7 @@ pub fn parse_pattern(
 
                 // Flush literal part
                 if !literal.is_empty() {
+                    allows_empty_default_string_match = false;
                     // If literal ends with whitespace, make it flexible to allow multiple spaces
                     // But use \s+ (one or more) instead of \s* (zero or more) to ensure we consume the space
                     let escaped = if literal.trim_end() != literal {
@@ -59,6 +62,9 @@ pub fn parse_pattern(
 
                 // Parse field specification
                 let (spec, name) = parse_field(&mut chars, extra_types)?;
+                if !spec.is_default_unconstrained_string() {
+                    allows_empty_default_string_match = false;
+                }
 
                 // Check if the next field (if any) is empty {} (non-greedy)
                 // This affects width-only string patterns: exact when followed by {}, greedy otherwise
@@ -205,6 +211,7 @@ pub fn parse_pattern(
 
     // Flush remaining literal
     if !literal.is_empty() {
+        allows_empty_default_string_match = false;
         // If literal ends with whitespace, make it flexible to allow multiple spaces
         let escaped = if literal.trim_end() != literal {
             // Literal ends with whitespace - replace trailing whitespace with \s*
@@ -226,6 +233,7 @@ pub fn parse_pattern(
         field_names,
         normalized_names,
         name_mapping,
+        allows_empty_default_string_match,
     ))
 }
 

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -147,3 +147,24 @@ def test_unused_left_alignment_bug():
 def test_match_trailing_newline():
     r = parse.parse("{}", "test\n")
     assert r[0] == "test\n"
+
+
+def test_empty_string_default_string_fields_formatparse_issue16():
+    """Parity with parse (parse#136): default string fields may match empty input."""
+    r = parse.parse("{}", "")
+    assert r is not None
+    assert r[0] == ""
+
+    r = parse.parse("{name}", "")
+    assert r is not None
+    assert r.named["name"] == ""
+
+    r = parse.parse("{}{}", "")
+    assert r is not None
+    assert r[0] == ""
+    assert r[1] == ""
+
+    r = parse.parse("{a}{b}", "xy")
+    assert r is not None
+    assert r.named["a"] == "x"
+    assert r.named["b"] == "y"


### PR DESCRIPTION
Fixes [#16](https://github.com/eddiethedean/formatparse/issues/16) (parity with the behavior discussed in [parse#136](https://github.com/r1chardj0n3s/parse/issues/136)).

## Approach

Changing the core regex fragment from `.+?` to `.*?` makes `parse('{a}{b}', 'xy')` prefer `('', 'xy')` instead of splitting characters across fields, which breaks search/findall and diverges from reference `parse`.

We keep `.+?` in `formatparse-core` and add an **empty-input fast path** in `parse()` only: `parse_pattern` records when the pattern has no non-empty literals and every field is a default unconstrained string (`FieldSpec::is_default_unconstrained_string`). For that case, `match_empty_default_string_parse` builds the same `Result` / `Match` as if each capture were `""`.

## Tests

- `tests/test_bugs.py`: regression for `{}`, `{name}`, `{}{}` on `""`, plus `{a}{b}` on `"xy"` to guard multi-field splitting.
