### PR TITLE
chore: migrate off deprecated ToPyObject::to_object (#45)

### DIFF
--- a/formatparse-pyo3/src/datetime/common.rs
+++ b/formatparse-pyo3/src/datetime/common.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 use std::collections::HashMap;
 
@@ -76,7 +77,7 @@ pub fn create_fixed_tz(py: Python, offset_minutes: i32, name: &str) -> PyResult<
     let fixed_tz_module = py.import("formatparse")?;
     let fixed_tz_class = fixed_tz_module.getattr("FixedTzOffset")?;
     let tz = fixed_tz_class.call1((offset_minutes, name.to_string()))?;
-    Ok(tz.to_object(py))
+    tz.into_py_any(py)
 }
 
 /// Parse timezone string into FixedTzOffset

--- a/formatparse-pyo3/src/datetime/ctime.rs
+++ b/formatparse-pyo3/src/datetime/ctime.rs
@@ -1,6 +1,7 @@
 use crate::datetime::common::get_abbreviated_month_map;
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 // Cached regex pattern for ctime datetime parsing
@@ -61,7 +62,7 @@ pub fn parse_ctime_datetime(py: Python, value: &str) -> PyResult<PyObject> {
 
             let dt =
                 datetime_class.call1((year, month, day, hour, minute, second, 0, py.None()))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 

--- a/formatparse-pyo3/src/datetime/fixed_tz.rs
+++ b/formatparse-pyo3/src/datetime/fixed_tz.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 
 /// Fixed timezone offset for datetime parsing
 #[pyclass]
@@ -62,7 +63,7 @@ impl FixedTzOffset {
         let timedelta_class = datetime_module.getattr("timedelta")?;
         // timedelta(seconds=offset_seconds)
         let delta = timedelta_class.call1((0, 0, self.offset_seconds))?;
-        Ok(delta.to_object(py))
+        delta.into_py_any(py)
     }
 
     /// tzinfo.dst() - returns None (no DST)

--- a/formatparse-pyo3/src/datetime/global.rs
+++ b/formatparse-pyo3/src/datetime/global.rs
@@ -1,6 +1,7 @@
 use crate::datetime::common::{get_month_map, parse_timezone, RE_TZ_IN_STRING};
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 // Cached regex patterns for global datetime parsing
@@ -54,7 +55,7 @@ pub fn parse_global_datetime(py: Python, value: &str) -> PyResult<PyObject> {
                     let (h, m, s) = parse_time_with_ampm(time_only)?;
                     let tzinfo = parse_tz(tz_str)?;
                     let dt = datetime_class.call1((year, month, day, h, m, s, 0, tzinfo))?;
-                    return Ok(dt.to_object(py));
+                    return dt.into_py_any(py);
                 } else {
                     parse_time_with_ampm(time_str)?
                 }
@@ -64,7 +65,7 @@ pub fn parse_global_datetime(py: Python, value: &str) -> PyResult<PyObject> {
 
             let dt =
                 datetime_class.call1((year, month, day, hour, minute, second, 0, py.None()))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 
@@ -106,7 +107,7 @@ pub fn parse_global_datetime(py: Python, value: &str) -> PyResult<PyObject> {
             };
 
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 

--- a/formatparse-pyo3/src/datetime/http.rs
+++ b/formatparse-pyo3/src/datetime/http.rs
@@ -1,6 +1,7 @@
 use crate::datetime::common::{create_fixed_tz, get_abbreviated_month_map};
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 // Cached regex pattern for HTTP datetime parsing
@@ -76,7 +77,7 @@ pub fn parse_http_datetime(py: Python, value: &str) -> PyResult<PyObject> {
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
 
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 

--- a/formatparse-pyo3/src/datetime/iso.rs
+++ b/formatparse-pyo3/src/datetime/iso.rs
@@ -1,6 +1,7 @@
 use crate::datetime::common::{create_fixed_tz, extract_microseconds};
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 // Cached regex patterns for ISO 8601 datetime parsing
@@ -48,7 +49,7 @@ pub fn parse_iso_datetime(py: Python, value: &str) -> PyResult<PyObject> {
                 .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day"))?;
             // Return datetime with time 00:00:00
             let dt = datetime_class.call1((year, month, day, 0, 0, 0, 0, py.None()))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 
@@ -105,7 +106,7 @@ pub fn parse_iso_datetime(py: Python, value: &str) -> PyResult<PyObject> {
                 microsecond,
                 tzinfo,
             ))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 
@@ -177,7 +178,7 @@ pub fn parse_iso_datetime(py: Python, value: &str) -> PyResult<PyObject> {
                 microsecond,
                 tzinfo,
             ))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 
@@ -249,7 +250,7 @@ pub fn parse_iso_datetime(py: Python, value: &str) -> PyResult<PyObject> {
                 microsecond,
                 tzinfo,
             ))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 
@@ -304,7 +305,7 @@ pub fn parse_iso_datetime(py: Python, value: &str) -> PyResult<PyObject> {
                 microsecond,
                 py.None(),
             ))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 

--- a/formatparse-pyo3/src/datetime/rfc2822.rs
+++ b/formatparse-pyo3/src/datetime/rfc2822.rs
@@ -1,6 +1,7 @@
 use crate::datetime::common::{create_fixed_tz, get_abbreviated_month_map};
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 // Cached regex patterns for RFC2822 datetime parsing
@@ -88,7 +89,7 @@ pub fn parse_rfc2822_datetime(py: Python, value: &str) -> PyResult<PyObject> {
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
 
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 
@@ -155,7 +156,7 @@ pub fn parse_rfc2822_datetime(py: Python, value: &str) -> PyResult<PyObject> {
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
 
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 
@@ -222,7 +223,7 @@ pub fn parse_rfc2822_datetime(py: Python, value: &str) -> PyResult<PyObject> {
             let tzinfo = create_fixed_tz(py, offset_minutes, "")?;
 
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 

--- a/formatparse-pyo3/src/datetime/strftime.rs
+++ b/formatparse-pyo3/src/datetime/strftime.rs
@@ -1,6 +1,7 @@
 use crate::datetime::common::get_month_map;
 use crate::error::regex_error;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 /// Check if a PyErr is a regex group redefinition error from strptime
@@ -196,14 +197,14 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
             second.unwrap_or(0),
             microsecond.unwrap_or(0),
         ))?;
-        Ok(time_obj.to_object(py))
+        Ok(time_obj.into_py_any(py)?)
     } else if has_date && !has_time {
         // Date only
         let year_val = year.unwrap_or(1970);
         let month_val = month.unwrap_or(1);
         let day_val = day.unwrap_or(1);
         let date = date_class.call1((year_val, month_val, day_val))?;
-        Ok(date.to_object(py))
+        Ok(date.into_py_any(py)?)
     } else {
         // Both date and time (or neither - default to datetime)
         let year_val = year.unwrap_or(1970);
@@ -219,7 +220,7 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
             microsecond.unwrap_or(0),
             py.None(),
         ))?;
-        Ok(dt.to_object(py))
+        Ok(dt.into_py_any(py)?)
     }
 }
 
@@ -301,7 +302,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                 let second: u8 = dt.getattr("second")?.extract().unwrap_or(0);
                 let microsecond: u32 = dt.getattr("microsecond")?.extract().unwrap_or(0);
                 let time_obj = time_class.call1((hour, minute, second, microsecond))?;
-                Ok(time_obj.to_object(py))
+                Ok(time_obj.into_py_any(py)?)
             }
             Err(e) => {
                 // Check if this is a regex group redefinition error
@@ -332,7 +333,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                     let days = timedelta.call1((day_of_year as i32 - 1,))?;
                     let add_method = jan1.getattr("__add__")?;
                     let result_date = add_method.call1((days,))?;
-                    return Ok(result_date.to_object(py));
+                    return result_date.into_py_any(py);
                 }
             }
             // Handle %j without year (use current year)
@@ -348,7 +349,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                     let days = timedelta.call1((day_of_year as i32 - 1,))?;
                     let add_method = jan1.getattr("__add__")?;
                     let result_date = add_method.call1((days,))?;
-                    return Ok(result_date.to_object(py));
+                    return result_date.into_py_any(py);
                 }
             }
         }
@@ -363,7 +364,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                 let month: u8 = dt.getattr("month")?.extract()?;
                 let day: u8 = dt.getattr("day")?.extract()?;
                 let date = date_class.call1((year, month, day))?;
-                Ok(date.to_object(py))
+                Ok(date.into_py_any(py)?)
             }
             Err(e) => {
                 // Check if this is a regex group redefinition error
@@ -406,7 +407,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
                                 PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid day")
                             })?;
                             let date = date_class.call1((year, month, day))?;
-                            return Ok(date.to_object(py));
+                            return date.into_py_any(py);
                         }
                     }
                 }
@@ -421,7 +422,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
         // Both date and time: return datetime
         let strptime = datetime_class.getattr("strptime")?;
         match strptime.call1((value, format_str)) {
-            Ok(dt) => Ok(dt.to_object(py)),
+            Ok(dt) => Ok(dt.into_py_any(py)?),
             Err(e) => {
                 // Check if this is a regex group redefinition error
                 if is_regex_group_redefinition_error(&e) {

--- a/formatparse-pyo3/src/datetime/system.rs
+++ b/formatparse-pyo3/src/datetime/system.rs
@@ -1,6 +1,7 @@
 use crate::datetime::common::get_abbreviated_month_map;
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 // Cached regex pattern for system datetime parsing
@@ -67,7 +68,7 @@ pub fn parse_system_datetime(py: Python, value: &str) -> PyResult<PyObject> {
                 0,
                 py.None(),
             ))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 

--- a/formatparse-pyo3/src/datetime/time.rs
+++ b/formatparse-pyo3/src/datetime/time.rs
@@ -1,6 +1,7 @@
 use crate::datetime::common::{create_fixed_tz, parse_time_with_ampm, RE_TZ_COLON};
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 // Cached regex pattern for timezone in time string
@@ -41,5 +42,5 @@ pub fn parse_time(py: Python, value: &str) -> PyResult<PyObject> {
     let (hour, minute, second) = parse_time_with_ampm(time_str)?;
 
     let time_obj = time_class.call1((hour, minute, second, 0, tzinfo))?;
-    Ok(time_obj.to_object(py))
+    time_obj.into_py_any(py)
 }

--- a/formatparse-pyo3/src/datetime/us.rs
+++ b/formatparse-pyo3/src/datetime/us.rs
@@ -3,6 +3,7 @@ use crate::datetime::common::{
 };
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 // Cached regex patterns for US datetime parsing
@@ -99,7 +100,7 @@ pub fn parse_us_datetime(py: Python, value: &str) -> PyResult<PyObject> {
             };
 
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 
@@ -145,7 +146,7 @@ pub fn parse_us_datetime(py: Python, value: &str) -> PyResult<PyObject> {
             };
 
             let dt = datetime_class.call1((year, month, day, hour, minute, second, 0, tzinfo))?;
-            return Ok(dt.to_object(py));
+            return dt.into_py_any(py);
         }
     }
 

--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -2,13 +2,12 @@
 //!
 //! formatparse-pyo3 provides Python bindings for the formatparse-core library.
 
-#![allow(deprecated)] // PyO3: ToPyObject::to_object pending migration to IntoPyObject
-
 use lru::LruCache;
 use once_cell::sync::Lazy;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
+use pyo3::IntoPyObjectExt;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -234,7 +233,7 @@ fn search(
                 let result_value = parse_result.borrow();
                 let adjusted = result_value.clone().with_offset(pos);
                 // Py::new() is already optimized when GIL is held
-                Ok(Some(Py::new(py, adjusted)?.into_py(py)))
+                Ok(Some(Py::new(py, adjusted)?.into_py_any(py)?))
             } else {
                 // It's a Match object - we need to adjust its span
                 // For now, just return it as-is (Match spans are relative to search start)
@@ -336,7 +335,7 @@ fn findall(
         // The Results object is lightweight - just stores raw data
         return Python::with_gil(|py| -> PyResult<PyObject> {
             let results = Results::new(raw_results);
-            Ok(Py::new(py, results)?.into_py(py))
+            Py::new(py, results)?.into_py_any(py)
         });
     }
 
@@ -534,7 +533,7 @@ fn extract_format(
             result.set_item("zero", true)?;
         }
 
-        Ok(result.into_py(py))
+        result.into_py_any(py)
     })
 }
 

--- a/formatparse-pyo3/src/match.rs
+++ b/formatparse-pyo3/src/match.rs
@@ -39,8 +39,8 @@ impl Match {
                 if let Some(ref original_name) = self.field_names.get(i).and_then(|n| n.as_ref()) {
                     // Check for repeated field names - values must match
                     if let Some(existing_value) = named.get(original_name) {
-                        let existing_obj = existing_value.to_object(py);
-                        let converted_obj = converted.to_object(py);
+                        let existing_obj = existing_value.clone_ref(py);
+                        let converted_obj = converted.clone_ref(py);
                         let are_equal: bool = existing_obj.bind(py).eq(converted_obj.bind(py)).unwrap_or(false);
                         if !are_equal {
                             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(

--- a/formatparse-pyo3/src/match_rs.rs
+++ b/formatparse-pyo3/src/match_rs.rs
@@ -2,6 +2,7 @@ use crate::error;
 use crate::result::ParseResult;
 use crate::types::FieldSpec;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 
 /// Owned components for constructing a [`Match`].
@@ -78,8 +79,8 @@ impl Match {
                         // Regular flat field name
                         // Check for repeated field names - values must match
                         if let Some(existing_value) = named.get(original_name.as_str()) {
-                            let existing_obj = existing_value.to_object(py);
-                            let converted_obj = converted.to_object(py);
+                            let existing_obj = existing_value.clone_ref(py);
+                            let converted_obj = converted.clone_ref(py);
                             let are_equal: bool = existing_obj
                                 .bind(py)
                                 .eq(converted_obj.bind(py))
@@ -99,7 +100,7 @@ impl Match {
         let parse_result =
             ParseResult::new_with_spans(fixed, named, self.span, self.field_spans.clone());
         // Py::new() is already optimized when GIL is held
-        Ok(Py::new(py, parse_result)?.to_object(py))
+        Py::new(py, parse_result)?.into_py_any(py)
     }
 }
 

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -4,6 +4,7 @@ use formatparse_core::FieldSpec;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyString, PyTuple};
+use pyo3::IntoPyObjectExt;
 use regex::Regex;
 use std::collections::HashMap;
 
@@ -489,8 +490,8 @@ impl FormatParser {
     fn __reduce__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let m = py.import("_formatparse")?;
         let compile_fn = m.getattr("compile")?;
-        let args = PyTuple::new_bound(py, [&self.pattern]);
-        Ok(PyTuple::new_bound(py, [compile_fn.as_any(), args.as_any()]).into_py(py))
+        let args = PyTuple::new(py, [&self.pattern])?;
+        PyTuple::new(py, [compile_fn.as_any(), args.as_any()])?.into_py_any(py)
     }
 
     /// Pickle state: pattern string only (see class doc for ``extra_types``).
@@ -498,7 +499,7 @@ impl FormatParser {
         use pyo3::types::PyDict;
         let state = PyDict::new(py);
         state.set_item("pattern", &self.pattern)?;
-        Ok(state.into_py(py))
+        state.into_py_any(py)
     }
 
     /// Restore from pickle state (pattern only; ``extra_types`` are not recovered).
@@ -544,7 +545,7 @@ impl Format {
     /// Format values into the pattern string using Python's format() method
     fn format(&self, py: Python, args: &Bound<'_, PyAny>) -> PyResult<String> {
         // Use Python's string format method to format values into the pattern
-        let pattern_obj = PyString::new_bound(py, &self.pattern);
+        let pattern_obj = PyString::new(py, &self.pattern);
         let format_method = pattern_obj.getattr("format")?;
 
         // Call format with the args (can be a single value, tuple, or *args)

--- a/formatparse-pyo3/src/parser/matching.rs
+++ b/formatparse-pyo3/src/parser/matching.rs
@@ -5,6 +5,7 @@ use crate::result::ParseResult;
 use formatparse_core::{count_capturing_groups, FieldSpec, FieldType};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use pyo3::IntoPyObjectExt;
 use regex::{Captures, Regex};
 use std::collections::HashMap;
 
@@ -108,13 +109,13 @@ pub fn insert_nested_dict(
             // It's not a dict, we can't nest - this is an error case
             // For now, just replace it (this shouldn't happen in practice)
             let new_dict = PyDict::new(py);
-            let new_dict_obj = new_dict.clone().into_py(py);
+            let new_dict_obj = new_dict.clone().into_py_any(py)?;
             named.insert(first_key.clone(), new_dict_obj);
             new_dict
         }
     } else {
         let new_dict = PyDict::new(py);
-        let new_dict_obj = new_dict.clone().into_py(py);
+        let new_dict_obj = new_dict.clone().into_py_any(py)?;
         named.insert(first_key.clone(), new_dict_obj);
         new_dict
     };
@@ -128,13 +129,13 @@ pub fn insert_nested_dict(
             } else {
                 // Not a dict, replace it
                 let new_dict = PyDict::new(py);
-                let new_dict_obj = new_dict.clone().into_py(py);
+                let new_dict_obj = new_dict.clone().into_py_any(py)?;
                 current_dict.set_item(key.as_str(), new_dict_obj)?;
                 new_dict
             }
         } else {
             let new_dict = PyDict::new(py);
-            let new_dict_obj = new_dict.clone().into_py(py);
+            let new_dict_obj = new_dict.clone().into_py_any(py)?;
             current_dict.set_item(key.as_str(), new_dict_obj)?;
             new_dict
         };
@@ -545,8 +546,8 @@ pub fn match_with_captures(
                             match named.get(original_name) {
                                 Some(existing_value) => {
                                     let are_equal: bool = {
-                                        let existing_obj = existing_value.to_object(py);
-                                        let converted_obj = converted.to_object(py);
+                                        let existing_obj = existing_value.clone_ref(py);
+                                        let converted_obj = converted.clone_ref(py);
                                         existing_obj
                                             .bind(py)
                                             .eq(converted_obj.bind(py))
@@ -602,8 +603,8 @@ pub fn match_with_captures(
                                 Some(existing_value) => {
                                     // Field exists - check if values match (repeated name case)
                                     let are_equal: bool = {
-                                        let existing_obj = existing_value.to_object(py);
-                                        let converted_obj = converted.to_object(py);
+                                        let existing_obj = existing_value.clone_ref(py);
+                                        let converted_obj = converted.clone_ref(py);
                                         existing_obj
                                             .bind(py)
                                             .eq(converted_obj.bind(py))
@@ -645,7 +646,7 @@ pub fn match_with_captures(
     if evaluate_result {
         let parse_result = ParseResult::new_with_spans(fixed, named, (start, end), field_spans);
         // Py::new() is already optimized when GIL is held
-        Ok(Some(Py::new(py, parse_result)?.to_object(py)))
+        Ok(Some(Py::new(py, parse_result)?.into_py_any(py)?))
     } else {
         // Create Match object with raw captures
         // Note: pattern is static, but Match needs owned String - this is acceptable
@@ -660,7 +661,7 @@ pub fn match_with_captures(
             span: (start, end),
             field_spans,
         });
-        Ok(Some(Py::new(py, match_obj)?.to_object(py)))
+        Ok(Some(Py::new(py, match_obj)?.into_py_any(py)?))
     }
 }
 
@@ -799,8 +800,8 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                                 match named.get(original_name) {
                                     Some(existing_value) => {
                                         let are_equal: bool = {
-                                            let existing_obj = existing_value.to_object(py);
-                                            let converted_obj = converted.to_object(py);
+                                            let existing_obj = existing_value.clone_ref(py);
+                                            let converted_obj = converted.clone_ref(py);
                                             existing_obj
                                                 .bind(py)
                                                 .eq(converted_obj.bind(py))
@@ -866,8 +867,8 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                                         // Field exists - check if values match (repeated name case)
                                         // Compare values using Python's equality (batch GIL operation)
                                         let are_equal: bool = {
-                                            let existing_obj = existing_value.to_object(py);
-                                            let converted_obj = converted.to_object(py);
+                                            let existing_obj = existing_value.clone_ref(py);
+                                            let converted_obj = converted.clone_ref(py);
                                             existing_obj
                                                 .bind(py)
                                                 .eq(converted_obj.bind(py))
@@ -928,7 +929,7 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
         if evaluate_result {
             let parse_result = ParseResult::new_with_spans(fixed, named, (start, end), field_spans);
             // Py::new() is already optimized when GIL is held
-            Ok(Some(Py::new(py, parse_result)?.to_object(py)))
+            Ok(Some(Py::new(py, parse_result)?.into_py_any(py)?))
         } else {
             // Create Match object with raw captures
             let match_obj = Match::new(MatchInit {
@@ -943,7 +944,7 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
             });
             // Use Py::new_bound for better performance
             // Py::new() is already optimized when GIL is held
-            Ok(Some(Py::new(py, match_obj)?.to_object(py)))
+            Ok(Some(Py::new(py, match_obj)?.into_py_any(py)?))
         }
     } else {
         Ok(None)
@@ -1013,8 +1014,8 @@ pub fn match_empty_default_string_parse(
                     match named.get(original_name) {
                         Some(existing_value) => {
                             let are_equal: bool = {
-                                let existing_obj = existing_value.to_object(py);
-                                let converted_obj = converted.to_object(py);
+                                let existing_obj = existing_value.clone_ref(py);
+                                let converted_obj = converted.clone_ref(py);
                                 existing_obj
                                     .bind(py)
                                     .eq(converted_obj.bind(py))
@@ -1048,7 +1049,7 @@ pub fn match_empty_default_string_parse(
 
     if evaluate_result {
         let parse_result = ParseResult::new_with_spans(fixed, named, (start, end), field_spans);
-        Ok(Some(Py::new(py, parse_result)?.to_object(py)))
+        Ok(Some(Py::new(py, parse_result)?.into_py_any(py)?))
     } else {
         let match_obj = Match::new(MatchInit {
             pattern: pattern.to_string(),
@@ -1060,6 +1061,6 @@ pub fn match_empty_default_string_parse(
             span: (start, end),
             field_spans,
         });
-        Ok(Some(Py::new(py, match_obj)?.to_object(py)))
+        Ok(Some(Py::new(py, match_obj)?.into_py_any(py)?))
     }
 }

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -1,5 +1,6 @@
 use formatparse_core::{FieldSpec, FieldType};
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 
 /// Raw match data without Python objects (for batch processing)
@@ -237,10 +238,10 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
 impl RawValue {
     pub fn to_py_object(&self, py: Python) -> PyObject {
         match self {
-            RawValue::String(s) => s.to_object(py),
-            RawValue::Integer(n) => n.to_object(py),
-            RawValue::Float(f) => f.to_object(py),
-            RawValue::Boolean(b) => b.to_object(py),
+            RawValue::String(s) => s.into_py_any(py).unwrap(),
+            RawValue::Integer(n) => n.into_py_any(py).unwrap(),
+            RawValue::Float(f) => f.into_py_any(py).unwrap(),
+            RawValue::Boolean(b) => b.into_py_any(py).unwrap(),
             RawValue::None => py.None(),
         }
     }

--- a/formatparse-pyo3/src/result.rs
+++ b/formatparse-pyo3/src/result.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::{PySlice, PyTuple};
+use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 
 #[pyclass]
@@ -230,14 +231,14 @@ impl ParseResult {
             let dict = pyo3::types::PyDict::new(py);
             for (key, value) in &self.field_spans {
                 let py_key: PyObject = if let Ok(idx) = key.parse::<usize>() {
-                    idx.into_py(py)
+                    idx.into_py_any(py)?
                 } else {
-                    key.clone().into_py(py)
+                    key.clone().into_py_any(py)?
                 };
                 let py_value = PyTuple::new(py, [value.0, value.1])?;
                 dict.set_item(py_key.bind(py), py_value)?;
             }
-            Ok(dict.into_py(py))
+            dict.into_py_any(py)
         })
     }
 }

--- a/formatparse-pyo3/src/results.rs
+++ b/formatparse-pyo3/src/results.rs
@@ -2,6 +2,7 @@ use crate::parser::raw_match::RawMatchData;
 use pyo3::exceptions::{PyIndexError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
+use pyo3::IntoPyObjectExt;
 
 /// Results container that stores raw match data and lazily converts to ParseResult
 /// This avoids creating all ParseResult objects upfront, improving performance
@@ -30,12 +31,12 @@ impl Results {
         let mut py_results: Vec<PyObject> = Vec::with_capacity(self.raw_data.len());
         for raw_data in &self.raw_data {
             let parse_result = raw_data.to_parse_result(py)?;
-            py_results.push(parse_result.to_object(py));
+            py_results.push(parse_result.into_py_any(py)?);
         }
 
         let items: Vec<_> = py_results.iter().map(|obj| obj.bind(py)).collect();
-        let results_list = PyList::new_bound(py, items);
-        let list_obj = results_list.to_object(py);
+        let results_list = PyList::new(py, items)?;
+        let list_obj = results_list.into_py_any(py)?;
 
         // Cache the result
         self.cached_results = Some(list_obj.clone_ref(py));
@@ -50,7 +51,7 @@ impl Results {
 
         let raw_data = &self.raw_data[index];
         let parse_result = raw_data.to_parse_result(py)?;
-        Ok(parse_result.to_object(py))
+        parse_result.into_py_any(py)
     }
 }
 
@@ -92,7 +93,7 @@ impl Results {
             // Use Python's __getitem__ to handle the slice
             let list_bound = list.bind(py);
             let slice_result = list_bound.get_item(key)?;
-            Ok(slice_result.to_object(py))
+            Ok(slice_result.into_py_any(py)?)
         } else {
             Err(PyTypeError::new_err(
                 "list indices must be integers or slices",
@@ -147,7 +148,7 @@ impl ResultsIterator {
             let results = self.results.bind(py);
             // Convert all items in a single batch (one GIL block)
             let list = results.call_method0("to_list")?;
-            self.cached_list = Some(list.to_object(py));
+            self.cached_list = Some(list.into_py_any(py)?);
         }
 
         // Now iterate over the cached list (no FFI overhead)
@@ -165,6 +166,6 @@ impl ResultsIterator {
 
         let item = list_bound.get_item(self.index)?;
         self.index += 1;
-        Ok(Some(item.to_object(py)))
+        Ok(Some(item.into_py_any(py)?))
     }
 }

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -2,6 +2,7 @@ use crate::datetime;
 use crate::error;
 use formatparse_core::{FieldSpec, FieldType};
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 
 /// Validate alignment+precision constraints for string fields
@@ -180,7 +181,7 @@ pub fn convert_value(
         FieldType::String => {
             // Fast path: no alignment means no trimming needed
             if spec.alignment.is_none() {
-                Ok(value.to_object(py))
+                Ok(value.into_py_any(py)?)
             } else {
                 // Strip fill characters and whitespace based on alignment
                 let trimmed = match spec.alignment {
@@ -219,7 +220,7 @@ pub fn convert_value(
                     }
                     _ => value, // No alignment: keep as-is
                 };
-                Ok(trimmed.to_object(py))
+                Ok(trimmed.into_py_any(py)?)
             }
         }
         FieldType::Integer => {
@@ -230,7 +231,7 @@ pub fn convert_value(
             {
                 // Try parsing directly first (most common case)
                 if let Ok(n) = value.trim().parse::<i64>() {
-                    return Ok(n.to_object(py));
+                    return n.into_py_any(py);
                 }
             }
 
@@ -313,19 +314,19 @@ pub fn convert_value(
                 result.map(|n| if is_negative { -n } else { n })
             };
             match v {
-                Ok(n) => Ok(n.to_object(py)),
+                Ok(n) => Ok(n.into_py_any(py)?),
                 Err(_) => Err(error::conversion_error(value, "integer")),
             }
         }
         FieldType::Float => {
             // Fast path: try parsing directly first (most floats don't have leading/trailing spaces)
             match value.parse::<f64>() {
-                Ok(n) => Ok(n.to_object(py)),
+                Ok(n) => Ok(n.into_py_any(py)?),
                 Err(_) => {
                     // Fallback: strip whitespace and try again
                     let trimmed = value.trim();
                     match trimmed.parse::<f64>() {
-                        Ok(n) => Ok(n.to_object(py)),
+                        Ok(n) => Ok(n.into_py_any(py)?),
                         Err(_) => Err(error::conversion_error(value, "float")),
                     }
                 }
@@ -344,19 +345,19 @@ pub fn convert_value(
                     matches!(lower.as_str(), "true" | "1" | "yes" | "on")
                 }
             };
-            Ok(b.to_object(py))
+            Ok(b.into_py_any(py)?)
         }
-        FieldType::Letters => Ok(value.to_object(py)), // Letters are just strings
-        FieldType::Word => Ok(value.to_object(py)),    // Words are just strings
-        FieldType::NonLetters => Ok(value.to_object(py)), // Non-letters are just strings
-        FieldType::NonWhitespace => Ok(value.to_object(py)), // Non-whitespace are just strings
-        FieldType::NonDigits => Ok(value.to_object(py)), // Non-digits are just strings
+        FieldType::Letters => Ok(value.into_py_any(py)?), // Letters are just strings
+        FieldType::Word => Ok(value.into_py_any(py)?),    // Words are just strings
+        FieldType::NonLetters => Ok(value.into_py_any(py)?), // Non-letters are just strings
+        FieldType::NonWhitespace => Ok(value.into_py_any(py)?), // Non-whitespace are just strings
+        FieldType::NonDigits => Ok(value.into_py_any(py)?), // Non-digits are just strings
         FieldType::NumberWithThousands => {
             // Strip thousands separators (comma or dot) and parse as integer
             let trimmed = value.trim();
             let cleaned = trimmed.replace(",", "").replace(".", "");
             match cleaned.parse::<i64>() {
-                Ok(n) => Ok(n.to_object(py)),
+                Ok(n) => Ok(n.into_py_any(py)?),
                 Err(_) => Err(error::conversion_error(value, "number with thousands")),
             }
         }
@@ -364,7 +365,7 @@ pub fn convert_value(
             // Parse as float (supports scientific notation)
             let trimmed = value.trim();
             match trimmed.parse::<f64>() {
-                Ok(n) => Ok(n.to_object(py)),
+                Ok(n) => Ok(n.into_py_any(py)?),
                 Err(_) => Err(error::conversion_error(value, "scientific notation")),
             }
         }
@@ -374,17 +375,17 @@ pub fn convert_value(
             let lower = trimmed.to_lowercase();
             // Check for nan/inf first
             if lower == "nan" {
-                Ok(f64::NAN.to_object(py))
+                Ok(f64::NAN.into_py_any(py)?)
             } else if lower == "inf" || lower == "+inf" {
-                Ok(f64::INFINITY.to_object(py))
+                Ok(f64::INFINITY.into_py_any(py)?)
             } else if lower == "-inf" {
-                Ok(f64::NEG_INFINITY.to_object(py))
+                Ok(f64::NEG_INFINITY.into_py_any(py)?)
             } else {
                 // Try int first
                 if let Ok(n) = trimmed.parse::<i64>() {
-                    Ok(n.to_object(py))
+                    Ok(n.into_py_any(py)?)
                 } else if let Ok(n) = trimmed.parse::<f64>() {
-                    Ok(n.to_object(py))
+                    Ok(n.into_py_any(py)?)
                 } else {
                     Err(error::conversion_error(value, "number"))
                 }
@@ -395,7 +396,7 @@ pub fn convert_value(
             let trimmed = value.trim();
             let num_str = trimmed.trim_end_matches('%');
             match num_str.parse::<f64>() {
-                Ok(n) => Ok((n / 100.0).to_object(py)),
+                Ok(n) => Ok((n / 100.0).into_py_any(py)?),
                 Err(_) => Err(error::conversion_error(value, "percentage")),
             }
         }
@@ -411,13 +412,13 @@ pub fn convert_value(
             if let Some(fmt) = &spec.strftime_format {
                 datetime::parse_strftime_datetime(py, value, fmt)
             } else {
-                Ok(value.to_object(py))
+                Ok(value.into_py_any(py)?)
             }
         }
-        FieldType::BracedContent => Ok(value.to_object(py)),
+        FieldType::BracedContent => Ok(value.into_py_any(py)?),
         FieldType::Custom(_) => {
             // Already handled above
-            Ok(value.to_object(py))
+            Ok(value.into_py_any(py)?)
         }
     }
 }


### PR DESCRIPTION
Closes #45.

## Summary
- Removed crate-level `#![allow(deprecated)]` from `formatparse-pyo3/src/lib.rs`.
- Replaced deprecated `ToPyObject::to_object(py)` with `IntoPyObjectExt::into_py_any(py)` (and `clone_ref(py)` where values were already `PyObject` used only for Python equality).
- Replaced deprecated `IntoPy::into_py(py)` on `Py` / `Bound` paths with `into_py_any(py)`.
- Updated deprecated `PyTuple::new_bound`, `PyList::new_bound`, `PyString::new_bound` to `PyTuple::new`, `PyList::new`, `PyString::new` with `?` where constructors return `PyResult`.
- Added `use pyo3::IntoPyObjectExt` where needed; `cargo clippy --fix` cleaned redundant `Ok(...?)` around infallible `into_py_any` chains.

## Verification
- `cargo fmt --all`
- `cargo clippy -p formatparse-core -p formatparse-pyo3 --all-targets --all-features -- -D warnings`
- `cargo test -p formatparse-core`
- `maturin develop --release`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/` (564 passed)

No remaining scoped `deprecated` allows.