### PR TITLE
feat: add :brace field for literal {...} payload in input (#15)

### DIFF
--- a/docs/user_guides/patterns.rst
+++ b/docs/user_guides/patterns.rst
@@ -58,6 +58,34 @@ Type specifiers control how the matched text is converted. Common types include:
    >>> result.named['active']
    0
 
+Brace-delimited text in the input (``:brace``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``{name:brace}`` when the **source text** contains a literal ``{`` … ``}``
+pair and you want the **inner** text as a string—including when it is empty
+(``{}``). The inner match is **non-greedy**; if literal text in the pattern
+follows the closing ``}``, the regex engine may match a **later** ``}`` so
+the remainder of the string still matches (same rules as a normal regular
+expression). Deeply nested ``{`` … ``}`` inside the payload is not supported
+as a separate MVP (see `#15`).
+
+.. doctest::
+
+   >>> from formatparse import parse
+   >>> line = "v:1 t:CON c:PUT i:cdcb {} [ Observe:0 ]"
+   >>> pat = "v:1 t:CON c:PUT i:cdcb {payload:brace} [ Observe:0 ]"
+   >>> r = parse(pat, line)
+   >>> r.named["payload"]
+   ''
+   >>> line2 = "v:1 t:CON c:PUT i:cdcb {telemetry} [ Observe:0 ]"
+   >>> pat2 = "v:1 t:CON c:PUT i:cdcb {payload:brace} [ Observe:0 ]"
+   >>> parse(pat2, line2).named["payload"]
+   'telemetry'
+
+Pattern literals still use doubled braces ``{{`` and ``}}`` for a single
+literal brace in the *pattern* string; ``:brace`` is only for matching
+brace-wrapped **payload** in the **input**.
+
 Format Specifiers
 -----------------
 

--- a/formatparse-core/src/types/definitions.rs
+++ b/formatparse-core/src/types/definitions.rs
@@ -24,6 +24,8 @@ pub enum FieldType {
     DateTimeTime,        // 'tt' - Time format
     DateTimeSystem,      // 'ts' - Linux system log format
     DateTimeStrftime,    // For %Y-%m-%d style patterns
+    /// Match `{...}` in the input; capture inner text (non-greedy to first `}`). Issue #15 / parse#146.
+    BracedContent,
     Custom(String),
 }
 

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -317,6 +317,10 @@ impl FieldSpec {
                     r".+?".to_string()
                 }
             }
+            FieldType::BracedContent => {
+                // Placeholder: named patterns use special regex in the PyO3 pattern compiler.
+                r".*?".to_string()
+            }
             FieldType::Boolean => {
                 "true|false|True|False|TRUE|FALSE|1|0|yes|no|Yes|No|YES|NO|on|off|On|Off|ON|OFF"
                     .to_string()
@@ -589,6 +593,14 @@ mod tests {
         let pattern = spec.to_regex_pattern(&HashMap::new(), None);
         // Should default to non-whitespace
         assert_eq!(pattern, r"\S+");
+    }
+
+    #[test]
+    fn test_field_spec_braced_content_placeholder_regex() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::BracedContent;
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        assert_eq!(pattern, r".*?");
     }
 
     #[test]

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -155,17 +155,30 @@ pub fn parse_pattern(
                     }
                 }
 
-                // Handle name normalization for regex groups
-                if let Some(ref original_name) = name {
+                // Issue #15 / parse#146: `{name:brace}` — capture text inside `{`…`}` in the input
+                // (non-greedy `.*?`; later pattern literals may force a later `}`). Supports empty `{}`.
+                // Requires a non-numbered name.
+                let group_pattern = if matches!(spec.field_type, FieldType::BracedContent) {
+                    let Some(ref original_name) = name else {
+                        return Err(error::pattern_error(
+                            "The :brace format requires a named field (e.g. {content:brace})",
+                        ));
+                    };
+                    if original_name.chars().all(|c| c.is_ascii_digit()) {
+                        return Err(error::pattern_error(
+                            "The :brace format cannot be used with numbered fields",
+                        ));
+                    }
+                    let normalized =
+                        normalize_field_name(original_name, &mut name_mapping, &normalized_names);
+                    format!("\\{{(?P<{}>.*?)\\}}", normalized)
+                } else if let Some(ref original_name) = name {
                     // Check if field name is numeric (numbered field like {0}, {1}) - these should be positional
                     let is_numeric = original_name.chars().all(|c| c.is_ascii_digit());
 
                     if is_numeric {
                         // Numbered fields are positional (unnamed groups), not named groups
-                        let group_pattern = format!("({})", pattern);
-                        regex_parts.push(group_pattern);
-                        field_names.push(None); // Store as None (positional)
-                        normalized_names.push(None);
+                        format!("({})", pattern)
                     } else {
                         // Normalize name: replace hyphens/dots with underscores, handle collisions
                         let normalized = normalize_field_name(
@@ -173,15 +186,33 @@ pub fn parse_pattern(
                             &mut name_mapping,
                             &normalized_names,
                         );
-                        let group_pattern = format!("(?P<{}>{})", normalized, pattern);
-                        regex_parts.push(group_pattern);
+                        format!("(?P<{}>{})", normalized, pattern)
+                    }
+                } else {
+                    format!("({})", pattern)
+                };
+
+                regex_parts.push(group_pattern);
+
+                // Handle name normalization for regex groups
+                if let Some(ref original_name) = name {
+                    // Check if field name is numeric (numbered field like {0}, {1}) - these should be positional
+                    let is_numeric = original_name.chars().all(|c| c.is_ascii_digit());
+
+                    if is_numeric {
+                        field_names.push(None); // Store as None (positional)
+                        normalized_names.push(None);
+                    } else {
+                        let normalized = normalize_field_name(
+                            original_name,
+                            &mut name_mapping,
+                            &normalized_names,
+                        );
                         field_names.push(Some(original_name.clone())); // Store original
                         normalized_names.push(Some(normalized.clone())); // Store normalized
                         name_mapping.insert(normalized, original_name.clone()); // Map normalized -> original
                     }
                 } else {
-                    let group_pattern = format!("({})", pattern);
-                    regex_parts.push(group_pattern);
                     field_names.push(None);
                     normalized_names.push(None);
                 }
@@ -535,6 +566,8 @@ pub fn parse_format_spec(
             FieldType::DateTimeTime
         } else if type_name == "ts" {
             FieldType::DateTimeSystem
+        } else if type_name == "brace" {
+            FieldType::BracedContent
         } else if type_name.len() > 1 {
             // Multi-character - always custom type
             FieldType::Custom(type_name)

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -231,6 +231,7 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
                 Err(_) => Err(format!("Could not convert '{}' to percentage", value)),
             }
         }
+        FieldType::BracedContent => Ok(RawValue::String(value.to_string())),
         // DateTime types and Custom types need Python, so we'll handle them differently
         _ => {
             // For types that require Python (datetime, custom), we can't convert to raw

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -165,6 +165,7 @@ pub fn convert_value(
             FieldType::DateTimeTime => "tt",
             FieldType::DateTimeSystem => "ts",
             FieldType::DateTimeStrftime => "strftime",
+            FieldType::BracedContent => "brace",
         };
 
         // If there's a custom converter for this type name, use it instead of built-in
@@ -413,6 +414,7 @@ pub fn convert_value(
                 Ok(value.to_object(py))
             }
         }
+        FieldType::BracedContent => Ok(value.to_object(py)),
         FieldType::Custom(_) => {
             // Already handled above
             Ok(value.to_object(py))

--- a/tests/test_brace_delimited.py
+++ b/tests/test_brace_delimited.py
@@ -1,0 +1,59 @@
+"""Brace-delimited payload in the input string (issue #15 / parse#146)."""
+
+import pytest
+
+from formatparse import compile, parse
+
+
+def test_brace_empty_inner():
+    line = "v:1 t:CON c:PUT i:cdcb {} [ Observe:0 ]"
+    pat = "v:1 t:CON c:PUT i:cdcb {payload:brace} [ Observe:0 ]"
+    r = parse(pat, line)
+    assert r is not None
+    assert r.named["payload"] == ""
+
+
+def test_brace_inner_text():
+    line = "v:1 t:CON c:PUT i:cdcb {telemetry} [ Observe:0 ]"
+    pat = "v:1 t:CON c:PUT i:cdcb {payload:brace} [ Observe:0 ]"
+    r = parse(pat, line)
+    assert r is not None
+    assert r.named["payload"] == "telemetry"
+
+
+def test_brace_stops_at_first_close_when_suffix_matches():
+    r = parse("a{x:brace}z", "a{inner}z")
+    assert r is not None
+    assert r.named["x"] == "inner"
+
+
+def test_brace_with_later_braces_backtracks_to_close_before_suffix():
+    # Literal "b" after "}" forces the match to use the "}" that still allows "b" to match.
+    r = parse("a{x:brace}b", "a{in}side}b")
+    assert r is not None
+    assert r.named["x"] == "in}side"
+
+
+def test_brace_requires_name():
+    with pytest.raises(ValueError, match=":brace format requires"):
+        compile("{:brace}")
+
+
+def test_brace_rejects_numbered_field():
+    with pytest.raises(ValueError, match=":brace format cannot"):
+        compile("{0:brace}")
+
+
+def test_brace_search():
+    from formatparse import search
+
+    s = search("x={v:brace}y", "prefix x={hello}y suffix")
+    assert s is not None
+    assert s.named["v"] == "hello"
+
+
+def test_brace_findall():
+    from formatparse import findall
+
+    xs = list(findall("{v:brace}", "{a}{b}"))
+    assert [m.named["v"] for m in xs] == ["a", "b"]


### PR DESCRIPTION
Closes #15. Upstream discussion: https://github.com/r1chardj0n3s/parse/issues/146

## MVP
- New format specifier `:brace` on **named** fields only, e.g. `{payload:brace}`.
- Matches a literal `{` … `}` in the **input** and captures inner text as `str`, including empty `{}`.
- Rejects `{:brace}` and numbered fields like `{0:brace}` at pattern compile time.
- Inner match uses non-greedy `.*?`; if literals follow the closing `}`, the engine may align to a **later** `}` so the rest of the pattern still matches (documented + tested).

## Files
- Core: `FieldType::BracedContent`, placeholder `to_regex_pattern` (real regex built in pattern compiler).
- PyO3: `parse_format_spec` (`brace`), `parse_pattern` emits `\\{(?P<name>.*?)\\}`, conversion/raw match as string.
- Docs: `docs/user_guides/patterns.rst`; tests: `tests/test_brace_delimited.py`.

Verified: `cargo fmt`, `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets -- -D warnings`, `cargo test -p formatparse-core`, `maturin develop --release`, `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/`.