### PR TITLE
chore: resolve dead_code in formatparse-pyo3 (#46)

### DIFF
--- a/formatparse-pyo3/src/datetime/common.rs
+++ b/formatparse-pyo3/src/datetime/common.rs
@@ -211,12 +211,8 @@ pub fn parse_microseconds(micros_str: &str) -> Result<u32, PyErr> {
 
 /// Extract microseconds from a capture group, handling padding
 pub fn extract_microseconds(cap: Option<regex::Match>) -> u32 {
-    cap.map(|m| {
-        let s = m.as_str();
-        let padded = format!("{:0<6}", s);
-        padded[..6.min(padded.len())].parse().unwrap_or(0)
-    })
-    .unwrap_or(0)
+    cap.map(|m| parse_microseconds(m.as_str()).unwrap_or(0))
+        .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/formatparse-pyo3/src/datetime/strftime.rs
+++ b/formatparse-pyo3/src/datetime/strftime.rs
@@ -1,4 +1,5 @@
 use crate::datetime::common::get_month_map;
+use crate::error::regex_error;
 use pyo3::prelude::*;
 use regex::Regex;
 
@@ -104,9 +105,7 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
     }
 
     let full_regex = format!("^{}$", regex_parts.join(""));
-    let re = Regex::new(&full_regex).map_err(|e| {
-        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid regex: {}", e))
-    })?;
+    let re = Regex::new(&full_regex).map_err(|e| regex_error(&e.to_string()))?;
 
     let captures = re.captures(value).ok_or_else(|| {
         PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(

--- a/formatparse-pyo3/src/error.rs
+++ b/formatparse-pyo3/src/error.rs
@@ -9,9 +9,7 @@ pub fn core_error_to_py_err(err: FormatParseError) -> PyErr {
         FormatParseError::PatternError(msg) => {
             PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Pattern error: {}", msg))
         }
-        FormatParseError::RegexError(msg) => PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            format!("Invalid regex pattern: {}", msg),
-        ),
+        FormatParseError::RegexError(msg) => errors::regex_error(msg.as_str()),
         FormatParseError::ConversionError(value, target_type) => {
             PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
                 "Invalid {}: {}",
@@ -111,12 +109,6 @@ pub mod errors {
             "Missing required field: {}",
             field
         ))
-    }
-
-    /// Create a validation error (used to signal invalid alignment+precision combinations)
-    /// This error should be caught and converted to None in matching code
-    pub fn validation_error(msg: &str) -> PyErr {
-        PyErr::new::<pyo3::exceptions::PyValueError, _>(msg.to_string())
     }
 }
 

--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -3,7 +3,6 @@
 //! formatparse-pyo3 provides Python bindings for the formatparse-core library.
 
 #![allow(deprecated)] // PyO3: ToPyObject::to_object pending migration to IntoPyObject
-#![allow(dead_code)] // Public / reserved helpers (e.g. error constructors, datetime parsers)
 #![allow(clippy::if_same_then_else)] // Parser mirrors symmetric branches intentionally
 #![allow(clippy::too_many_arguments)] // PyO3 entry points and format spec plumbing
 #![allow(clippy::type_complexity)] // PyO3-heavy signatures

--- a/formatparse-pyo3/src/match_rs.rs
+++ b/formatparse-pyo3/src/match_rs.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 /// Match object that stores raw regex captures without type conversion
 #[pyclass]
 pub struct Match {
+    #[pyo3(get)]
     pattern: String,
     field_specs: Vec<FieldSpec>,
     field_names: Vec<Option<String>>,

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -320,9 +320,8 @@ impl FormatParser {
             None => {
                 // Create a dummy instance for unpickling - __setstate__ will initialize it properly
                 // We need to create a valid but minimal instance
-                let empty_regex = Regex::new("^$").map_err(|e| {
-                    PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid regex: {}", e))
-                })?;
+                let empty_regex =
+                    Regex::new("^$").map_err(|e| crate::error::regex_error(&e.to_string()))?;
                 Ok(Self {
                     pattern: String::new(),
                     regex: empty_regex.clone(),


### PR DESCRIPTION
Closes #46.

## Changes
- Removed crate-level `#![allow(dead_code)]` from [formatparse-pyo3/src/lib.rs](formatparse-pyo3/src/lib.rs); `cargo check -p formatparse-pyo3` is warning-clean.
- **`parse_microseconds`**: [extract_microseconds](formatparse-pyo3/src/datetime/common.rs) now delegates to it (single implementation for padding/truncation).
- **`regex_error`**: used from [core_error_to_py_err](formatparse-pyo3/src/error.rs) for `RegexError`, [strftime fallback](formatparse-pyo3/src/datetime/strftime.rs) `Regex::new`, and [FormatParser](formatparse-pyo3/src/parser/format_parser.rs) unpickle placeholder regex. Strftime compile failures now use the same `Invalid regex pattern: …` prefix as other paths (was `Invalid regex: …`).
- **`validation_error`**: removed (unused; no in-repo callers).
- **`Match.pattern`**: exposed to Python with `#[pyo3(get)]` so the stored pattern is a read-only attribute (parity with holding the field for debugging / future API).

## Verification
`cargo fmt`, `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets -- -D warnings`, `cargo test -p formatparse-core`, `maturin develop --release`, `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/` (563 passed, 5 skipped).