### PR TITLE
feat: composition MVP — embed parsers via extra_types (#7)

### DIFF
--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -2,6 +2,7 @@ use crate::error;
 use crate::parser::matching::{
     match_with_captures, match_with_captures_raw, CapturedMatchContext, FieldCaptureSlices,
 };
+use formatparse_core::count_capturing_groups;
 use formatparse_core::parser::{validate_input_length, validate_pattern_length, MAX_FIELDS};
 use formatparse_core::FieldSpec;
 use pyo3::exceptions::PyValueError;
@@ -402,6 +403,26 @@ impl FormatParser {
             .iter()
             .filter_map(|n| n.clone())
             .collect()
+    }
+
+    /// Raw regex body for this pattern (no ``^``/``$``, no ``(?s)`` prefix).
+    ///
+    /// Intended for **composition** (GitHub issue #7): embed this string as a custom
+    /// type’s ``pattern`` when building a parent pattern via ``extra_types``. Do not use
+    /// :meth:`_expression` for that purpose; it applies display-oriented transforms that are
+    /// not guaranteed to be valid regex fragments.
+    #[getter]
+    fn regex_subpattern(&self) -> String {
+        self.regex_str.clone()
+    }
+
+    /// Number of capturing groups in :meth:`regex_subpattern`.
+    ///
+    /// Use as ``regex_group_count`` on a converter object when composing (see
+    /// :func:`formatparse.composed_type`).
+    #[getter]
+    fn regex_capturing_group_count(&self) -> usize {
+        count_capturing_groups(&self.regex_str)
     }
 
     /// Get the internal regex expression string (for testing)

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -12,6 +12,13 @@ with :func:`with_pattern`. See :func:`compile` and the `Custom types user guide
 capture is non-greedy up to the next literal or field in the pattern. Width,
 precision, and alignment are not supported with ``:ml`` in the current release
 (see `GitHub issue #8 <https://github.com/eddiethedean/formatparse/issues/8>`_).
+
+**Composition (sub-parsers):** use :func:`composed_type` to wrap a compiled
+:class:`FormatParser` and pass it in ``extra_types`` so one field is parsed by the
+child parser and returns a nested :class:`ParseResult`. The parent pickle story is
+unchanged (only the parent pattern string is restored); re-supply ``extra_types``
+after unpickling, including any composed child parsers (see `GitHub issue #7
+<https://github.com/eddiethedean/formatparse/issues/7>`_).
 """
 
 from __future__ import annotations
@@ -561,6 +568,66 @@ def with_pattern(
     return decorator
 
 
+class ComposedType:
+    """Wrap a compiled :class:`FormatParser` for use as one ``extra_types`` converter.
+
+    Instances expose ``pattern`` and ``regex_group_count`` for the parent's regex
+    builder (GitHub issue #7). Prefer constructing via :func:`composed_type`.
+
+    Pickling a parent :class:`FormatParser` still does not restore ``extra_types``;
+    rebuild composed mappings after unpickling.
+    """
+
+    __slots__ = ("_parser", "pattern", "regex_group_count")
+
+    def __init__(self, parser: FormatParser) -> None:
+        self._parser = parser
+        self.pattern = parser.regex_subpattern
+        self.regex_group_count = parser.regex_capturing_group_count
+
+    def __call__(self, text: str) -> ParseResult:
+        result = self._parser.parse(text)
+        if result is None:
+            raise ValueError(
+                "Composed sub-parser did not match the captured text; the child "
+                "pattern must accept the substring matched by the parent field."
+            )
+        return result
+
+
+def composed_type(parser: FormatParser) -> ComposedType:
+    """Wrap a compiled parser for embedding in another pattern's ``extra_types``.
+
+    The parent pattern refers to a custom type name; the value is this wrapper,
+    which delegates parsing of the captured substring to ``parser``.
+
+    Example::
+
+        >>> from formatparse import compile, composed_type
+        >>> ts = compile("{year:d}-{month:02d}-{day:02d}")
+        >>> log = compile(
+        ...     "{ts:Timestamp} [{level}] {msg}",
+        ...     extra_types={"Timestamp": composed_type(ts)},
+        ... )
+        >>> r = log.parse("2024-01-15 [ERROR] oops")
+        >>> r.named["level"]
+        'ERROR'
+        >>> r.named["msg"]
+        'oops'
+        >>> inner = r.named["ts"]
+        >>> inner.named["year"], inner.named["month"], inner.named["day"]
+        (2024, 1, 15)
+
+    :param parser: Child parser produced by :func:`compile`.
+    :returns: Callable with ``pattern`` / ``regex_group_count`` set for composition.
+
+    .. note::
+        Pattern ``+``, inheritance, and flattening nested fields into the parent
+        result are not implemented yet (see issue #7).
+    """
+    return ComposedType(parser)
+
+
 class BidirectionalPattern:
     """A bidirectional pattern that can parse and format strings.
 
@@ -961,4 +1028,6 @@ __all__ = [
     "findall_iter",
     "FindallIter",
     "with_pattern",
+    "composed_type",
+    "ComposedType",
 ]

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,46 @@
+"""Composition MVP: embed compiled parsers via extra_types (GitHub issue #7)."""
+
+import pytest
+
+from formatparse import ComposedType, ParseResult, compile, composed_type
+
+
+def test_composed_log_line_nested_parse_result():
+    ts = compile("{year:d}-{month:02d}-{day:02d}")
+    log = compile(
+        "{ts:Timestamp} [{level}] {msg}",
+        extra_types={"Timestamp": composed_type(ts)},
+    )
+    r = log.parse("2024-01-15 [ERROR] oops")
+    assert r is not None
+    assert r.named["level"] == "ERROR"
+    assert r.named["msg"] == "oops"
+    inner = r.named["ts"]
+    assert isinstance(inner, ParseResult)
+    assert inner.named["year"] == 2024
+    assert inner.named["month"] == 1
+    assert inner.named["day"] == 15
+
+
+def test_composed_type_exposes_pattern_and_group_count():
+    ts = compile("{a:d}")
+    c = composed_type(ts)
+    assert isinstance(c, ComposedType)
+    assert isinstance(c.pattern, str) and len(c.pattern) > 0
+    assert isinstance(c.regex_group_count, int)
+    assert c.regex_group_count >= 1
+
+
+def test_wrong_regex_group_count_still_errors_at_parent_compile():
+    ts = compile("{x:d}-{y:d}")
+    good = composed_type(ts)
+
+    class BadConverter:
+        pattern = good.pattern
+        regex_group_count = 0
+
+        def __call__(self, text: str) -> None:
+            return None
+
+    with pytest.raises(ValueError, match="capturing groups"):
+        compile("{z:Bad}", extra_types={"Bad": BadConverter()})


### PR DESCRIPTION
## Summary

Implements a **narrow composition MVP** for [issue #7](https://github.com/eddiethedean/formatparse/issues/7): reuse the existing `extra_types` pipeline (`pattern` + `regex_group_count`) with a compiled child `FormatParser`, returning a nested `ParseResult` for that field.

## Changes

- **Rust:** `FormatParser.regex_subpattern` and `FormatParser.regex_capturing_group_count` (raw `regex_str` body + `count_capturing_groups`; documented vs `_expression`).
- **Python:** `ComposedType` and `composed_type(parser)`; module docstring + `__all__`.
- **Tests:** `tests/test_composition.py` (log line + nested date, property exposure, validation error when `regex_group_count` mismatches).

## Deferred (not this PR)

- Pattern `+` operator, inheritance / extension, flattening nested fields into parent results, recursive nested format strings (#12), changing pickle to embed child parsers.

Progresses #7