### PR TITLE
feat: add ValidationPipeline MVP (#11)

### DIFF
--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -21,11 +21,12 @@ after unpickling, including any composed child parsers (see `GitHub issue #7
 <https://github.com/eddiethedean/formatparse/issues/7>`_).
 
 **Post-parse validators:** after :func:`parse` or :meth:`FormatParser.parse`, run
-callables with :func:`apply_validators`, or pass ``validators=`` to :func:`parse`
-(see `GitHub issue #10 <https://github.com/eddiethedean/formatparse/issues/10>`_).
+callables with :func:`apply_validators`, or pass ``validators=`` / ``pipeline=`` to
+:func:`parse`. See `GitHub issue #10 <https://github.com/eddiethedean/formatparse/issues/10>`_
+and `GitHub issue #11 <https://github.com/eddiethedean/formatparse/issues/11>`_.
+Use :class:`ValidationPipeline` to register steps then :meth:`~ValidationPipeline.apply`.
 Keys are field names (``str``) or positional indices (``int`` for ``fixed``).
-In-process ``{...:validator(...)}`` syntax and async pipelines are deferred
-(issues #10 / #11).
+Inline ``{...:validator(...)}`` syntax and async pipelines are deferred.
 """
 
 from __future__ import annotations
@@ -264,6 +265,83 @@ def apply_validators(
     return result
 
 
+class ValidationPipeline:
+    """Ordered registry of per-field validators (GitHub issue #11 MVP).
+
+    Build with :meth:`add_validator`, then :meth:`apply` on a :class:`ParseResult`.
+    Field keys follow the same convention as :func:`apply_validators` (``str`` for
+    named fields, ``int`` for ``fixed`` indices). If the same field is registered
+    twice, the **last** registration wins.
+
+    Async validators, Rust ``parse_with_validation``, and lenient logging modes
+    are out of scope for this MVP (see issue #11).
+    """
+
+    __slots__ = ("_steps",)
+
+    def __init__(self) -> None:
+        self._steps: List[Tuple[Union[str, int], Callable[..., Any]]] = []
+
+    def add_validator(
+        self,
+        field: Union[str, int],
+        fn: Callable[..., Any],
+    ) -> ValidationPipeline:
+        """Register ``fn`` for ``field``; returns ``self`` for chaining."""
+        self._steps.append((field, fn))
+        return self
+
+    def as_mapping(self) -> Dict[Union[str, int], Callable[..., Any]]:
+        """Last registration per field wins (dict built in ``add_validator`` order)."""
+        m: Dict[Union[str, int], Callable[..., Any]] = {}
+        for k, fn in self._steps:
+            m[k] = fn
+        return m
+
+    def apply(
+        self,
+        result: Optional[ParseResult],
+        *,
+        mode: ValidationMode = "strict",
+    ) -> Optional[ParseResult]:
+        """Run all validators; same semantics as :func:`apply_validators`."""
+        return apply_validators(result, self.as_mapping(), mode=mode)
+
+
+def in_range(
+    min_value: Optional[Union[int, float]] = None,
+    max_value: Optional[Union[int, float]] = None,
+) -> Callable[[Union[int, float]], None]:
+    """Return a validator that accepts numeric ``value`` within ``[min_value, max_value]``."""
+
+    def check(value: Union[int, float]) -> None:
+        if min_value is not None and value < min_value:
+            raise ValidationError(
+                f"expected value >= {min_value!r}, got {value!r}",
+            )
+        if max_value is not None and value > max_value:
+            raise ValidationError(
+                f"expected value <= {max_value!r}, got {value!r}",
+            )
+
+    return check
+
+
+def non_empty_str(value: Any) -> None:
+    """Reject ``None``, non-strings, or blank/whitespace-only strings."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError("expected non-empty string")
+
+
+def _validation_source_exclusive(
+    *,
+    validators: Optional[ValidatorMap],
+    pipeline: Optional[ValidationPipeline],
+) -> None:
+    if validators is not None and pipeline is not None:
+        raise ValueError("pass only one of validators= or pipeline=")
+
+
 # Wrap compile to catch RepeatedNameError
 def compile(pattern: str, extra_types: Optional[ExtraTypes] = None) -> FormatParser:
     """Compile a pattern into a FormatParser for repeated use.
@@ -337,6 +415,7 @@ def parse(
     evaluate_result: bool = True,
     *,
     validators: Optional[ValidatorMap] = None,
+    pipeline: Optional[ValidationPipeline] = None,
     validation_mode: ValidationMode = "strict",
 ) -> Optional[ParseResult]:
     """Parse a string using a format specification.
@@ -359,13 +438,13 @@ def parse(
     :type case_sensitive: bool
     :param evaluate_result: Whether to evaluate and convert result types (default: True)
     :type evaluate_result: bool
-    :param validators: Optional map of field key (``str`` name or ``int`` ``fixed`` index)
-        to validator callable; see :func:`apply_validators`.
-    :param validation_mode: ``\"strict\"`` or ``\"collect\"`` for :func:`apply_validators`.
+    :param validators: Optional map of field key to validator; see :func:`apply_validators`.
+    :param pipeline: Optional :class:`ValidationPipeline` (mutually exclusive with ``validators``).
+    :param validation_mode: ``\"strict\"`` or ``\"collect\"`` for validation.
     :returns: ParseResult object if match found, None otherwise
     :rtype: ParseResult or None
-    :raises ValueError: If pattern is invalid
-    :raises ValidationError: If ``validators`` is set and validation fails in strict mode
+    :raises ValueError: If pattern is invalid, or both ``validators`` and ``pipeline`` are set
+    :raises ValidationError: If validation fails in strict mode
     :raises MultipleValidationErrors: If ``validation_mode='collect'`` and any validator fails
 
     Example::
@@ -379,12 +458,15 @@ def parse(
         >>> result.fixed
         ('Hello', 'World')
     """
+    _validation_source_exclusive(validators=validators, pipeline=pipeline)
     r = _parse(pattern, string, extra_types, case_sensitive, evaluate_result)
+    if pipeline is not None:
+        return pipeline.apply(r, mode=validation_mode)
     return apply_validators(r, validators, mode=validation_mode)
 
 
 class ValidatedParser:
-    """Thin wrapper around :class:`FormatParser` with optional ``validators`` on :meth:`parse`.
+    """Thin wrapper around :class:`FormatParser` with optional ``validators`` / ``pipeline`` on :meth:`parse`.
 
     Other attributes and methods are forwarded to the inner parser (e.g. ``search``,
     ``pattern``). Use when you compile once and want the same validation ergonomics
@@ -407,9 +489,13 @@ class ValidatedParser:
         evaluate_result: bool = True,
         *,
         validators: Optional[ValidatorMap] = None,
+        pipeline: Optional[ValidationPipeline] = None,
         validation_mode: ValidationMode = "strict",
     ) -> Optional[ParseResult]:
+        _validation_source_exclusive(validators=validators, pipeline=pipeline)
         r = self._parser.parse(string, case_sensitive, extra_types, evaluate_result)
+        if pipeline is not None:
+            return pipeline.apply(r, mode=validation_mode)
         return apply_validators(r, validators, mode=validation_mode)
 
 
@@ -1219,6 +1305,9 @@ __all__ = [
     "ValidationMode",
     "ValidatorMap",
     "apply_validators",
+    "ValidationPipeline",
+    "in_range",
+    "non_empty_str",
     "validator",
     "ValidatedParser",
 ]

--- a/tests/test_validation_pipeline.py
+++ b/tests/test_validation_pipeline.py
@@ -1,0 +1,87 @@
+"""ValidationPipeline and built-in validators (GitHub issue #11 MVP)."""
+
+import pytest
+
+from formatparse import (
+    MultipleValidationErrors,
+    ValidationError,
+    ValidationPipeline,
+    ValidatedParser,
+    apply_validators,
+    compile,
+    in_range,
+    non_empty_str,
+    parse,
+)
+
+
+def test_pipeline_apply_delegates_to_collect():
+    p = ValidationPipeline()
+    p.add_validator("a", lambda v: (_ for _ in ()).throw(ValidationError("bad a")))
+    p.add_validator("b", lambda v: (_ for _ in ()).throw(ValidationError("bad b")))
+    r = parse("{a:d}-{b:d}", "1-2")
+    assert r is not None
+    with pytest.raises(MultipleValidationErrors) as exc:
+        p.apply(r, mode="collect")
+    assert {e.field for e in exc.value.errors} == {"a", "b"}
+
+
+def test_pipeline_last_validator_wins_same_field():
+    pipe = (
+        ValidationPipeline()
+        .add_validator("x", lambda _: None)
+        .add_validator("x", lambda _: (_ for _ in ()).throw(ValidationError("second")))
+    )
+    r = parse("{x:d}", "1")
+    assert r is not None
+    with pytest.raises(ValidationError, match="second"):
+        pipe.apply(r)
+
+
+def test_parse_with_pipeline_keyword():
+    pl = ValidationPipeline().add_validator("x", in_range(0, 5))
+    r = parse("{x:d}", "3", pipeline=pl)
+    assert r is not None
+    assert r.named["x"] == 3
+
+
+    pl = ValidationPipeline().add_validator("a", lambda _: None)
+    with pytest.raises(ValueError, match="only one of"):
+        parse("{a:d}", "1", validators={"a": lambda _: None}, pipeline=pl)
+
+
+def test_validated_parser_with_pipeline():
+    pl = (
+        ValidationPipeline()
+        .add_validator("age", in_range(0, 150))
+        .add_validator("name", non_empty_str)
+    )
+    vp = ValidatedParser(compile("{name} {age:d}"))
+    r = vp.parse("Ann 40", pipeline=pl)
+    assert r is not None
+    assert r.named["name"] == "Ann"
+    assert r.named["age"] == 40
+
+
+def test_validated_parser_pipeline_conflict():
+    pl = ValidationPipeline().add_validator("a", lambda _: None)
+    vp = ValidatedParser(compile("{a:d}"))
+    with pytest.raises(ValueError, match="only one of"):
+        vp.parse("1", validators={"a": lambda _: None}, pipeline=pl)
+
+
+def test_in_range_pass_and_fail():
+    r = parse("{n:d}", "10", validators={"n": in_range(1, 20)})
+    assert r is not None
+    assert r.named["n"] == 10
+    r2 = parse("{n:d}", "99")
+    assert r2 is not None
+    with pytest.raises(ValidationError, match="expected value <="):
+        apply_validators(r2, {"n": in_range(1, 20)})
+
+
+def test_non_empty_str():
+    r = parse("{s}", "hi", validators={"s": non_empty_str})
+    assert r is not None
+    with pytest.raises(ValidationError, match="non-empty"):
+        parse("{s}", "   ", validators={"s": non_empty_str})


### PR DESCRIPTION
## Summary

MVP for [issue #11](https://github.com/eddiethedean/formatparse/issues/11) on top of #10 validation: **`ValidationPipeline`**, **`parse(..., pipeline=...)`**, **`ValidatedParser.parse(..., pipeline=...)`**, and small helpers **`in_range`**, **`non_empty_str`**.

## API

- `ValidationPipeline.add_validator(field, fn)` (chainable) / `apply(result, mode=...)` → delegates to `apply_validators`; last registration wins per field.
- `validators=` and `pipeline=` are mutually exclusive on `parse` and `ValidatedParser.parse` (`ValueError` if both set).

## Deferred

- Async / DB hooks, Rust `parse_with_validation`, lenient logging mode, full built-in library (email, URL, phone), cross-field hooks.

Progresses #11