### PR TITLE
chore: remove too_many_arguments crate allow (#47)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -3,7 +3,6 @@
 //! formatparse-pyo3 provides Python bindings for the formatparse-core library.
 
 #![allow(deprecated)] // PyO3: ToPyObject::to_object pending migration to IntoPyObject
-#![allow(clippy::too_many_arguments)] // PyO3 entry points and format spec plumbing
 #![allow(clippy::type_complexity)] // PyO3-heavy signatures
 
 use lru::LruCache;
@@ -316,11 +315,13 @@ fn findall(
                 &captures,
                 string,
                 match_start,
-                &parser.field_specs,
-                &parser.field_names,
-                &parser.normalized_names,
-                &parser.custom_type_groups,
-                &parser.has_nested_dict_fields,
+                &crate::parser::matching::FieldCaptureSlices {
+                    field_specs: &parser.field_specs,
+                    field_names: &parser.field_names,
+                    normalized_names: &parser.normalized_names,
+                    custom_type_groups: &parser.custom_type_groups,
+                    has_nested_dict_fields: &parser.has_nested_dict_fields,
+                },
             ) {
                 raw_results.push(raw_data);
                 last_end = match_end;
@@ -365,17 +366,19 @@ fn findall(
 
             if let Some(result) = crate::parser::matching::match_with_captures(
                 &captures,
-                string,
-                match_start,
-                &parser.pattern,
-                &parser.field_specs,
-                &parser.field_names,
-                &parser.normalized_names,
-                &parser.custom_type_groups,
-                &parser.has_nested_dict_fields,
-                py,
-                extra_types_ref,
-                evaluate_result,
+                &crate::parser::matching::CapturedMatchContext {
+                    pattern: &parser.pattern,
+                    fields: crate::parser::matching::FieldCaptureSlices {
+                        field_specs: &parser.field_specs,
+                        field_names: &parser.field_names,
+                        normalized_names: &parser.normalized_names,
+                        custom_type_groups: &parser.custom_type_groups,
+                        has_nested_dict_fields: &parser.has_nested_dict_fields,
+                    },
+                    py,
+                    custom_converters: extra_types_ref,
+                    evaluate_result,
+                },
             )? {
                 results.push(result);
                 last_end = match_end;

--- a/formatparse-pyo3/src/match_rs.rs
+++ b/formatparse-pyo3/src/match_rs.rs
@@ -4,6 +4,18 @@ use crate::types::FieldSpec;
 use pyo3::prelude::*;
 use std::collections::HashMap;
 
+/// Owned components for constructing a [`Match`].
+pub struct MatchInit {
+    pub pattern: String,
+    pub field_specs: Vec<FieldSpec>,
+    pub field_names: Vec<Option<String>>,
+    pub normalized_names: Vec<Option<String>>,
+    pub captures: Vec<Option<String>>,
+    pub named_captures: HashMap<String, String>,
+    pub span: (usize, usize),
+    pub field_spans: HashMap<String, (usize, usize)>,
+}
+
 /// Match object that stores raw regex captures without type conversion
 #[pyclass]
 pub struct Match {
@@ -92,25 +104,16 @@ impl Match {
 }
 
 impl Match {
-    pub fn new(
-        pattern: String,
-        field_specs: Vec<FieldSpec>,
-        field_names: Vec<Option<String>>,
-        normalized_names: Vec<Option<String>>,
-        captures: Vec<Option<String>>,
-        named_captures: HashMap<String, String>,
-        span: (usize, usize),
-        field_spans: HashMap<String, (usize, usize)>,
-    ) -> Self {
+    pub fn new(init: MatchInit) -> Self {
         Self {
-            pattern,
-            field_specs,
-            field_names,
-            normalized_names,
-            captures,
-            named_captures,
-            span,
-            field_spans,
+            pattern: init.pattern,
+            field_specs: init.field_specs,
+            field_names: init.field_names,
+            normalized_names: init.normalized_names,
+            captures: init.captures,
+            named_captures: init.named_captures,
+            span: init.span,
+            field_spans: init.field_spans,
         }
     }
 }

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -184,14 +184,16 @@ impl FormatParser {
                 };
                 return crate::parser::matching::match_with_regex(
                     search_regex,
-                    string,
-                    &self.pattern,
-                    &self.field_specs,
-                    &self.field_names,
-                    &self.normalized_names,
-                    py,
-                    extra_types_ref,
-                    evaluate_result,
+                    &crate::parser::matching::RegexMatchContext {
+                        string,
+                        pattern: &self.pattern,
+                        field_specs: &self.field_specs,
+                        field_names: &self.field_names,
+                        normalized_names: &self.normalized_names,
+                        py,
+                        custom_converters: extra_types_ref,
+                        evaluate_result,
+                    },
                 );
             }
             Ok(None)
@@ -238,14 +240,16 @@ impl FormatParser {
 
             crate::parser::matching::match_with_regex(
                 regex,
-                string,
-                &self.pattern,
-                &self.field_specs,
-                &self.field_names,
-                &self.normalized_names,
-                py,
-                extra_types_ref,
-                evaluate_result,
+                &crate::parser::matching::RegexMatchContext {
+                    string,
+                    pattern: &self.pattern,
+                    field_specs: &self.field_specs,
+                    field_names: &self.field_names,
+                    normalized_names: &self.normalized_names,
+                    py,
+                    custom_converters: extra_types_ref,
+                    evaluate_result,
+                },
             )
         })
     }

--- a/formatparse-pyo3/src/parser/matching.rs
+++ b/formatparse-pyo3/src/parser/matching.rs
@@ -1,5 +1,5 @@
 use crate::error;
-use crate::match_rs::Match;
+use crate::match_rs::{Match, MatchInit};
 use crate::parser::raw_match::{RawMatchData, RawValue};
 use crate::result::ParseResult;
 use formatparse_core::{count_capturing_groups, FieldSpec, FieldType};
@@ -7,6 +7,36 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use regex::{Captures, Regex};
 use std::collections::HashMap;
+
+/// Precomputed field metadata slices passed into capture-based match helpers.
+pub struct FieldCaptureSlices<'a> {
+    pub field_specs: &'a [FieldSpec],
+    pub field_names: &'a [Option<String>],
+    pub normalized_names: &'a [Option<String>],
+    pub custom_type_groups: &'a [usize],
+    pub has_nested_dict_fields: &'a [bool],
+}
+
+/// Pattern, field layout, and Python conversion context for [`match_with_captures`].
+pub struct CapturedMatchContext<'a> {
+    pub pattern: &'a str,
+    pub fields: FieldCaptureSlices<'a>,
+    pub py: Python<'a>,
+    pub custom_converters: &'a HashMap<String, PyObject>,
+    pub evaluate_result: bool,
+}
+
+/// Inputs to [`match_with_regex`] beyond the compiled `Regex`.
+pub struct RegexMatchContext<'a> {
+    pub string: &'a str,
+    pub pattern: &'a str,
+    pub field_specs: &'a [FieldSpec],
+    pub field_names: &'a [Option<String>],
+    pub normalized_names: &'a [Option<String>],
+    pub py: Python<'a>,
+    pub custom_converters: &'a HashMap<String, PyObject>,
+    pub evaluate_result: bool,
+}
 
 /// Get a value from a nested dict structure in the named HashMap
 /// Returns None if the path doesn't exist or any intermediate value is not a dict
@@ -282,12 +312,14 @@ pub fn match_with_captures_raw(
     captures: &Captures,
     _string: &str,
     _match_start: usize,
-    field_specs: &[FieldSpec],
-    field_names: &[Option<String>],
-    normalized_names: &[Option<String>],
-    custom_type_groups: &[usize],
-    has_nested_dict_fields: &[bool],
+    fields: &FieldCaptureSlices<'_>,
 ) -> Result<Option<RawMatchData>, String> {
+    let field_specs = fields.field_specs;
+    let field_names = fields.field_names;
+    let normalized_names = fields.normalized_names;
+    let custom_type_groups = fields.custom_type_groups;
+    let has_nested_dict_fields = fields.has_nested_dict_fields;
+
     let full_match = captures.get(0).unwrap();
     let start = full_match.start();
     let end = full_match.end();
@@ -378,18 +410,18 @@ fn values_equal(a: &RawValue, b: &RawValue) -> bool {
 /// Note: captures are from the full string, so positions are already absolute
 pub fn match_with_captures(
     captures: &Captures,
-    _string: &str,
-    _match_start: usize,
-    pattern: &str,
-    field_specs: &[FieldSpec],
-    field_names: &[Option<String>],
-    normalized_names: &[Option<String>],
-    custom_type_groups: &[usize], // Pre-computed pattern_groups per field
-    has_nested_dict_fields: &[bool], // Pre-computed flags: does field name contain '['?
-    py: Python,
-    custom_converters: &HashMap<String, PyObject>,
-    evaluate_result: bool,
+    ctx: &CapturedMatchContext<'_>,
 ) -> PyResult<Option<PyObject>> {
+    let field_specs = ctx.fields.field_specs;
+    let field_names = ctx.fields.field_names;
+    let normalized_names = ctx.fields.normalized_names;
+    let custom_type_groups = ctx.fields.custom_type_groups;
+    let has_nested_dict_fields = ctx.fields.has_nested_dict_fields;
+    let pattern = ctx.pattern;
+    let py = ctx.py;
+    let custom_converters = ctx.custom_converters;
+    let evaluate_result = ctx.evaluate_result;
+
     let full_match = captures.get(0).unwrap();
     let start = full_match.start(); // Already absolute position in full string
     let end = full_match.end(); // Already absolute position in full string
@@ -618,32 +650,31 @@ pub fn match_with_captures(
         // Create Match object with raw captures
         // Note: pattern is static, but Match needs owned String - this is acceptable
         // as Match objects are only created when evaluate_result=False (less common)
-        let match_obj = Match::new(
-            pattern.to_string(),
-            field_specs.to_vec(),
-            field_names.to_vec(),
-            normalized_names.to_vec(),
-            captures_vec,
+        let match_obj = Match::new(MatchInit {
+            pattern: pattern.to_string(),
+            field_specs: field_specs.to_vec(),
+            field_names: field_names.to_vec(),
+            normalized_names: normalized_names.to_vec(),
+            captures: captures_vec,
             named_captures,
-            (start, end),
+            span: (start, end),
             field_spans,
-        );
+        });
         Ok(Some(Py::new(py, match_obj)?.to_object(py)))
     }
 }
 
 /// Match a regex against a string and extract results
-pub fn match_with_regex(
-    regex: &Regex,
-    string: &str,
-    pattern: &str,
-    field_specs: &[FieldSpec],
-    field_names: &[Option<String>],
-    normalized_names: &[Option<String>],
-    py: Python,
-    custom_converters: &HashMap<String, PyObject>,
-    evaluate_result: bool,
-) -> PyResult<Option<PyObject>> {
+pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<Option<PyObject>> {
+    let string = ctx.string;
+    let pattern = ctx.pattern;
+    let field_specs = ctx.field_specs;
+    let field_names = ctx.field_names;
+    let normalized_names = ctx.normalized_names;
+    let py = ctx.py;
+    let custom_converters = ctx.custom_converters;
+    let evaluate_result = ctx.evaluate_result;
+
     if let Some(captures) = regex.captures(string) {
         // Pre-allocate with capacity based on expected field count
         let field_count = field_specs.len();
@@ -900,16 +931,16 @@ pub fn match_with_regex(
             Ok(Some(Py::new(py, parse_result)?.to_object(py)))
         } else {
             // Create Match object with raw captures
-            let match_obj = Match::new(
-                pattern.to_string(),
-                field_specs.to_vec(),
-                field_names.to_vec(),
-                normalized_names.to_vec(),
-                captures_vec,
+            let match_obj = Match::new(MatchInit {
+                pattern: pattern.to_string(),
+                field_specs: field_specs.to_vec(),
+                field_names: field_names.to_vec(),
+                normalized_names: normalized_names.to_vec(),
+                captures: captures_vec,
                 named_captures,
-                (start, end),
+                span: (start, end),
                 field_spans,
-            );
+            });
             // Use Py::new_bound for better performance
             // Py::new() is already optimized when GIL is held
             Ok(Some(Py::new(py, match_obj)?.to_object(py)))
@@ -1019,16 +1050,16 @@ pub fn match_empty_default_string_parse(
         let parse_result = ParseResult::new_with_spans(fixed, named, (start, end), field_spans);
         Ok(Some(Py::new(py, parse_result)?.to_object(py)))
     } else {
-        let match_obj = Match::new(
-            pattern.to_string(),
-            field_specs.to_vec(),
-            field_names.to_vec(),
-            normalized_names.to_vec(),
-            captures_vec,
+        let match_obj = Match::new(MatchInit {
+            pattern: pattern.to_string(),
+            field_specs: field_specs.to_vec(),
+            field_names: field_names.to_vec(),
+            normalized_names: normalized_names.to_vec(),
+            captures: captures_vec,
             named_captures,
-            (start, end),
+            span: (start, end),
             field_spans,
-        );
+        });
         Ok(Some(Py::new(py, match_obj)?.to_object(py)))
     }
 }


### PR DESCRIPTION
Closes #47.

## Summary
- Removed crate-level `#![allow(clippy::too_many_arguments)]` from `formatparse-pyo3/src/lib.rs`.
- **Clippy** reported 4 sites (limit 7): `Match::new`, `match_with_captures_raw`, `match_with_captures`, `match_with_regex`.
- Introduced small context types in `parser/matching.rs`:
  - `FieldCaptureSlices` — field specs, names, normalized names, custom group counts, nested-dict flags (shared by raw + captured paths).
  - `CapturedMatchContext` — pattern, `FieldCaptureSlices`, `py`, `custom_converters`, `evaluate_result` for `match_with_captures`.
  - `RegexMatchContext` — string, pattern, field slices, py, converters, `evaluate_result` for `match_with_regex`.
- `Match::new` now takes `MatchInit` in `match_rs.rs` (single argument).
- **No** function-scoped `too_many_arguments` allows added.

## Verification
- `cargo fmt --all`
- `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets -- -D warnings`
- `cargo test -p formatparse-core`
- `maturin develop --release`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/` (564 passed)