### PR TITLE
chore: remove type_complexity crate allow (#48)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -3,7 +3,6 @@
 //! formatparse-pyo3 provides Python bindings for the formatparse-core library.
 
 #![allow(deprecated)] // PyO3: ToPyObject::to_object pending migration to IntoPyObject
-#![allow(clippy::type_complexity)] // PyO3-heavy signatures
 
 use lru::LruCache;
 use once_cell::sync::Lazy;

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -4,12 +4,10 @@ use pyo3::prelude::*;
 use regex;
 use std::collections::HashMap;
 
-/// Parse a format pattern string into regex parts, field specs, and names
-pub fn parse_pattern(
-    pattern: &str,
-    extra_types: Option<&HashMap<String, PyObject>>,
-    custom_patterns: &HashMap<String, String>,
-) -> PyResult<(
+/// Result tuple from [`parse_pattern`]: compiled pattern string, search regex string, field
+/// specs, original and normalized field names, normalized-to-original name map, and whether
+/// `""` may match when every field is a default unconstrained string.
+pub type ParsedPatternParts = (
     String,
     String,
     Vec<FieldSpec>,
@@ -17,7 +15,14 @@ pub fn parse_pattern(
     Vec<Option<String>>,
     HashMap<String, String>,
     bool,
-)> {
+);
+
+/// Parse a format pattern string into regex parts, field specs, and names
+pub fn parse_pattern(
+    pattern: &str,
+    extra_types: Option<&HashMap<String, PyObject>>,
+    custom_patterns: &HashMap<String, String>,
+) -> PyResult<ParsedPatternParts> {
     // Pre-allocate with estimated capacity based on pattern length
     let estimated_fields = pattern.matches('{').count();
     let mut regex_parts = Vec::with_capacity(estimated_fields * 2);


### PR DESCRIPTION
Closes #48.

## Summary
- Removed crate-level `#![allow(clippy::type_complexity)]` from `formatparse-pyo3/src/lib.rs`.
- **Clippy** (`-p formatparse-pyo3 --all-targets --all-features -- -D warnings`) reported one hit: `parse_pattern` return type in `parser/pattern.rs`.
- Added public type alias `ParsedPatternParts` for that tuple; **no** scoped `type_complexity` allows.

## Verification
- `cargo fmt --all`
- `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets --all-features -- -D warnings`
- `cargo test -p formatparse-core`
- `maturin develop --release`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/` (564 passed)