### PR TITLE
feat: add parse_batch API (#14)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -153,7 +153,12 @@ fn parse(
         })
     });
     match get_or_create_parser(pattern, extra_types_cloned) {
-        Ok(parser) => parser.parse_internal(string, case_sensitive, extra_types, evaluate_result),
+        Ok(parser) => parser.parse_internal(
+            string,
+            case_sensitive,
+            extra_types.as_ref(),
+            evaluate_result,
+        ),
         Err(e) => {
             let err_msg = e.to_string();
             // Propagate NotImplementedError (for unsupported features like quoted keys)
@@ -168,6 +173,81 @@ fn parse(
             }
         }
     }
+}
+
+/// Parse many strings with the same pattern, compiling the pattern once.
+///
+/// Each input string uses the same semantics as `parse` (including
+/// `extra_types`, `case_sensitive`, and `evaluate_result`). Non-matches
+/// become Python `None` at that index in the returned list.
+#[pyfunction]
+#[pyo3(signature = (pattern, strings, extra_types=None, case_sensitive=false, evaluate_result=true))]
+fn parse_batch(
+    pattern: &str,
+    strings: Vec<String>,
+    extra_types: Option<HashMap<String, PyObject>>,
+    case_sensitive: bool,
+    evaluate_result: bool,
+) -> PyResult<PyObject> {
+    formatparse_core::validate_pattern_length(pattern)
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
+    if pattern.contains('\0') {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Pattern contains null byte",
+        ));
+    }
+
+    for s in &strings {
+        formatparse_core::validate_input_length(s)
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
+        if s.contains('\0') {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Input string contains null byte",
+            ));
+        }
+    }
+
+    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+        extra_types.as_ref().map(|et| {
+            et.iter()
+                .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                .collect()
+        })
+    });
+
+    let parser = match get_or_create_parser(pattern, extra_types_cloned) {
+        Ok(p) => p,
+        Err(e) => {
+            let err_msg = e.to_string();
+            if err_msg.contains("not supported") {
+                return Err(e);
+            }
+            if err_msg.contains("Expected '}'") {
+                return Python::with_gil(|py| -> PyResult<PyObject> {
+                    let none_obj = py.None().into_py_any(py)?;
+                    let mut out: Vec<PyObject> = Vec::with_capacity(strings.len());
+                    for _ in 0..strings.len() {
+                        out.push(none_obj.clone_ref(py));
+                    }
+                    let items: Vec<_> = out.iter().map(|o| o.bind(py)).collect();
+                    PyList::new(py, items)?.into_py_any(py)
+                });
+            }
+            return Err(e);
+        }
+    };
+
+    Python::with_gil(|py| -> PyResult<PyObject> {
+        let mut out: Vec<PyObject> = Vec::with_capacity(strings.len());
+        for s in &strings {
+            match parser.parse_internal(s, case_sensitive, extra_types.as_ref(), evaluate_result)? {
+                Some(obj) => out.push(obj),
+                None => out.push(py.None().into_py_any(py)?),
+            }
+        }
+        let items: Vec<_> = out.iter().map(|o| o.bind(py)).collect();
+        PyList::new(py, items)?.into_py_any(py)
+    })
 }
 
 /// Search for a pattern in a string
@@ -541,6 +621,7 @@ fn extract_format(
 #[pymodule]
 fn _formatparse(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_batch, m)?)?;
     m.add_function(wrap_pyfunction!(search, m)?)?;
     m.add_function(wrap_pyfunction!(findall, m)?)?;
     m.add_function(wrap_pyfunction!(compile, m)?)?;

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -205,21 +205,18 @@ impl FormatParser {
         &self,
         string: &str,
         case_sensitive: bool,
-        extra_types: Option<HashMap<String, PyObject>>,
+        extra_types: Option<&HashMap<String, PyObject>>,
         evaluate_result: bool,
     ) -> PyResult<Option<PyObject>> {
         Python::with_gil(|py| {
+            let empty = HashMap::<String, PyObject>::new();
+            let extra_types_ref = extra_types.unwrap_or(&empty);
+
             // Use existing regex (custom type handling is done in convert_value)
             let regex = if case_sensitive {
                 &self.regex
             } else {
                 self.regex_case_insensitive.as_ref().unwrap_or(&self.regex)
-            };
-
-            let extra_types_ref = if let Some(ref et) = extra_types {
-                et
-            } else {
-                &HashMap::new()
             };
 
             if string.is_empty()
@@ -385,7 +382,12 @@ impl FormatParser {
                 }
                 Ok(Some(merged))
             })?;
-        self.parse_internal(string, case_sensitive, merged_extra_types, evaluate_result)
+        self.parse_internal(
+            string,
+            case_sensitive,
+            merged_extra_types.as_ref(),
+            evaluate_result,
+        )
     }
 
     /// Get the list of named field names (returns normalized names for compatibility)

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Optional,
     Protocol,
+    Sequence,
     Tuple,
     TypedDict,
     Union,
@@ -43,6 +44,7 @@ except PackageNotFoundError:
 # Import from the Rust extension module
 from _formatparse import (  # type: ignore[import-not-found, import-untyped]
     parse as _parse,
+    parse_batch as _parse_batch,
     search as _search,
     findall as _findall,
     compile as _compile,
@@ -210,6 +212,42 @@ def parse(
         ('Hello', 'World')
     """
     return _parse(pattern, string, extra_types, case_sensitive, evaluate_result)
+
+
+def parse_batch(
+    pattern: str,
+    strings: Sequence[str],
+    extra_types: Optional[ExtraTypes] = None,
+    case_sensitive: bool = False,
+    evaluate_result: bool = True,
+) -> List[Optional[ParseResult]]:
+    """Parse many strings with the same pattern (compile once, sequential apply).
+
+    This is intended for workloads that apply one pattern to many strings: the
+    compiled regex is resolved once (same LRU cache as :func:`parse` /
+    :func:`compile`) and each string is parsed in order. Non-matches appear as
+    ``None`` at the corresponding index.
+
+    ``strings`` is copied to a list of ``str`` on the Rust side (pass a
+    ``list`` or ``tuple`` of strings; a bare ``str`` is treated as an iterable
+    of characters, which is usually not what you want).
+
+    :param pattern: Format specification pattern
+    :param strings: Sequence of strings to parse (e.g. list or tuple)
+    :param extra_types: Same as :func:`parse`
+    :param case_sensitive: Same as :func:`parse`
+    :param evaluate_result: Same as :func:`parse`
+    :returns: List of :class:`ParseResult` or ``None`` per input string
+
+    Example::
+
+        >>> out = parse_batch("{:d}", ["1", "2", "x"])
+        >>> out[0].fixed[0]
+        1
+        >>> out[2] is None
+        True
+    """
+    return _parse_batch(pattern, list(strings), extra_types, case_sensitive, evaluate_result)
 
 
 def search(
@@ -880,6 +918,7 @@ class BidirectionalResult:
 __all__ = [
     "__version__",
     "parse",
+    "parse_batch",
     "search",
     "findall",
     "with_pattern",

--- a/tests/test_parse_batch.py
+++ b/tests/test_parse_batch.py
@@ -1,0 +1,96 @@
+"""Tests for parse_batch (issue #14)."""
+
+import pytest
+
+from formatparse import parse, parse_batch, with_pattern
+
+
+def test_parse_batch_empty():
+    assert parse_batch("{:d}", []) == []
+
+
+def test_parse_batch_all_match():
+    out = parse_batch("{:d}-{:d}", ["1-2", "3-4"])
+    assert len(out) == 2
+    assert out[0] is not None and out[0].fixed == (1, 2)
+    assert out[1] is not None and out[1].fixed == (3, 4)
+
+
+def test_parse_batch_mixed_none():
+    out = parse_batch("{:d}", ["1", "x", "3"])
+    assert out[0] is not None and out[0].fixed[0] == 1
+    assert out[1] is None
+    assert out[2] is not None and out[2].fixed[0] == 3
+
+
+def test_parse_batch_tuple_input():
+    out = parse_batch("{:d}", ("10", "20"))
+    assert [r.fixed[0] if r else None for r in out] == [10, 20]
+
+
+def _assert_parse_result_equal(a, b):
+    assert (a is None) == (b is None)
+    if a is None:
+        return
+    assert a.named == b.named
+    assert a.fixed == b.fixed
+
+
+def test_parse_batch_parity_with_parse():
+    pattern = "{name}: {age:d}"
+    strings = ["Alice: 30", "nope", "Bob: 25"]
+    batch = parse_batch(pattern, strings)
+    for s, b in zip(strings, batch):
+        _assert_parse_result_equal(b, parse(pattern, s))
+
+
+def test_parse_batch_extra_types():
+    @with_pattern(r"\d+")
+    def as_int(text):
+        return int(text)
+
+    extra = {"N": as_int}
+    strings = ["v: 1", "v: 2", "v: x"]
+    batch = parse_batch("v: {:N}", strings, extra_types=extra)
+    singles = [parse("v: {:N}", s, extra_types=extra) for s in strings]
+    assert len(batch) == len(singles)
+    for b, s in zip(batch, singles):
+        _assert_parse_result_equal(b, s)
+
+
+def test_parse_batch_case_sensitive():
+    pattern = "Hello, {name}"
+    strings = ["Hello, Alice", "hello, Bob"]
+    ins = parse_batch(pattern, strings, case_sensitive=True)
+    assert ins[0] is not None and ins[0].named["name"] == "Alice"
+    assert ins[1] is None
+
+    outs = parse_batch(pattern, strings, case_sensitive=False)
+    assert outs[0] is not None and outs[0].named["name"] == "Alice"
+    assert outs[1] is not None and outs[1].named["name"] == "Bob"
+
+
+def test_parse_batch_evaluate_result_false():
+    pattern = "hello {}"
+    strings = ["hello world", "hello there"]
+    batch = parse_batch(pattern, strings, evaluate_result=False)
+    singles = [parse(pattern, s, evaluate_result=False) for s in strings]
+    assert len(batch) == 2
+    for b, s in zip(batch, singles):
+        assert b is not None
+        assert s is not None
+        assert b.evaluate_result().fixed == s.evaluate_result().fixed
+
+
+def test_parse_batch_null_byte_in_string_raises():
+    with pytest.raises(ValueError, match="null byte"):
+        parse_batch("{:d}", ["1", "bad\x00"])
+
+
+def test_parse_batch_smoke_many():
+    n = 500
+    strings = [str(i) for i in range(n)]
+    out = parse_batch("{:d}", strings)
+    assert len(out) == n
+    for i, r in enumerate(out):
+        assert r is not None and r.fixed[0] == i


### PR DESCRIPTION
Closes #14.

## Summary
This PR adds `parse_batch(pattern, strings, *, extra_types=None, case_sensitive=False, evaluate_result=True)`, exported from `formatparse`. The Rust binding compiles the pattern once (same LRU cache as `parse` / `compile`), then parses each string sequentially and returns a Python `list` of `ParseResult` or `None` per input.

`FormatParser::parse_internal` now takes `extra_types` as `Option<&HashMap<...>>` so batch parsing does not clone the converter map on every string.

## MVP scope (this PR)
- Sequential batch only; inputs are materialized as `Vec<String>` on the Rust side (Python wrapper uses `list(strings)`).
- Same validation as `parse` for pattern and each string (length limits, null bytes).
- Same soft handling as `parse` when pattern compilation fails with `Expected '}'`: each output slot is `None`.

## Follow-ups (not in this PR)
- Parallel / Rayon batching, SIMD, or a lazy iterator API can build on this surface once semantics and tests are settled.