### PR TITLE
chore: remove wrong_self_convention crate allow (#50)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::if_same_then_else)] // Parser mirrors symmetric branches intentionally
 #![allow(clippy::too_many_arguments)] // PyO3 entry points and format spec plumbing
 #![allow(clippy::type_complexity)] // PyO3-heavy signatures
-#![allow(clippy::wrong_self_convention)] // `to_py_object` mirrors Python naming
 
 use lru::LruCache;
 use once_cell::sync::Lazy;

--- a/formatparse-pyo3/src/results.rs
+++ b/formatparse-pyo3/src/results.rs
@@ -109,7 +109,9 @@ impl Results {
         })
     }
 
-    /// Convert to list (forces conversion of all items)
+    /// Convert to list (forces conversion of all items).
+    /// Name matches the `parse` library Python API (`results.to_list()`).
+    #[allow(clippy::wrong_self_convention)] // `to_*` + `&mut self` is required by pymethods / API parity
     fn to_list(&mut self, py: Python) -> PyResult<PyObject> {
         self.convert_all(py)
     }


### PR DESCRIPTION
Closes #50.

## Summary
- Removed crate-level `#![allow(clippy::wrong_self_convention)]` from `formatparse-pyo3/src/lib.rs`.
- `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets -- -D warnings` reported a single hit: `Results::to_list` in `results.rs` (PyO3 `#[pymethods]`, `&mut self` for caching). Renaming would break the Python API (`results.to_list()` parity with `parse`).
- Added a **method-scoped** `#[allow(clippy::wrong_self_convention)]` with a short doc + inline rationale on that method only.

## Verification
- `cargo fmt --all`
- `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets -- -D warnings`
- `cargo test -p formatparse-core`
- `maturin develop --release`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/`