### PR TITLE
feat: add is_valid_email and is_valid_url validators (#11)

### DIFF
--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -29,8 +29,10 @@ Use :class:`ValidationPipeline` for per-field steps (:meth:`~ValidationPipeline.
 and whole-result hooks (:meth:`~ValidationPipeline.add_hook`), then
 :meth:`~ValidationPipeline.apply`. Field keys are names (``str``) or ``fixed`` indices
 (``int``). ``validation_mode='lenient'`` logs validator and hook failures with
-:func:`warnings.warn` and still returns the :class:`ParseResult`. Inline ``{...:validator(...)}``
-syntax and async pipelines are deferred.
+:func:`warnings.warn` and still returns the :class:`ParseResult`. Built-ins
+:func:`in_range`, :func:`non_empty_str`, :func:`is_valid_email`, and :func:`is_valid_url`
+help with common checks (email/URL are heuristic, not full RFC or security audits).
+Inline ``{...:validator(...)}`` syntax and async pipelines are deferred.
 """
 
 from __future__ import annotations
@@ -55,6 +57,7 @@ from typing import (
 import re
 import warnings
 from importlib.metadata import PackageNotFoundError, version as _package_version
+from urllib.parse import urlparse
 
 # PEP 440 string for the installed distribution; falls back to workspace Cargo.toml
 # when running from a source checkout without package metadata (see issue #38).
@@ -449,6 +452,43 @@ def non_empty_str(value: Any) -> None:
     """Reject ``None``, non-strings, or blank/whitespace-only strings."""
     if not isinstance(value, str) or not value.strip():
         raise ValidationError("expected non-empty string")
+
+
+# Practical ``user@host`` check (not full RFC 5322 / internationalized email).
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+
+
+def is_valid_email(value: Any) -> None:
+    """Reject values that are not plausible ``user@domain`` mailbox strings.
+
+    Uses a simple ASCII pattern suitable for post-parse validation only. It does
+    not implement full RFC 5322 (no quoted-string local parts, no comments) and is
+    not a deliverability or security check.
+
+    :raises ValidationError: If ``value`` is not a non-empty string matching the pattern.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError("expected a non-empty string for email")
+    if not _EMAIL_RE.fullmatch(value.strip()):
+        raise ValidationError("invalid email address")
+
+
+def is_valid_url(value: Any) -> None:
+    """Reject values that are not ``http`` or ``https`` URLs with a non-empty host.
+
+    Uses :func:`urllib.parse.urlparse`. This does not verify reachability, TLS, or
+    that the resource exists.
+
+    :raises ValidationError: If the string is empty, the scheme is not ``http``/``https``,
+        or the parsed URL has no network location (host).
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError("expected a non-empty string for URL")
+    parsed = urlparse(value.strip())
+    if parsed.scheme not in ("http", "https"):
+        raise ValidationError("expected URL with http or https scheme")
+    if not parsed.netloc:
+        raise ValidationError("invalid URL: missing host")
 
 
 def _validation_source_exclusive(
@@ -1431,6 +1471,8 @@ __all__ = [
     "ValidationPipeline",
     "in_range",
     "non_empty_str",
+    "is_valid_email",
+    "is_valid_url",
     "validator",
     "ValidatedParser",
 ]

--- a/tests/test_builtin_validators.py
+++ b/tests/test_builtin_validators.py
@@ -1,0 +1,79 @@
+"""Built-in post-parse validators (issue #11): email and URL."""
+
+import pytest
+
+from formatparse import (
+    ValidationError,
+    ValidationPipeline,
+    ValidationWarning,
+    is_valid_email,
+    is_valid_url,
+    parse,
+)
+
+
+def test_is_valid_email_accepts_common_forms():
+    is_valid_email("user@example.com")
+    is_valid_email("  u.name+tag@host.co.uk  ")
+    is_valid_email("a@b.co")
+
+
+def test_is_valid_email_rejects():
+    with pytest.raises(ValidationError, match="non-empty string"):
+        is_valid_email("")
+    with pytest.raises(ValidationError, match="non-empty string"):
+        is_valid_email("   ")
+    with pytest.raises(ValidationError, match="invalid email"):
+        is_valid_email("not-an-email")
+    with pytest.raises(ValidationError, match="invalid email"):
+        is_valid_email("@host.com")
+    with pytest.raises(ValidationError, match="invalid email"):
+        is_valid_email("user@")
+    with pytest.raises(ValidationError, match="non-empty string"):
+        is_valid_email(None)  # type: ignore[arg-type]
+
+
+def test_is_valid_url_accepts_http_https():
+    is_valid_url("https://example.com/path?q=1")
+    is_valid_url("http://127.0.0.1:8080/")
+    is_valid_url("http://localhost/foo")
+
+
+def test_is_valid_url_rejects():
+    with pytest.raises(ValidationError, match="non-empty string"):
+        is_valid_url("")
+    with pytest.raises(ValidationError, match="http or https"):
+        is_valid_url("ftp://example.com/")
+    with pytest.raises(ValidationError, match="http or https"):
+        is_valid_url("mailto:a@b.com")
+    with pytest.raises(ValidationError, match="missing host"):
+        is_valid_url("https://")
+    with pytest.raises(ValidationError, match="missing host"):
+        is_valid_url("http:///path")
+    with pytest.raises(ValidationError, match="non-empty string"):
+        is_valid_url(None)  # type: ignore[arg-type]
+
+
+def test_parse_with_is_valid_url():
+    r = parse("{u}", "https://x.example/", validators={"u": is_valid_url})
+    assert r is not None
+    assert r.named["u"] == "https://x.example/"
+
+
+def test_parse_strict_is_valid_email_raises():
+    with pytest.raises(ValidationError, match="invalid email"):
+        parse("{e}", "bad", validators={"e": is_valid_email})
+
+
+def test_parse_lenient_is_valid_email_warns():
+    with pytest.warns(ValidationWarning, match="invalid email"):
+        r = parse("{e}", "bad", validators={"e": is_valid_email}, validation_mode="lenient")
+    assert r is not None
+    assert r.named["e"] == "bad"
+
+
+def test_validation_pipeline_is_valid_email():
+    pl = ValidationPipeline().add_validator("e", is_valid_email)
+    r = parse("{e}", "hi@there.org")
+    assert r is not None
+    pl.apply(r)


### PR DESCRIPTION
Progresses #11

Adds post-parse helpers `is_valid_email` and `is_valid_url` (stdlib `urllib.parse` for URLs; practical ASCII pattern for mailboxes—documented as non–RFC-5322-complete). Exported from the public package.

**Still deferred on #11:** phone/date builtins, `parse_with_validation`, async validators, transform chains, inline `{...:validator(...)}` syntax.