### PR TITLE
docs: expand extra_types usage guide (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ for result in results:
 
 For more examples and detailed usage, see the [documentation](https://formatparse.readthedocs.io/).
 
+## Custom types (`extra_types`)
+
+Map format-specifier names in your pattern to Python callables with the `@with_pattern` decorator. The type name after the colon in the field (for example `Number` in `{:Number}`) must match a key in the `extra_types` dict.
+
+```python
+from formatparse import parse, with_pattern
+
+@with_pattern(r"\d+")
+def parse_int(text: str) -> int:
+    return int(text)
+
+result = parse("n={:Number}", "n=42", extra_types={"Number": parse_int})
+assert result.fixed[0] == 42
+```
+
+If your regex uses capturing parentheses, set `regex_group_count` on `@with_pattern` so the engine can align groups correctly. Full examples, `search` / `findall` usage, and pitfalls are in the **[Custom types](https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html)** user guide.
+
+**Caching:** `parse`, `search`, `findall`, and `compile` share an internal LRU cache keyed by the pattern string and a fingerprint of `extra_types` (each converter’s `pattern` and `regex_group_count`). Two dicts with the same keys and equivalent converters reuse the same compiled regex; changing a converter’s `pattern` without changing the dict identity can still reuse a stale cache entry—use a fresh dict or restart the process if you change patterns at runtime. See [issue #29](https://github.com/eddiethedean/formatparse/issues/29).
+
+**Pickling:** A pickled `FormatParser` stores only the pattern string. After `pickle.loads`, pass `extra_types` again when calling `parse` / `search` / `findall` if your pattern uses custom types.
+
 ## Performance
 
 formatparse is significantly faster than the original Python `parse` library, with speedups ranging from **3x to 80x** depending on the use case. The Rust backend provides:

--- a/docs/examples/cookbook.rst
+++ b/docs/examples/cookbook.rst
@@ -63,6 +63,23 @@ Extract data from delimited strings:
    >>> result.named['city']
    'NYC'
 
+Custom types (``extra_types``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :func:`with_pattern` and pass converters in ``extra_types`` (see the
+:doc:`../user_guides/custom_types` guide):
+
+.. doctest::
+
+   >>> from formatparse import parse, with_pattern
+   >>> @with_pattern(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
+   ... def parse_email(text):
+   ...     return text.lower()
+   >>> r = parse("Contact {:Email}", "Contact User@Example.COM",
+   ...           extra_types={"Email": parse_email})
+   >>> r.fixed[0]
+   'user@example.com'
+
 Performance Tips
 ----------------
 

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -10,6 +10,12 @@ use std::collections::HashMap;
 #[pyclass(module = "_formatparse")]
 /// Compiled format pattern for parsing strings.
 ///
+/// Construct with :func:`formatparse.compile` (or ``FormatParser(pattern, extra_types=...)`` in Python).
+///
+/// **Custom types:** converters passed as ``extra_types`` at compile time are stored
+/// and merged with any ``extra_types`` passed per call to ``parse`` or ``search``
+/// (per-call keys override stored keys).
+///
 /// **Pickling:** Only the pattern string is serialized. If the parser was built
 /// with ``extra_types``, those converters are **not** restored after unpickling;
 /// call ``compile(pattern, extra_types=...)`` again with the same mapping.
@@ -338,7 +344,10 @@ impl FormatParser {
         }
     }
 
-    /// Parse a string using this compiled pattern
+    /// Parse a string using this compiled pattern.
+    ///
+    /// Merges ``extra_types`` from compile time with any ``extra_types`` passed here
+    /// (call-time wins on duplicate keys).
     #[pyo3(signature = (string, case_sensitive=false, extra_types=None, evaluate_result=true))]
     fn parse(
         &self,
@@ -429,7 +438,10 @@ impl FormatParser {
         }
     }
 
-    /// Search for the pattern in a string
+    /// Search for the pattern in a string.
+    ///
+    /// Merges ``extra_types`` from compile time with any ``extra_types`` passed here
+    /// (call-time wins on duplicate keys), same as :meth:`parse`.
     #[pyo3(signature = (string, case_sensitive=true, extra_types=None, evaluate_result=true))]
     fn search(
         &self,
@@ -446,7 +458,25 @@ impl FormatParser {
             return Err(PyValueError::new_err("Input string contains null byte"));
         }
 
-        self.search_pattern(string, case_sensitive, extra_types, evaluate_result)
+        let merged_extra_types =
+            Python::with_gil(|py| -> PyResult<Option<HashMap<String, PyObject>>> {
+                let mut merged = if let Some(ref stored) = self.stored_extra_types {
+                    stored
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                        .collect()
+                } else {
+                    HashMap::new()
+                };
+                if let Some(ref provided) = extra_types {
+                    for (k, v) in provided {
+                        merged.insert(k.clone(), v.clone_ref(py));
+                    }
+                }
+                Ok(Some(merged))
+            })?;
+
+        self.search_pattern(string, case_sensitive, merged_extra_types, evaluate_result)
     }
 
     /// Pickle support: rebuild with ``compile(pattern)`` only (no ``extra_types``).

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -2,6 +2,11 @@
 Parse strings using a specification based on the Python format() syntax.
 
 This is a Rust-backed implementation of the parse library for better performance.
+
+**Custom types:** pass a mapping as ``extra_types`` from each type name used in the
+pattern (e.g. ``{:Number}`` → key ``\"Number\"``) to a callable, usually decorated
+with :func:`with_pattern`. See :func:`compile` and the `Custom types user guide
+<https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html>`_.
 """
 
 from __future__ import annotations
@@ -60,7 +65,8 @@ class ConverterProtocol(Protocol):
         ...
 
 
-# Type alias for extra_types parameter
+# Type alias: mapping from custom type name (e.g. ``Number`` in ``{:Number}``) to a
+# callable with ``pattern`` and optional ``regex_group_count`` (see :func:`with_pattern`).
 ExtraTypes = Dict[str, ConverterProtocol]
 
 
@@ -111,9 +117,22 @@ def compile(pattern: str, extra_types: Optional[ExtraTypes] = None) -> FormatPar
     not pay full pattern-to-regex compilation on every iteration (see
     `issue #29 <https://github.com/eddiethedean/formatparse/issues/29>`_).
 
+    **Custom types:** keys are the *type names* used after ``:`` in fields (for example
+    ``Number`` in ``{:Number}`` or ``{x:Number}``). Values are callables, usually from
+    :func:`with_pattern`, which attach a ``pattern`` regex fragment and optional
+    ``regex_group_count`` when the regex contains capturing parentheses. See the
+    `Custom types guide <https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html>`_
+    for examples with :func:`search` / :func:`findall` and for ``regex_group_count``.
+
+    The cache fingerprints each name's ``pattern`` and ``regex_group_count``. If you
+    mutate those attributes on a live converter object, reuse the same ``extra_types``
+    dict, and the fingerprint stays unchanged, you can see a stale compiled parser until
+    the process restarts—prefer a fresh dict or new function objects when changing
+    patterns at runtime.
+
     :param pattern: Format specification pattern (e.g., ``"{name}: {age:d}"``)
     :type pattern: str
-    :param extra_types: Optional dictionary of custom type converters
+    :param extra_types: Optional mapping of custom type names to converters (see above)
     :type extra_types: dict, optional
     :returns: FormatParser object that can be used to parse strings
     :rtype: FormatParser
@@ -165,7 +184,11 @@ def parse(
     :type pattern: str
     :param string: String to parse
     :type string: str
-    :param extra_types: Optional dictionary of custom type converters
+    :param extra_types: Optional mapping of custom type names (after ``:`` in the field)
+        to callables, typically from :func:`with_pattern`. Uses the same compiled-parser
+        cache as :func:`compile` (pattern plus per-name ``pattern`` /
+        ``regex_group_count``). See the
+        `Custom types guide <https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html>`_.
     :type extra_types: dict, optional
     :param case_sensitive: Whether matching should be case sensitive (default: False)
     :type case_sensitive: bool
@@ -211,7 +234,8 @@ def search(
     :type pos: int
     :param endpos: End position for search (default: None for end of string)
     :type endpos: int, optional
-    :param extra_types: Optional dictionary of custom type converters
+    :param extra_types: Same semantics as :func:`parse` (custom types / cache); see
+        `Custom types guide <https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html>`_.
     :type extra_types: dict, optional
     :param case_sensitive: Whether matching should be case sensitive (default: True)
     :type case_sensitive: bool
@@ -269,7 +293,10 @@ def findall(
     :type pattern: str
     :param string: String to search
     :type string: str
-    :param extra_types: Optional dictionary of custom type converters
+    :param extra_types: Same semantics as :func:`parse`. When provided, the Rust fast
+        path that returns :class:`Results` is disabled and a Python ``list`` is built
+        instead (see returns below). See the
+        `Custom types guide <https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html>`_.
     :type extra_types: dict, optional
     :param case_sensitive: Whether matching should be case sensitive (default: False)
     :type case_sensitive: bool

--- a/tests/test_formatparser.py
+++ b/tests/test_formatparser.py
@@ -27,11 +27,9 @@ def test_compile_with_extra_types():
     def parse_number(text):
         return int(text)
 
-    # compile() doesn't take extra_types - pass them to parse() instead
-    # Pattern needs to include literal prefix
-    parser = compile("value: {value:Number}")
+    parser = compile("value: {value:Number}", extra_types={"Number": parse_number})
     assert parser is not None
-    result = parser.parse("value: 42", extra_types={"Number": parse_number})
+    result = parser.parse("value: 42")
     assert result is not None
     assert result.named["value"] == 42
 
@@ -90,6 +88,20 @@ def test_parser_parse_evaluate_result_false():
     # Should be a Match object, not ParseResult
     result = match.evaluate_result()
     assert result.named["name"] == "World"
+
+
+def test_parser_search_uses_stored_extra_types():
+    """search() merges compile-time extra_types like parse() (issue #17 / UX)."""
+    from formatparse import with_pattern
+
+    @with_pattern(r"\d+")
+    def parse_number(text):
+        return int(text)
+
+    parser = compile("n={:Number}", extra_types={"Number": parse_number})
+    result = parser.search("prefix n=42 suffix")
+    assert result is not None
+    assert result.fixed[0] == 42
 
 
 def test_parser_search_basic():


### PR DESCRIPTION
## Summary

Closes documentation gap from [#17](https://github.com/eddiethedean/formatparse/issues/17) / [parse#148](https://github.com/r1chardj0n3s/parse/issues/148): `extra_types`, `with_pattern`, cache behavior, and pickling.

## Changes

- **README:** Custom types (`extra_types`) section with minimal example, link to [Custom types](https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html), LRU cache fingerprint note (#29), pickling reminder.
- **`formatparse/__init__.py`:** Module blurb; expanded `compile` / `parse` / `search` / `findall` docs for `extra_types` and RTD link.
- **`FormatParser` (Rust):** Class and method docs; **`search` now merges** compile-time `extra_types` with per-call mapping (same as `parse`), with regression test.
- **`docs/examples/cookbook.rst`:** Short `extra_types` + `with_pattern` doctest linking the user guide.
- **`tests/test_formatparser.py`:** Correct `compile(..., extra_types=...)` example; new test for stored types on `search`.

## Verification

- `cargo clippy -p formatparse-pyo3 --all-targets -- -D warnings`
- `maturin develop --release`
- `python -m sphinx -b html docs docs/_build/html`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/` (553 passed)
