### PR TITLE
chore: remove clippy manual_strip allow (#44)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(deprecated)] // PyO3: ToPyObject::to_object pending migration to IntoPyObject
 #![allow(dead_code)] // Public / reserved helpers (e.g. error constructors, datetime parsers)
 #![allow(clippy::if_same_then_else)] // Parser mirrors symmetric branches intentionally
-#![allow(clippy::manual_strip)] // Signed numeric parsing keeps explicit slice paths
 #![allow(clippy::too_many_arguments)] // PyO3 entry points and format spec plumbing
 #![allow(clippy::type_complexity)] // PyO3-heavy signatures
 #![allow(clippy::wrong_self_convention)] // `to_py_object` mirrors Python naming

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -126,10 +126,10 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
             }
 
             let trimmed = trimmed_str.as_str();
-            let (is_negative, num_str) = if trimmed.starts_with('-') {
-                (true, &trimmed[1..])
-            } else if trimmed.starts_with('+') {
-                (false, &trimmed[1..])
+            let (is_negative, num_str) = if let Some(rest) = trimmed.strip_prefix('-') {
+                (true, rest)
+            } else if let Some(rest) = trimmed.strip_prefix('+') {
+                (false, rest)
             } else {
                 (false, trimmed)
             };

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -272,10 +272,10 @@ pub fn convert_value(
 
             let trimmed = trimmed_str.as_str();
             // Handle negative numbers with prefixes (e.g., "-0o10")
-            let (is_negative, num_str) = if trimmed.starts_with('-') {
-                (true, &trimmed[1..])
-            } else if trimmed.starts_with('+') {
-                (false, &trimmed[1..])
+            let (is_negative, num_str) = if let Some(rest) = trimmed.strip_prefix('-') {
+                (true, rest)
+            } else if let Some(rest) = trimmed.strip_prefix('+') {
+                (false, rest)
             } else {
                 (false, trimmed)
             };


### PR DESCRIPTION
Closes #44.

## What changed
- Removed `#![allow(clippy::manual_strip)]` from [formatparse-pyo3/src/lib.rs](formatparse-pyo3/src/lib.rs).
- Replaced `starts_with('±') + &s[1..]` with `strip_prefix('-')` / `strip_prefix('+')` for integer sign handling in [formatparse-pyo3/src/types/conversion.rs](formatparse-pyo3/src/types/conversion.rs) and [formatparse-pyo3/src/parser/raw_match.rs](formatparse-pyo3/src/parser/raw_match.rs).

## Clippy
With the allow removed, `cargo clippy -p formatparse-pyo3 --all-targets -- -D warnings` reported only these four `manual_strip` sites; all addressed. No intended behavior change.

## Verification
- `cargo fmt --all`
- `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets -- -D warnings`
- `cargo test -p formatparse-core`
- `maturin develop --release` + `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/` (563 passed, 5 skipped).