### PR TITLE
chore: remove if_same_then_else crate allow (#49)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -3,7 +3,6 @@
 //! formatparse-pyo3 provides Python bindings for the formatparse-core library.
 
 #![allow(deprecated)] // PyO3: ToPyObject::to_object pending migration to IntoPyObject
-#![allow(clippy::if_same_then_else)] // Parser mirrors symmetric branches intentionally
 #![allow(clippy::too_many_arguments)] // PyO3 entry points and format spec plumbing
 #![allow(clippy::type_complexity)] // PyO3-heavy signatures
 

--- a/formatparse-pyo3/src/parser/matching.rs
+++ b/formatparse-pyo3/src/parser/matching.rs
@@ -149,7 +149,7 @@ pub fn extract_capture<'a>(
 /// processing that field, matching the main match loops' bookkeeping.
 fn per_field_capture_geometry(
     field_specs: &[FieldSpec],
-    normalized_names: &[Option<String>],
+    _normalized_names: &[Option<String>],
     py: Python<'_>,
     custom_converters: &HashMap<String, PyObject>,
     precomputed_pattern_groups: Option<&[usize]>,
@@ -166,11 +166,7 @@ fn per_field_capture_geometry(
             0
         };
         out.push((aci, go));
-        if normalized_names.get(i).and_then(|n| n.as_ref()).is_none() {
-            aci += 1;
-        } else {
-            aci += 1;
-        }
+        aci += 1;
         if spec.alignment.is_some() {
             go += 1;
         }
@@ -315,11 +311,7 @@ pub fn match_with_captures_raw(
             group_offset,
         );
 
-        if normalized_names.get(i).and_then(|n| n.as_ref()).is_none() {
-            actual_capture_index += 1;
-        } else {
-            actual_capture_index += 1;
-        }
+        actual_capture_index += 1;
 
         if let Some(cap) = cap {
             let value_str = cap.as_str();

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -107,19 +107,8 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
                 if trimmed_str.starts_with('-') || trimmed_str.starts_with('+') {
                     let sign_char = &trimmed_str[..1];
                     let rest = &trimmed_str[1..];
-                    if rest.starts_with("0x")
-                        || rest.starts_with("0X")
-                        || rest.starts_with("0o")
-                        || rest.starts_with("0O")
-                        || rest.starts_with("0b")
-                        || rest.starts_with("0B")
-                    {
-                        let rest_trimmed = rest.trim_start_matches(fill_ch);
-                        trimmed_str = format!("{}{}", sign_char, rest_trimmed);
-                    } else {
-                        let rest_trimmed = rest.trim_start_matches(fill_ch);
-                        trimmed_str = format!("{}{}", sign_char, rest_trimmed);
-                    }
+                    let rest_trimmed = rest.trim_start_matches(fill_ch);
+                    trimmed_str = format!("{}{}", sign_char, rest_trimmed);
                 } else {
                     trimmed_str = trimmed_str.trim_start_matches(fill_ch).to_string();
                 }


### PR DESCRIPTION
Closes #49.

## Summary
- Removed crate-level `#![allow(clippy::if_same_then_else)]` from `formatparse-pyo3/src/lib.rs`.
- Resolved **three** Clippy hits by collapsing dead symmetric branches (no new scoped allows):
  - `per_field_capture_geometry`: both branches only incremented `aci` → single `aci += 1`.
  - `match_with_captures_raw`: same for `actual_capture_index`.
  - Integer `FieldType::Integer` path in `raw_match.rs`: sign + `=` fill stripping used the same logic for radix-prefixed and non-prefixed `rest` → one block.
- `normalized_names` in `per_field_capture_geometry` is now `_normalized_names` (still passed from callers for a stable signature; the old if did not use it).

## Verification
- `cargo fmt --all`
- `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets -- -D warnings`
- `cargo test -p formatparse-core`
- `maturin develop --release`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/`