### PR TITLE
feat: support width/alignment with multiline :ml (#70)

### DIFF
--- a/formatparse-core/src/types/definitions.rs
+++ b/formatparse-core/src/types/definitions.rs
@@ -26,7 +26,8 @@ pub enum FieldType {
     DateTimeStrftime,    // For %Y-%m-%d style patterns
     /// Match `{...}` in the input; capture inner text (non-greedy to first `}`). Issue #15 / parse#146.
     BracedContent,
-    /// Multiline text between anchors; format specifier `:ml` (GitHub issue #8). MVP: no width/align.
+    /// Multiline text between anchors; format specifier `:ml` (issues #8, #70). Supports
+    /// width, precision, alignment, and fill like strings; sign / zero-padding / ``=`` align not supported.
     Multiline,
     Custom(String),
 }

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -106,8 +106,39 @@ impl FieldSpec {
                 }
             }
             FieldType::Multiline => {
-                // Non-greedy any-char including newlines; does not rely on DOTALL for this fragment.
-                r"[\s\S]+?".to_string()
+                // Same layout as strings, but ``.`` cannot span newlines in Rust regex; use ``[\s\S]``.
+                const ML: &str = "[\\s\\S]";
+                if let Some(prec) = self.precision {
+                    if let Some(align) = self.alignment {
+                        let fill_ch = self.fill.unwrap_or(' ');
+                        let fill_escaped = regex::escape(&fill_ch.to_string());
+                        match align {
+                            '<' => format!("{}{{{}}}(?:{}*)", ML, prec, fill_escaped),
+                            '>' => format!("(?:{}*){}{{{}}}", fill_escaped, ML, prec),
+                            '^' => format!(
+                                "(?:{}*){}{{{}}}(?:{}*)",
+                                fill_escaped, ML, prec, fill_escaped
+                            ),
+                            _ => format!("{}{{{}}}", ML, prec),
+                        }
+                    } else {
+                        format!("{}{{{}}}", ML, prec)
+                    }
+                } else if let Some(width) = self.width {
+                    match next_field_is_greedy {
+                        Some(false) => format!("{}{{{}}}", ML, width),
+                        _ => format!("{}{{{},}}", ML, width),
+                    }
+                } else if self.alignment.is_some() {
+                    match self.alignment {
+                        Some('<') => format!("({}+?)(?:\\s*)", ML),
+                        Some('>') => format!(" *({}+?)", ML),
+                        Some('^') => format!("(?:\\s*)({}+?)(?:\\s*)", ML),
+                        _ => format!("{}+?", ML),
+                    }
+                } else {
+                    r"[\s\S]+?".to_string()
+                }
             }
             FieldType::Integer => {
                 let sign = self
@@ -400,11 +431,41 @@ mod tests {
     }
 
     #[test]
-    fn test_field_spec_multiline() {
+    fn test_field_spec_multiline_with_width() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Multiline;
+        spec.width = Some(3);
         let pattern = spec.to_regex_pattern(&HashMap::new(), None);
-        assert_eq!(pattern, r"[\s\S]+?");
+        assert_eq!(pattern, r"[\s\S]{3,}");
+    }
+
+    #[test]
+    fn test_field_spec_multiline_with_width_exact_next_field() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Multiline;
+        spec.width = Some(4);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), Some(false));
+        assert_eq!(pattern, r"[\s\S]{4}");
+    }
+
+    #[test]
+    fn test_field_spec_multiline_align_right() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Multiline;
+        spec.alignment = Some('>');
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        assert_eq!(pattern, r" *([\s\S]+?)");
+    }
+
+    #[test]
+    fn test_field_spec_multiline_precision_left_fill() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Multiline;
+        spec.precision = Some(3);
+        spec.alignment = Some('<');
+        spec.fill = Some('.');
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        assert_eq!(pattern, r"[\s\S]{3}(?:\.*)");
     }
 
     #[test]

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -314,20 +314,22 @@ pub fn normalize_field_name(
     normalized
 }
 
-/// Reject `:ml` combined with width, precision, alignment, etc. (MVP; GitHub issue #8).
+/// Reject `:ml` combined with numeric-only format specifiers (GitHub issues #8, #70).
+///
+/// Width, precision, alignment, and fill are supported for multiline fields; ``sign``,
+/// ``zero_pad``, and ``=`` alignment remain unsupported.
 pub fn validate_multiline_mvp(spec: &FieldSpec) -> PyResult<()> {
     if !matches!(spec.field_type, FieldType::Multiline) {
         return Ok(());
     }
-    if spec.width.is_some()
-        || spec.precision.is_some()
-        || spec.alignment.is_some()
-        || spec.fill.is_some()
-        || spec.sign.is_some()
-        || spec.zero_pad
-    {
+    if spec.sign.is_some() || spec.zero_pad {
         return Err(error::pattern_error(
-            "Multiline type :ml does not support width, precision, alignment, fill, sign, or zero-padding",
+            "Multiline type :ml does not support sign or zero-padding",
+        ));
+    }
+    if spec.alignment == Some('=') {
+        return Err(error::pattern_error(
+            "Multiline type :ml does not support '=' alignment",
         ));
     }
     Ok(())

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -9,9 +9,10 @@ with :func:`with_pattern`. See :func:`compile` and the `Custom types user guide
 <https://formatparse.readthedocs.io/en/latest/user_guides/custom_types.html>`_.
 
 **Multiline text:** use ``{name:ml}`` when a single field may span newlines; the
-capture is non-greedy up to the next literal or field in the pattern. Width,
-precision, and alignment are not supported with ``:ml`` in the current release
-(see `GitHub issue #8 <https://github.com/eddiethedean/formatparse/issues/8>`_).
+capture is non-greedy up to the next literal or field. Width, precision, alignment,
+and fill are supported like plain string fields (see `GitHub issue #70
+<https://github.com/eddiethedean/formatparse/issues/70>`_); sign, zero-padding, and
+``=`` alignment are not supported with ``:ml``.
 
 **Composition (sub-parsers):** use :func:`composed_type` to wrap a compiled
 :class:`FormatParser` and pass it in ``extra_types`` so one field is parsed by the

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -1,4 +1,4 @@
-"""Multiline field type ``:ml`` (GitHub issue #8)."""
+"""Multiline field type ``:ml`` (issues #8, #70)."""
 
 import pytest
 
@@ -27,9 +27,62 @@ def test_compile_ml_pattern():
     assert r.named["body"] == "a\nb"
 
 
-def test_ml_rejects_width():
-    with pytest.raises(ValueError, match="Multiline"):
-        compile("{x:10ml}")
+def test_compile_ml_with_width():
+    p = compile("START\n{body:5ml}\nEND")
+    r = p.parse("START\nabcde\nEND")
+    assert r is not None
+    assert r.named["body"] == "abcde"
+
+
+def test_ml_width_greedy_between_anchors():
+    r = parse("BEGIN\n{body:3ml}\nEND", "BEGIN\nabc\nEND")
+    assert r is not None
+    assert r.named["body"] == "abc"
+
+
+def test_ml_alignment_right_strip_leading_spaces():
+    r = parse("<<<{body:>ml}>>>", "<<<      hi\nthere>>>")
+    assert r is not None
+    assert r.named["body"] == "hi\nthere"
+
+
+def test_ml_alignment_left_trailing_spaces_trimmed():
+    r = parse("<<<{body:<ml}>>>", "<<<hi\nthere      >>>")
+    assert r is not None
+    assert r.named["body"] == "hi\nthere"
+
+
+def test_ml_alignment_center():
+    r = parse("<<<{body:^ml}>>>", "<<<   x\ny   >>>")
+    assert r is not None
+    assert r.named["body"] == "x\ny"
+
+
+def test_ml_left_align_with_width_keeps_padding():
+    r = parse("value: {body:<10ml}", "value: hi\nthere     ")
+    assert r is not None
+    assert r.named["body"] == "hi\nthere     "
+
+
+def test_ml_precision_exact_multiline():
+    r = parse("X{body:.5ml}Y", "Xa\nb\ncY")
+    assert r is not None
+    assert r.named["body"] == "a\nb\nc"
+
+
+def test_ml_rejects_sign():
+    with pytest.raises(ValueError, match="sign"):
+        compile("{x:+ml}")
+
+
+def test_ml_rejects_zero_pad():
+    with pytest.raises(ValueError, match="zero"):
+        compile("{x:05ml}")
+
+
+def test_ml_rejects_equals_alignment():
+    with pytest.raises(ValueError, match="='"):
+        compile("{x:=10ml}")
 
 
 def test_plain_brace_newline_regression():


### PR DESCRIPTION
Fixes #70

- `:ml` fields now accept the same width / precision / alignment / fill layout as strings in `to_regex_pattern`, using `[\s\S]` so newlines are included in quantified spans.
- Still rejected for multiline: `sign`, `zero_pad`, and `=` alignment (numeric formatting).
- Python module docs and `FieldType::Multiline` comment updated; regression and new integration tests in `tests/test_multiline.py`.