### PR TITLE
feat: add multiline field type :ml (#8)

### DIFF
--- a/formatparse-core/src/types/definitions.rs
+++ b/formatparse-core/src/types/definitions.rs
@@ -26,6 +26,8 @@ pub enum FieldType {
     DateTimeStrftime,    // For %Y-%m-%d style patterns
     /// Match `{...}` in the input; capture inner text (non-greedy to first `}`). Issue #15 / parse#146.
     BracedContent,
+    /// Multiline text between anchors; format specifier `:ml` (GitHub issue #8). MVP: no width/align.
+    Multiline,
     Custom(String),
 }
 

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -105,6 +105,10 @@ impl FieldSpec {
                     r".+?".to_string()
                 }
             }
+            FieldType::Multiline => {
+                // Non-greedy any-char including newlines; does not rely on DOTALL for this fragment.
+                r"[\s\S]+?".to_string()
+            }
             FieldType::Integer => {
                 let sign = self
                     .sign
@@ -393,6 +397,14 @@ mod tests {
         let spec = FieldSpec::new();
         let pattern = spec.to_regex_pattern(&HashMap::new(), None);
         assert_eq!(pattern, r".+?");
+    }
+
+    #[test]
+    fn test_field_spec_multiline() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Multiline;
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        assert_eq!(pattern, r"[\s\S]+?");
     }
 
     #[test]

--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -578,6 +578,7 @@ fn extract_format(
     // Parse the format spec string
     let mut spec = FieldSpec::new();
     crate::parser::pattern::parse_format_spec(format_string, &mut spec, None);
+    crate::parser::pattern::validate_multiline_mvp(&spec)?;
 
     // Extract type from the original format_string (preserve original type chars like 'o', 'x', 'b')
     // Parse the format spec to extract the type characters that come after width/precision/alignment

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -314,6 +314,25 @@ pub fn normalize_field_name(
     normalized
 }
 
+/// Reject `:ml` combined with width, precision, alignment, etc. (MVP; GitHub issue #8).
+pub fn validate_multiline_mvp(spec: &FieldSpec) -> PyResult<()> {
+    if !matches!(spec.field_type, FieldType::Multiline) {
+        return Ok(());
+    }
+    if spec.width.is_some()
+        || spec.precision.is_some()
+        || spec.alignment.is_some()
+        || spec.fill.is_some()
+        || spec.sign.is_some()
+        || spec.zero_pad
+    {
+        return Err(error::pattern_error(
+            "Multiline type :ml does not support width, precision, alignment, fill, sign, or zero-padding",
+        ));
+    }
+    Ok(())
+}
+
 /// Check if two field types match (for repeated name validation)
 pub fn field_types_match(t1: &FieldType, t2: &FieldType) -> bool {
     use std::mem::discriminant;
@@ -435,6 +454,7 @@ pub fn parse_field(
 
     // Parse format spec to extract alignment, width, precision, type, etc.
     parse_format_spec(&format_spec, &mut spec, extra_types);
+    validate_multiline_mvp(&spec)?;
 
     let name = if field_name.is_empty() {
         None
@@ -573,6 +593,8 @@ pub fn parse_format_spec(
             FieldType::DateTimeSystem
         } else if type_name == "brace" {
             FieldType::BracedContent
+        } else if type_name == "ml" {
+            FieldType::Multiline
         } else if type_name.len() > 1 {
             // Multi-character - always custom type
             FieldType::Custom(type_name)

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -51,7 +51,7 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
     // For now, only handle built-in types
 
     match &spec.field_type {
-        FieldType::String => {
+        FieldType::String | FieldType::Multiline => {
             // Fast path: no alignment means no trimming needed
             if spec.alignment.is_none() {
                 Ok(RawValue::String(value.to_string()))

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -167,6 +167,7 @@ pub fn convert_value(
             FieldType::DateTimeSystem => "ts",
             FieldType::DateTimeStrftime => "strftime",
             FieldType::BracedContent => "brace",
+            FieldType::Multiline => "ml",
         };
 
         // If there's a custom converter for this type name, use it instead of built-in
@@ -178,7 +179,7 @@ pub fn convert_value(
 
     // Use built-in conversion
     match &spec.field_type {
-        FieldType::String => {
+        FieldType::String | FieldType::Multiline => {
             // Fast path: no alignment means no trimming needed
             if spec.alignment.is_none() {
                 Ok(value.into_py_any(py)?)

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -7,6 +7,11 @@ This is a Rust-backed implementation of the parse library for better performance
 pattern (e.g. ``{:Number}`` → key ``\"Number\"``) to a callable, usually decorated
 with :func:`with_pattern`. See :func:`compile` and the `Custom types user guide
 <https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html>`_.
+
+**Multiline text:** use ``{name:ml}`` when a single field may span newlines; the
+capture is non-greedy up to the next literal or field in the pattern. Width,
+precision, and alignment are not supported with ``:ml`` in the current release
+(see `GitHub issue #8 <https://github.com/eddiethedean/formatparse/issues/8>`_).
 """
 
 from __future__ import annotations

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -1,0 +1,38 @@
+"""Multiline field type ``:ml`` (GitHub issue #8)."""
+
+import pytest
+
+from formatparse import compile, parse
+
+
+def test_multiline_named_field_lf():
+    r = parse("BEGIN\n{body:ml}\nEND", "BEGIN\nalpha\nbeta\nEND")
+    assert r.named["body"] == "alpha\nbeta"
+
+
+def test_multiline_named_field_crlf():
+    r = parse("BEGIN\r\n{body:ml}\r\nEND", "BEGIN\r\nalpha\r\nbeta\r\nEND")
+    assert r.named["body"] == "alpha\r\nbeta"
+
+
+def test_multiline_then_literal_field():
+    r = parse("{a:ml}\n---\n{b}", "first\nblock\n---\nrest")
+    assert r.named["a"] == "first\nblock"
+    assert r.named["b"] == "rest"
+
+
+def test_compile_ml_pattern():
+    p = compile("{body:ml}")
+    r = p.parse("a\nb")
+    assert r.named["body"] == "a\nb"
+
+
+def test_ml_rejects_width():
+    with pytest.raises(ValueError, match="Multiline"):
+        compile("{x:10ml}")
+
+
+def test_plain_brace_newline_regression():
+    """Unchanged: default ``{}`` between anchors still parses across newlines."""
+    r = parse("X{}Y", "Xa\nbY")
+    assert r.fixed[0] == "a\nb"


### PR DESCRIPTION
## Summary

Implements a scoped MVP for **multiline matching** (GitHub issue #8): built-in format specifier `:ml` maps to `FieldType::Multiline` and a non-greedy `[\s\S]+?` capture so fields may include newlines up to the next literal or field anchor.

## Details

- **Core:** `FieldType::Multiline` and regex fragment in `FieldSpec::to_regex_pattern`.
- **Pattern:** Parse `ml` before the multi-character custom-type branch; `validate_multiline_mvp` rejects width, precision, alignment, fill, sign, and zero-padding (same check from `extract_format`).
- **Conversion / raw:** Treat like string for capture value (no extra trimming).
- **Docs:** Short note in `formatparse/__init__.py` module docstring.
- **Tests:** `tests/test_multiline.py` (LF, CRLF, adjacent field, `compile`, rejection of `{x:10ml}`, regression for plain `{}`).

## Deferred (follow-ups / issue comments)

- Backslash line continuations and indentation-based blocks.
- Supporting width/alignment with `:ml` if desired later.

Progresses #8