### PR TITLE
feat: backslash line continuations in format patterns (#68)

### DIFF
--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -4,7 +4,6 @@
 
 use lru::LruCache;
 use once_cell::sync::Lazy;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use pyo3::IntoPyObjectExt;
@@ -20,6 +19,7 @@ mod datetime;
 mod error;
 mod match_rs;
 mod parser;
+mod pattern_normalize;
 mod result;
 mod results;
 mod types;
@@ -92,7 +92,8 @@ fn get_or_create_parser(
     pattern: &str,
     extra_types: Option<HashMap<String, PyObject>>,
 ) -> PyResult<Arc<FormatParser>> {
-    let cache_key = Python::with_gil(|py| create_cache_key_hash(py, pattern, &extra_types));
+    let normalized = pattern_normalize::prepare_compiled_pattern(pattern)?;
+    let cache_key = Python::with_gil(|py| create_cache_key_hash(py, &normalized, &extra_types));
 
     // Try to get from cache (minimize lock scope)
     let cached = {
@@ -105,7 +106,10 @@ fn get_or_create_parser(
     }
 
     // Not in cache, create new parser
-    let parser = Arc::new(FormatParser::new_with_extra_types(pattern, extra_types)?);
+    let parser = Arc::new(FormatParser::new_with_extra_types(
+        &normalized,
+        extra_types,
+    )?);
 
     // Store in cache (minimize lock scope)
     {
@@ -127,17 +131,10 @@ fn parse(
     evaluate_result: bool,
 ) -> PyResult<Option<PyObject>> {
     // Validate input lengths
-    formatparse_core::validate_pattern_length(pattern)
-        .map_err(pyo3::exceptions::PyValueError::new_err)?;
     formatparse_core::validate_input_length(string)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
 
     // Check for null bytes in inputs
-    if pattern.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "Pattern contains null byte",
-        ));
-    }
     if string.contains('\0') {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "Input string contains null byte",
@@ -189,14 +186,6 @@ fn parse_batch(
     case_sensitive: bool,
     evaluate_result: bool,
 ) -> PyResult<PyObject> {
-    formatparse_core::validate_pattern_length(pattern)
-        .map_err(pyo3::exceptions::PyValueError::new_err)?;
-    if pattern.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "Pattern contains null byte",
-        ));
-    }
-
     for s in &strings {
         formatparse_core::validate_input_length(s)
             .map_err(pyo3::exceptions::PyValueError::new_err)?;
@@ -277,17 +266,10 @@ fn search(
     }
 
     // Validate input lengths
-    formatparse_core::validate_pattern_length(pattern)
-        .map_err(pyo3::exceptions::PyValueError::new_err)?;
     formatparse_core::validate_input_length(string)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
 
     // Check for null bytes in inputs
-    if pattern.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "Pattern contains null byte",
-        ));
-    }
     if string.contains('\0') {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "Input string contains null byte",
@@ -336,17 +318,10 @@ fn findall(
     evaluate_result: bool,
 ) -> PyResult<PyObject> {
     // Validate input lengths
-    formatparse_core::validate_pattern_length(pattern)
-        .map_err(pyo3::exceptions::PyValueError::new_err)?;
     formatparse_core::validate_input_length(string)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
 
     // Check for null bytes in inputs
-    if pattern.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "Pattern contains null byte",
-        ));
-    }
     if string.contains('\0') {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "Input string contains null byte",
@@ -488,16 +463,9 @@ fn findall_iter(
     case_sensitive: bool,
     evaluate_result: bool,
 ) -> PyResult<Py<FindallIter>> {
-    formatparse_core::validate_pattern_length(pattern)
-        .map_err(pyo3::exceptions::PyValueError::new_err)?;
     formatparse_core::validate_input_length(string)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
 
-    if pattern.contains('\0') {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "Pattern contains null byte",
-        ));
-    }
     if string.contains('\0') {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "Input string contains null byte",
@@ -547,14 +515,6 @@ fn compile(
     pattern: &str,
     extra_types: Option<HashMap<String, PyObject>>,
 ) -> PyResult<FormatParser> {
-    // Validate pattern length
-    formatparse_core::validate_pattern_length(pattern).map_err(PyValueError::new_err)?;
-
-    // Check for null bytes in pattern
-    if pattern.contains('\0') {
-        return Err(PyValueError::new_err("Pattern contains null byte"));
-    }
-
     let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
         extra_types.as_ref().map(|et| {
             et.iter()

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -3,7 +3,7 @@ use crate::parser::matching::{
     match_with_captures, match_with_captures_raw, CapturedMatchContext, FieldCaptureSlices,
 };
 use formatparse_core::count_capturing_groups;
-use formatparse_core::parser::{validate_input_length, validate_pattern_length, MAX_FIELDS};
+use formatparse_core::parser::{validate_input_length, MAX_FIELDS};
 use formatparse_core::FieldSpec;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -56,15 +56,7 @@ impl FormatParser {
         pattern: &str,
         extra_types: Option<HashMap<String, PyObject>>,
     ) -> PyResult<Self> {
-        // Validate pattern length
-        validate_pattern_length(pattern).map_err(PyValueError::new_err)?;
-
-        // Check for null bytes in pattern
-        if pattern.contains('\0') {
-            return Err(PyValueError::new_err("Pattern contains null byte"));
-        }
-
-        // Extract patterns from converter functions and build custom_patterns map
+        let pattern_owned = crate::pattern_normalize::prepare_compiled_pattern(pattern)?;
         let custom_patterns = Python::with_gil(|py| -> PyResult<HashMap<String, String>> {
             let mut patterns = HashMap::new();
             if let Some(ref extra_types_map) = extra_types {
@@ -89,7 +81,11 @@ impl FormatParser {
             normalized_names,
             name_mapping,
             allows_empty_default_string_match,
-        ) = crate::parser::pattern::parse_pattern(pattern, extra_types.as_ref(), &custom_patterns)?;
+        ) = crate::parser::pattern::parse_pattern(
+            &pattern_owned,
+            extra_types.as_ref(),
+            &custom_patterns,
+        )?;
 
         // Validate field count
         if field_specs.len() > MAX_FIELDS {
@@ -147,7 +143,7 @@ impl FormatParser {
             formatparse_core::build_search_regex(regex.as_str(), false).ok();
 
         Ok(Self {
-            pattern: pattern.to_string(),
+            pattern: pattern_owned,
             regex,
             regex_str,
             regex_case_insensitive,
@@ -319,11 +315,7 @@ impl FormatParser {
         extra_types: Option<HashMap<String, PyObject>>,
     ) -> PyResult<Self> {
         match pattern {
-            Some(p) => {
-                // Validate pattern length if provided
-                validate_pattern_length(p).map_err(PyValueError::new_err)?;
-                Self::new_with_extra_types(p, extra_types)
-            }
+            Some(p) => Self::new_with_extra_types(p, extra_types),
             None => {
                 // Create a dummy instance for unpickling - __setstate__ will initialize it properly
                 // We need to create a valid but minimal instance

--- a/formatparse-pyo3/src/pattern_normalize.rs
+++ b/formatparse-pyo3/src/pattern_normalize.rs
@@ -1,0 +1,122 @@
+//! Backslash–newline line continuations in format **pattern** strings (GitHub issue #68).
+//!
+//! A run of `k` backslashes immediately before a line ending (`\n` or `\r\n`) is handled
+//! like common escaping rules: if `k` is odd, the line continues (the last backslash
+//! plus the line break are removed, and `floor((k-1)/2)` literal backslashes are kept);
+//! if `k` is even, `k/2` literal backslashes are kept and the line break is preserved.
+//! After a continuation, ASCII spaces and tabs at the start of the next physical line are
+//! stripped so indented continued fragments do not insert unwanted literals. Other
+//! characters—including a leading newline on the next line—are kept, so a blank
+//! continuation line can be used to emit a literal line break right after a join.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::PyResult;
+
+/// Fold backslash line continuations; does not validate length or null bytes.
+pub fn normalize_pattern_line_continuations(pattern: &str) -> String {
+    let b = pattern.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0usize;
+    while i < b.len() {
+        let start = i;
+        let mut j = i;
+        while j < b.len() && b[j] != b'\n' && b[j] != b'\r' {
+            j += 1;
+        }
+        let seg = &b[start..j];
+        if j == b.len() {
+            out.extend_from_slice(seg);
+            break;
+        }
+        let mut k = 0usize;
+        let mut p = seg.len();
+        while p > 0 && seg[p - 1] == b'\\' {
+            k += 1;
+            p -= 1;
+        }
+        let prefix_end = seg.len().saturating_sub(k);
+        if k % 2 == 1 {
+            out.extend_from_slice(&seg[..prefix_end]);
+            let emit = (k - 1) / 2;
+            out.extend(std::iter::repeat_n(b'\\', emit));
+            if b[j] == b'\r' && j + 1 < b.len() && b[j + 1] == b'\n' {
+                i = j + 2;
+            } else {
+                i = j + 1;
+            }
+            while i < b.len() && matches!(b[i], b' ' | b'\t') {
+                i += 1;
+            }
+        } else {
+            out.extend_from_slice(seg);
+            if b[j] == b'\r' && j + 1 < b.len() && b[j + 1] == b'\n' {
+                out.push(b'\r');
+                out.push(b'\n');
+                i = j + 2;
+            } else {
+                out.push(b[j]);
+                i = j + 1;
+            }
+        }
+    }
+    // Only ASCII backslash/newline edits; `pattern` was valid UTF-8.
+    String::from_utf8(out).expect("pattern normalization preserves UTF-8")
+}
+
+pub fn prepare_compiled_pattern(pattern: &str) -> PyResult<String> {
+    if pattern.contains('\0') {
+        return Err(PyValueError::new_err("Pattern contains null byte"));
+    }
+    let normalized = normalize_pattern_line_continuations(pattern);
+    formatparse_core::validate_pattern_length(&normalized).map_err(PyValueError::new_err)?;
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn continuation_joins_lines() {
+        assert_eq!(normalize_pattern_line_continuations("foo\\\nbar"), "foobar");
+    }
+
+    #[test]
+    fn continuation_crlf() {
+        assert_eq!(
+            normalize_pattern_line_continuations("foo\\\r\nbar"),
+            "foobar"
+        );
+    }
+
+    #[test]
+    fn even_backslashes_keep_newline() {
+        assert_eq!(
+            normalize_pattern_line_continuations("foo\\\\\nbar"),
+            "foo\\\\\nbar"
+        );
+    }
+
+    #[test]
+    fn odd_three_backslashes() {
+        assert_eq!(normalize_pattern_line_continuations("a\\\\\\\nb"), "a\\b");
+    }
+
+    #[test]
+    fn literal_newline_unchanged() {
+        assert_eq!(normalize_pattern_line_continuations("a\nb"), "a\nb");
+    }
+
+    #[test]
+    fn empty() {
+        assert_eq!(normalize_pattern_line_continuations(""), "");
+    }
+
+    #[test]
+    fn continuation_strips_spaces_tabs_on_next_line() {
+        assert_eq!(
+            normalize_pattern_line_continuations("foo\\\n  \t  bar"),
+            "foobar"
+        );
+    }
+}

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -14,6 +14,11 @@ and fill are supported like plain string fields (see `GitHub issue #70
 <https://github.com/eddiethedean/formatparse/issues/70>`_); sign, zero-padding, and
 ``=`` alignment are not supported with ``:ml``.
 
+**Long patterns:** a backslash immediately before the end of a line continues the
+pattern on the next line (``\\r\\n`` or ``\\n``); doubled backslashes keep a literal
+newline. Leading spaces and tabs on the continued line are stripped (see `GitHub
+issue #68 <https://github.com/eddiethedean/formatparse/issues/68>`_).
+
 **Composition (sub-parsers):** use :func:`composed_type` to wrap a compiled
 :class:`FormatParser` and pass it in ``extra_types`` so one field is parsed by the
 child parser and returns a nested :class:`ParseResult`. The parent pickle story is

--- a/tests/test_pattern_continuations.py
+++ b/tests/test_pattern_continuations.py
@@ -1,0 +1,65 @@
+"""Pattern backslash line continuations (GitHub issue #68)."""
+
+from formatparse import compile, parse, search
+
+
+def _assert_same_parse(pattern_a: str, pattern_b: str, text: str) -> None:
+    """Compare parse outcomes; ``ParseResult`` does not implement value equality."""
+    ra, rb = parse(pattern_a, text), parse(pattern_b, text)
+    assert (ra is None) == (rb is None)
+    if ra is None:
+        return
+    assert ra.span == rb.span
+    assert dict(ra.named) == dict(rb.named)
+    assert tuple(ra.fixed) == tuple(rb.fixed)
+
+
+def test_parse_continued_pattern_matches_single_line():
+    continued = "Hello, \\\n{name}!"
+    single = "Hello, {name}!"
+    _assert_same_parse(continued, single, "Hello, world!")
+
+
+def test_parse_crlf_continuation():
+    continued = "x\\\r\ny"
+    assert parse(continued, "xy") is not None
+
+
+def test_double_backslash_keeps_newline_in_pattern():
+    # Even number of backslashes before newline: newline stays in the pattern.
+    pat = "a\\\\\nb"
+    p = compile(pat)
+    assert p.pattern == pat
+    text = "a\\\\\nb"
+    assert p.parse(text) is not None
+
+
+def test_triple_backslash_continuation():
+    continued = "a\\\\\\\nb"
+    single = "a\\b"
+    _assert_same_parse(continued, single, "a\\b")
+
+
+def test_continued_line_leading_whitespace_stripped():
+    continued = "foo\\\n    bar"
+    assert parse(continued, "foobar") is not None
+
+
+def test_ml_field_equivalent_single_line():
+    # Blank line after the continuation keeps a literal newline before ``{body:ml}`` (``\\\n`` drops one).
+    continued = "BEGIN\\\n\n{body:ml}\nEND"
+    single = "BEGIN\n{body:ml}\nEND"
+    text = "BEGIN\na\nb\nEND"
+    _assert_same_parse(continued, single, text)
+
+
+def test_search_continuation():
+    continued = "foo\\\n{name}"
+    single = "foo{name}"
+    assert search(continued, "foox", evaluate_result=False) is not None
+    assert search(single, "foox", evaluate_result=False) is not None
+
+
+def test_compile_stores_normalized_pattern():
+    p = compile("a\\\nb")
+    assert p.pattern == "ab"


### PR DESCRIPTION
## Summary
Implements **pattern-only** backslash line continuations before compile and LRU cache fingerprinting (see [#68](https://github.com/eddiethedean/formatparse/issues/68)).

- New `pattern_normalize` module: fold `\` + end-of-line (`\n` / `\r\n`) with odd/even backslash semantics; strip leading ASCII spaces/tabs on the continued line; null-byte rejection and pattern length validation on the normalized string.
- `get_or_create_parser` and `FormatParser::new_with_extra_types` use the normalized pattern consistently.
- Python integration tests and module doc blurb.

## Deferred (follow-up, not this PR)
- Continuation markers in **matched input text** (second goal in the issue).

Progresses #68.