### PR TITLE
feat: add findall_iter incremental iterator (#13)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -25,7 +25,7 @@ mod results;
 mod types;
 
 pub use datetime::FixedTzOffset;
-pub use parser::{Format, FormatParser};
+pub use parser::{FindallIter, Format, FormatParser};
 pub use result::*;
 pub use results::Results;
 pub use types::conversion::*;
@@ -395,6 +395,67 @@ fn findall(
     })
 }
 
+/// Iterator over non-overlapping matches (same scan as :func:`findall`, one item per step).
+///
+/// See :class:`FindallIter` for memory semantics and limitations (issue #13 MVP).
+#[pyfunction]
+#[pyo3(signature = (pattern, string, extra_types=None, case_sensitive=false, evaluate_result=true))]
+fn findall_iter(
+    py: Python<'_>,
+    pattern: &str,
+    string: &str,
+    extra_types: Option<HashMap<String, PyObject>>,
+    case_sensitive: bool,
+    evaluate_result: bool,
+) -> PyResult<Py<FindallIter>> {
+    formatparse_core::validate_pattern_length(pattern)
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
+    formatparse_core::validate_input_length(string)
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
+
+    if pattern.contains('\0') {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Pattern contains null byte",
+        ));
+    }
+    if string.contains('\0') {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Input string contains null byte",
+        ));
+    }
+
+    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+        extra_types.as_ref().map(|et| {
+            et.iter()
+                .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                .collect()
+        })
+    });
+    let parser = get_or_create_parser(pattern, extra_types_cloned)?;
+
+    let et_map = Python::with_gil(|py| -> HashMap<String, PyObject> {
+        extra_types
+            .as_ref()
+            .map(|et| {
+                et.iter()
+                    .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                    .collect()
+            })
+            .unwrap_or_default()
+    });
+
+    Py::new(
+        py,
+        FindallIter::new(
+            parser,
+            string.to_string(),
+            case_sensitive,
+            evaluate_result,
+            et_map,
+        ),
+    )
+}
+
 /// Compile a pattern into a FormatParser for reuse.
 ///
 /// Uses the same LRU cache as the `parse`, `search`, and `findall` bindings:
@@ -543,6 +604,7 @@ fn _formatparse(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse, m)?)?;
     m.add_function(wrap_pyfunction!(search, m)?)?;
     m.add_function(wrap_pyfunction!(findall, m)?)?;
+    m.add_function(wrap_pyfunction!(findall_iter, m)?)?;
     m.add_function(wrap_pyfunction!(compile, m)?)?;
     m.add_function(wrap_pyfunction!(extract_format, m)?)?;
     m.add_class::<ParseResult>()?;
@@ -551,5 +613,6 @@ fn _formatparse(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FixedTzOffset>()?;
     m.add_class::<Match>()?;
     m.add_class::<Results>()?;
+    m.add_class::<FindallIter>()?;
     Ok(())
 }

--- a/formatparse-pyo3/src/parser.rs
+++ b/formatparse-pyo3/src/parser.rs
@@ -12,5 +12,5 @@ pub mod format_parser;
 pub mod matching;
 pub mod raw_match;
 
-pub use format_parser::{Format, FormatParser};
+pub use format_parser::{FindallIter, Format, FormatParser};
 pub use pattern::parse_field_path;

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -1,4 +1,7 @@
 use crate::error;
+use crate::parser::matching::{
+    match_with_captures, match_with_captures_raw, CapturedMatchContext, FieldCaptureSlices,
+};
 use formatparse_core::parser::{validate_input_length, validate_pattern_length, MAX_FIELDS};
 use formatparse_core::FieldSpec;
 use pyo3::exceptions::PyValueError;
@@ -7,6 +10,7 @@ use pyo3::types::{PyString, PyTuple};
 use pyo3::IntoPyObjectExt;
 use regex::Regex;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[pyclass(module = "_formatparse")]
 /// Compiled format pattern for parsing strings.
@@ -483,6 +487,59 @@ impl FormatParser {
         self.search_pattern(string, case_sensitive, merged_extra_types, evaluate_result)
     }
 
+    /// Yield non-overlapping matches from ``string`` one at a time.
+    ///
+    /// Same matching rules as :func:`findall`, but each ``__next__`` converts at most one
+    /// match, lowering peak memory when you stream results. This does **not** read
+    /// arbitrary file chunks with backtracking; pair with line-based file iteration only
+    /// when matches cannot span line breaks (see GitHub issue #13).
+    #[pyo3(signature = (string, case_sensitive=false, extra_types=None, evaluate_result=true))]
+    fn findall_iter(
+        &self,
+        py: Python<'_>,
+        string: &str,
+        case_sensitive: bool,
+        extra_types: Option<HashMap<String, PyObject>>,
+        evaluate_result: bool,
+    ) -> PyResult<Py<FindallIter>> {
+        validate_input_length(string).map_err(PyValueError::new_err)?;
+
+        if string.contains('\0') {
+            return Err(PyValueError::new_err("Input string contains null byte"));
+        }
+
+        let merged_extra_types =
+            Python::with_gil(|py| -> PyResult<Option<HashMap<String, PyObject>>> {
+                let mut merged = if let Some(ref stored) = self.stored_extra_types {
+                    stored
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                        .collect()
+                } else {
+                    HashMap::new()
+                };
+                if let Some(ref provided) = extra_types {
+                    for (k, v) in provided {
+                        merged.insert(k.clone(), v.clone_ref(py));
+                    }
+                }
+                Ok(Some(merged))
+            })?;
+
+        let merged_map = merged_extra_types.unwrap_or_default();
+        let arc = std::sync::Arc::new(self.clone());
+        Py::new(
+            py,
+            FindallIter::new(
+                arc,
+                string.to_string(),
+                case_sensitive,
+                evaluate_result,
+                merged_map,
+            ),
+        )
+    }
+
     /// Pickle support: rebuild with ``compile(pattern)`` only (no ``extra_types``).
     ///
     /// Custom type converters cannot be serialized reliably; use
@@ -556,5 +613,152 @@ impl Format {
             format_method.call1((args,))?
         };
         result.extract()
+    }
+}
+
+/// Incremental iterator over ``findall``-style matches (issue #13 MVP).
+///
+/// Yields one match at a time using the same non-overlapping scan as :func:`findall`,
+/// without building a full :class:`Results` or list first. This lowers peak memory when
+/// you only consume matches sequentially. It does **not** implement arbitrary chunked
+/// file I/O or cross-chunk backtracking; use line-by-line reads only when your pattern
+/// cannot span physical line breaks.
+#[pyclass(module = "_formatparse", name = "FindallIter")]
+pub struct FindallIter {
+    parser: Arc<FormatParser>,
+    haystack: String,
+    case_sensitive: bool,
+    evaluate_result: bool,
+    fast_path: bool,
+    extra_types: HashMap<String, PyObject>,
+    last_end: usize,
+    search_pos: usize,
+}
+
+impl FindallIter {
+    pub fn new(
+        parser: Arc<FormatParser>,
+        haystack: String,
+        case_sensitive: bool,
+        evaluate_result: bool,
+        extra_types: HashMap<String, PyObject>,
+    ) -> Self {
+        let has_custom_converters = !extra_types.is_empty();
+        let has_nested_dicts = parser.has_nested_dict_fields.iter().any(|&b| b);
+        let fast_path = !has_custom_converters && evaluate_result && !has_nested_dicts;
+        Self {
+            parser,
+            haystack,
+            case_sensitive,
+            evaluate_result,
+            fast_path,
+            extra_types,
+            last_end: 0,
+            search_pos: 0,
+        }
+    }
+}
+
+#[pymethods]
+impl FindallIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        if slf.fast_path {
+            loop {
+                if slf.search_pos > slf.haystack.len() {
+                    return Ok(None);
+                }
+                let search_regex = slf.parser.get_search_regex(slf.case_sensitive);
+                let Some(caps) = search_regex.captures_at(&slf.haystack, slf.search_pos) else {
+                    return Ok(None);
+                };
+                let m0 = caps.get(0).unwrap();
+                let match_start = m0.start();
+                let match_end = m0.end();
+
+                if match_start < slf.last_end {
+                    slf.search_pos = slf.last_end.max(match_start.saturating_add(1));
+                    continue;
+                }
+
+                let slices = FieldCaptureSlices {
+                    field_specs: &slf.parser.field_specs,
+                    field_names: &slf.parser.field_names,
+                    normalized_names: &slf.parser.normalized_names,
+                    custom_type_groups: &slf.parser.custom_type_groups,
+                    has_nested_dict_fields: &slf.parser.has_nested_dict_fields,
+                };
+
+                match match_with_captures_raw(&caps, &slf.haystack, match_start, &slices) {
+                    Ok(Some(raw_data)) => {
+                        slf.last_end = match_end;
+                        if match_start == match_end {
+                            slf.last_end += 1;
+                        }
+                        slf.search_pos = slf.last_end;
+                        let pr = raw_data.to_parse_result(py)?;
+                        return Ok(Some(pr.into_py_any(py)?));
+                    }
+                    Ok(None) | Err(_) => {
+                        slf.search_pos = match_start.saturating_add(1);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        loop {
+            if slf.search_pos > slf.haystack.len() {
+                return Ok(None);
+            }
+            let search_regex = slf.parser.get_search_regex(slf.case_sensitive);
+            let Some(caps) = search_regex.captures_at(&slf.haystack, slf.search_pos) else {
+                return Ok(None);
+            };
+            let m0 = caps.get(0).unwrap();
+            let match_start = m0.start();
+            let match_end = m0.end();
+
+            if match_start < slf.last_end {
+                slf.search_pos = slf.last_end.max(match_start.saturating_add(1));
+                continue;
+            }
+
+            let ctx = CapturedMatchContext {
+                pattern: &slf.parser.pattern,
+                fields: FieldCaptureSlices {
+                    field_specs: &slf.parser.field_specs,
+                    field_names: &slf.parser.field_names,
+                    normalized_names: &slf.parser.normalized_names,
+                    custom_type_groups: &slf.parser.custom_type_groups,
+                    has_nested_dict_fields: &slf.parser.has_nested_dict_fields,
+                },
+                py,
+                custom_converters: &slf.extra_types,
+                evaluate_result: slf.evaluate_result,
+            };
+
+            match match_with_captures(&caps, &ctx)? {
+                Some(result) => {
+                    slf.last_end = match_end;
+                    if match_start == match_end {
+                        slf.last_end += 1;
+                    }
+                    slf.search_pos = slf.last_end;
+                    return Ok(Some(result));
+                }
+                None => {
+                    slf.search_pos = match_start.saturating_add(1);
+                    continue;
+                }
+            }
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        "<FindallIter>".to_string()
     }
 }

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -16,6 +16,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterator,
     List,
     Optional,
     Protocol,
@@ -45,9 +46,11 @@ from _formatparse import (  # type: ignore[import-not-found, import-untyped]
     parse as _parse,
     search as _search,
     findall as _findall,
+    findall_iter as _findall_iter,
     compile as _compile,
     ParseResult,
     FormatParser,
+    FindallIter,
     FixedTzOffset as _FixedTzOffset,
     Results,
 )
@@ -323,6 +326,35 @@ def findall(
         3
     """
     return _findall(pattern, string, extra_types, case_sensitive, evaluate_result)
+
+
+def findall_iter(
+    pattern: str,
+    string: str,
+    extra_types: Optional[ExtraTypes] = None,
+    case_sensitive: bool = False,
+    evaluate_result: bool = True,
+) -> Iterator[Any]:
+    """Yield non-overlapping matches for ``pattern`` in ``string``, one at a time.
+
+    Semantics match :func:`findall` (same ``extra_types``, ``case_sensitive``, and
+    ``evaluate_result``), but each step converts at most one match. This lowers peak
+    memory when you stream results instead of building a full :class:`Results` or list.
+
+    This is a **partial** answer to `issue #13 <https://github.com/eddiethedean/formatparse/issues/13>`_:
+    it does **not** implement arbitrary chunked file reads with backtracking across
+    chunk boundaries. For logs, a common pattern is line-sized strings (matches must not
+    span lines)::
+
+        parser = compile("ID:{id:d}")
+        with open("log.txt") as f:
+            for line in f:
+                for m in parser.findall_iter(line.strip()):
+                    process(m.named["id"])
+
+    :returns: Iterator of :class:`ParseResult` or :class:`Match` (same as ``findall``)
+    """
+    return _findall_iter(pattern, string, extra_types, case_sensitive, evaluate_result)
 
 
 # Create a tzinfo-compatible wrapper for FixedTzOffset
@@ -882,5 +914,7 @@ __all__ = [
     "parse",
     "search",
     "findall",
+    "findall_iter",
+    "FindallIter",
     "with_pattern",
 ]

--- a/tests/test_findall_iter.py
+++ b/tests/test_findall_iter.py
@@ -1,0 +1,79 @@
+"""Tests for findall_iter / FindallIter (issue #13 MVP)."""
+
+import pytest
+
+from formatparse import ParseResult, compile, findall, findall_iter, with_pattern
+
+
+def _assert_parse_like_equal(a, b):
+    """Compare ParseResult-like objects (after Match.evaluate_result if needed)."""
+    if not isinstance(a, ParseResult):
+        a = a.evaluate_result()
+    if not isinstance(b, ParseResult):
+        b = b.evaluate_result()
+    assert a.named == b.named
+    assert a.fixed == b.fixed
+
+
+def test_findall_iter_empty_string():
+    assert list(findall_iter("ID:{id:d}", "")) == []
+
+
+def test_findall_iter_no_matches():
+    assert list(findall_iter("ID:{id:d}", "nothing")) == []
+
+
+def test_findall_iter_parity_fast_path_many():
+    pattern = "ID:{id:d}"
+    text = " ".join(f"ID:{i}" for i in range(50))
+    a = list(findall(pattern, text))
+    b = list(findall_iter(pattern, text))
+    assert len(a) == len(b) == 50
+    for x, y in zip(a, b):
+        _assert_parse_like_equal(x, y)
+
+
+def test_findall_iter_parity_fast_path_extract():
+    s = "".join(r.fixed[0] for r in findall_iter(">{}<", "<p>some <b>bold</b> text</p>"))
+    assert s == "some bold text"
+
+
+def test_findall_iter_parity_extra_types():
+    @with_pattern(r"\d+")
+    def as_int(text):
+        return int(text)
+
+    pattern = "v:{:N}"
+    text = "v:1 v:2 v:3"
+    extra = {"N": as_int}
+    a = list(findall(pattern, text, extra_types=extra))
+    b = list(findall_iter(pattern, text, extra_types=extra))
+    assert len(a) == len(b) == 3
+    for x, y in zip(a, b):
+        _assert_parse_like_equal(x, y)
+
+
+def test_findall_iter_evaluate_result_false_parity():
+    pattern = ">{}<"
+    text = "<p>a</p> <p>b</p>"
+    a = list(findall(pattern, text, evaluate_result=False))
+    b = list(findall_iter(pattern, text, evaluate_result=False))
+    assert len(a) == len(b)
+    for x, y in zip(a, b):
+        _assert_parse_like_equal(x, y)
+
+
+def test_findall_iter_null_byte_raises():
+    with pytest.raises(ValueError, match="null byte"):
+        list(findall_iter("{}", "a\x00b"))
+
+
+def test_format_parser_findall_iter_parity():
+    pattern = "ID:{id:d}"
+    parser = compile(pattern)
+    text = "ID:1 ID:2"
+    a = list(findall(pattern, text))
+    b = list(parser.findall_iter(text))
+    assert len(a) == len(b) == 2
+    for x, y in zip(a, b):
+        _assert_parse_like_equal(x, y)


### PR DESCRIPTION
Progresses https://github.com/eddiethedean/formatparse/issues/13.

## Summary
- Add `FindallIter` (Rust `#[pyclass]`) and module-level `findall_iter(pattern, string, ...)` with the same validation and match semantics as `findall`, stepping with `Regex::captures_at` so we yield one match per `__next__` without first collecting all raw matches into a `Results` vec.
- Add `FormatParser.findall_iter` with the same `extra_types` merge rules as `parse` / `search`.
- Export `findall_iter` and `FindallIter` from `formatparse` (including `__all__`).
- Tests: parity vs `findall` for fast path, `extra_types`, `evaluate_result=False`, empty/no-match, null-byte error, compiled parser.

## MVP vs remaining #13 scope
This PR **does not** implement chunked file I/O, backtracking across buffer boundaries, or `findall_streaming(file_handle, chunk_size=...)` as sketched in the issue; it targets **sequential consumption** and lower peak memory for many matches in one string (and documented line-at-a-time file patterns when matches do not span lines).