### PR TITLE
feat: indent-block field type :blk (#69)

### DIFF
--- a/formatparse-core/src/indent_block.rs
+++ b/formatparse-core/src/indent_block.rs
@@ -1,0 +1,87 @@
+//! Strip common leading indentation from a captured block (GitHub issue #69).
+//!
+//! Used for ``{name:blk}`` after the same regex boundaries as ``:ml``. Blank lines and
+//! lines that contain only spaces or tabs do not contribute to the computed margin.
+//! Tabs count as single characters (not expanded). Output lines are joined with ``\\n``.
+
+/// Remove the largest common prefix of spaces/tabs from each line (see module docs).
+pub fn strip_common_indent(s: &str) -> String {
+    let lines: Vec<String> = s
+        .split('\n')
+        .map(|p| p.strip_suffix('\r').unwrap_or(p).to_string())
+        .collect();
+
+    let mut margin: Option<usize> = None;
+    for line in &lines {
+        if line.is_empty() {
+            continue;
+        }
+        if line.chars().all(|c| c == ' ' || c == '\t') {
+            continue;
+        }
+        let indent = line.chars().take_while(|c| *c == ' ' || *c == '\t').count();
+        margin = Some(match margin {
+            None => indent,
+            Some(m) => m.min(indent),
+        });
+    }
+    let m = margin.unwrap_or(0);
+    if m == 0 {
+        return s.to_string();
+    }
+
+    let mut out = String::with_capacity(s.len());
+    for (i, line) in lines.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let lead = line.chars().take_while(|c| *c == ' ' || *c == '\t').count();
+        let rest: String = if lead >= m {
+            line.chars().skip(m).collect()
+        } else {
+            line.trim_start_matches([' ', '\t']).to_string()
+        };
+        out.push_str(&rest);
+    }
+    out.trim_start_matches('\n').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(strip_common_indent(""), "");
+    }
+
+    #[test]
+    fn no_leading_indent_unchanged() {
+        assert_eq!(strip_common_indent("a\nb"), "a\nb");
+    }
+
+    #[test]
+    fn strips_common_spaces() {
+        assert_eq!(strip_common_indent("  a\n  b"), "a\nb");
+    }
+
+    #[test]
+    fn blank_lines_do_not_set_margin() {
+        assert_eq!(strip_common_indent("  a\n\n  b"), "a\n\nb");
+    }
+
+    #[test]
+    fn crlf_segments() {
+        assert_eq!(strip_common_indent("  a\r\n  b"), "a\nb");
+    }
+
+    #[test]
+    fn leading_newline_after_dedent_trimmed() {
+        assert_eq!(strip_common_indent("\n  a\n  b"), "a\nb");
+    }
+
+    #[test]
+    fn tabs_count_as_single_indent_chars() {
+        assert_eq!(strip_common_indent("\tx\n\ty"), "x\ny");
+    }
+}

--- a/formatparse-core/src/lib.rs
+++ b/formatparse-core/src/lib.rs
@@ -4,9 +4,11 @@
 //! and type definitions. It has no dependencies on Python or PyO3.
 
 pub mod error;
+pub mod indent_block;
 pub mod parser;
 pub mod types;
 
+pub use indent_block::strip_common_indent;
 pub use parser::{
     count_capturing_groups, validate_field_name, validate_input_length, validate_pattern_length,
     MAX_FIELDS, MAX_FIELD_NAME_LENGTH, MAX_INPUT_LENGTH, MAX_PATTERN_LENGTH,

--- a/formatparse-core/src/types/definitions.rs
+++ b/formatparse-core/src/types/definitions.rs
@@ -29,6 +29,9 @@ pub enum FieldType {
     /// Multiline text between anchors; format specifier `:ml` (issues #8, #70). Supports
     /// width, precision, alignment, and fill like strings; sign / zero-padding / ``=`` align not supported.
     Multiline,
+    /// Indented block: same match boundaries as ``:ml``, then strip common leading spaces/tabs
+    /// per line (issue #69). Format specifier ``:blk``.
+    IndentBlock,
     Custom(String),
 }
 

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -105,8 +105,9 @@ impl FieldSpec {
                     r".+?".to_string()
                 }
             }
-            FieldType::Multiline => {
+            FieldType::Multiline | FieldType::IndentBlock => {
                 // Same layout as strings, but ``.`` cannot span newlines in Rust regex; use ``[\s\S]``.
+                // ``IndentBlock`` (:blk) uses the same fragment as ``Multiline``; dedent is applied after capture.
                 const ML: &str = "[\\s\\S]";
                 if let Some(prec) = self.precision {
                     if let Some(align) = self.alignment {
@@ -421,6 +422,21 @@ mod tests {
     fn test_strftime_to_regex_unknown() {
         let result = strftime_to_regex("%Z");
         assert_eq!(result, ".+?");
+    }
+
+    #[test]
+    fn test_field_spec_indent_block_matches_multiline_regex() {
+        let mut ml = FieldSpec::new();
+        ml.field_type = FieldType::Multiline;
+        ml.width = Some(3);
+        let mut blk = FieldSpec::new();
+        blk.field_type = FieldType::IndentBlock;
+        blk.width = Some(3);
+        let custom = HashMap::new();
+        assert_eq!(
+            ml.to_regex_pattern(&custom, None),
+            blk.to_regex_pattern(&custom, None)
+        );
     }
 
     #[test]

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -314,22 +314,25 @@ pub fn normalize_field_name(
     normalized
 }
 
-/// Reject `:ml` combined with numeric-only format specifiers (GitHub issues #8, #70).
+/// Reject `:ml` / `:blk` combined with numeric-only format specifiers (GitHub issues #8, #69, #70).
 ///
-/// Width, precision, alignment, and fill are supported for multiline fields; ``sign``,
-/// ``zero_pad``, and ``=`` alignment remain unsupported.
+/// Width, precision, alignment, and fill are supported for multiline and indent-block fields;
+/// ``sign``, ``zero_pad``, and ``=`` alignment remain unsupported.
 pub fn validate_multiline_mvp(spec: &FieldSpec) -> PyResult<()> {
-    if !matches!(spec.field_type, FieldType::Multiline) {
+    if !matches!(
+        spec.field_type,
+        FieldType::Multiline | FieldType::IndentBlock
+    ) {
         return Ok(());
     }
     if spec.sign.is_some() || spec.zero_pad {
         return Err(error::pattern_error(
-            "Multiline type :ml does not support sign or zero-padding",
+            "Multiline types :ml and :blk do not support sign or zero-padding",
         ));
     }
     if spec.alignment == Some('=') {
         return Err(error::pattern_error(
-            "Multiline type :ml does not support '=' alignment",
+            "Multiline types :ml and :blk do not support '=' alignment",
         ));
     }
     Ok(())
@@ -597,6 +600,8 @@ pub fn parse_format_spec(
             FieldType::BracedContent
         } else if type_name == "ml" {
             FieldType::Multiline
+        } else if type_name == "blk" {
+            FieldType::IndentBlock
         } else if type_name.len() > 1 {
             // Multi-character - always custom type
             FieldType::Custom(type_name)

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -52,41 +52,14 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
 
     match &spec.field_type {
         FieldType::String | FieldType::Multiline => {
-            // Fast path: no alignment means no trimming needed
-            if spec.alignment.is_none() {
-                Ok(RawValue::String(value.to_string()))
-            } else {
-                // Strip fill characters and whitespace based on alignment
-                let trimmed = match spec.alignment {
-                    Some('<') => {
-                        if spec.width.is_some() {
-                            value
-                        } else if let Some(fill_ch) = spec.fill {
-                            value.trim_end_matches(fill_ch).trim_end()
-                        } else {
-                            value.trim_end()
-                        }
-                    }
-                    Some('>') => {
-                        // Right-aligned: strip leading fill chars, then leading spaces
-                        if let Some(fill_ch) = spec.fill {
-                            value.trim_start_matches(fill_ch).trim_start()
-                        } else {
-                            value.trim_start()
-                        }
-                    }
-                    Some('^') => {
-                        // Center-aligned: strip both leading and trailing fill chars, then spaces
-                        if let Some(fill_ch) = spec.fill {
-                            value.trim_matches(fill_ch).trim()
-                        } else {
-                            value.trim()
-                        }
-                    }
-                    _ => value, // No alignment: keep as-is
-                };
-                Ok(RawValue::String(trimmed.to_string()))
-            }
+            let t = crate::types::conversion::trim_string_or_multiline_value(spec, value);
+            Ok(RawValue::String(t.into_owned()))
+        }
+        FieldType::IndentBlock => {
+            let t = crate::types::conversion::trim_string_or_multiline_value(spec, value);
+            Ok(RawValue::String(formatparse_core::strip_common_indent(
+                t.as_ref(),
+            )))
         }
         FieldType::Integer => {
             // Fast path: common case - decimal integer, no special formatting

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -13,124 +13,171 @@ use std::collections::HashMap;
 /// - Total width (including fill chars) should not exceed specified width when width is specified
 /// - Content length (after removing fill chars) should not exceed precision
 pub fn validate_alignment_precision(spec: &FieldSpec, value: &str) -> bool {
-    if let FieldType::String = &spec.field_type {
-        if let (Some(prec), Some(align)) = (spec.precision, spec.alignment) {
-            // When width == precision == captured length and the field is zero-filled
-            // right-aligned, leading/trailing '0' cannot be distinguished from content
-            // (GitHub issue #40; parse parity).
-            if align == '>'
-                && spec.fill == Some('0')
-                && spec.width == Some(prec)
-                && Some(value.len()) == spec.width
-            {
-                return true;
+    if !matches!(
+        &spec.field_type,
+        FieldType::String | FieldType::Multiline | FieldType::IndentBlock
+    ) {
+        return true;
+    }
+    if let (Some(prec), Some(align)) = (spec.precision, spec.alignment) {
+        // When width == precision == captured length and the field is zero-filled
+        // right-aligned, leading/trailing '0' cannot be distinguished from content
+        // (GitHub issue #40; parse parity).
+        if align == '>'
+            && spec.fill == Some('0')
+            && spec.width == Some(prec)
+            && Some(value.len()) == spec.width
+        {
+            return true;
+        }
+
+        let fill_ch = spec.fill.unwrap_or(' ');
+        let has_leading_fill = value.starts_with(fill_ch);
+        let has_trailing_fill = value.ends_with(fill_ch);
+
+        // Count leading and trailing fill characters
+        let leading_count = value.chars().take_while(|&c| c == fill_ch).count();
+        let trailing_count = value.chars().rev().take_while(|&c| c == fill_ch).count();
+        // Avoid underflow: if all chars are fill, content_len is 0
+        let content_len = if leading_count + trailing_count >= value.len() {
+            0
+        } else {
+            value.len() - leading_count - trailing_count
+        };
+
+        // Special case: if all chars are fill (content_len == 0), allow it if total length equals width
+        if content_len == 0 {
+            if let Some(width) = spec.width {
+                if value.len() == width {
+                    return true; // Valid: empty content, all fill, total = width
+                }
             }
+            return false; // Invalid: all fill but doesn't match width
+        }
 
-            let fill_ch = spec.fill.unwrap_or(' ');
-            let has_leading_fill = value.starts_with(fill_ch);
-            let has_trailing_fill = value.ends_with(fill_ch);
-
-            // Count leading and trailing fill characters
-            let leading_count = value.chars().take_while(|&c| c == fill_ch).count();
-            let trailing_count = value.chars().rev().take_while(|&c| c == fill_ch).count();
-            // Avoid underflow: if all chars are fill, content_len is 0
-            let content_len = if leading_count + trailing_count >= value.len() {
-                0
-            } else {
-                value.len() - leading_count - trailing_count
-            };
-
-            // Special case: if all chars are fill (content_len == 0), allow it if total length equals width
-            if content_len == 0 {
+        match align {
+            '>' => {
+                // Right-aligned: fill chars should only be on the left
+                // Reject if fill char on both sides (invalid) - but only if there's actual content
+                if has_leading_fill && has_trailing_fill {
+                    return false;
+                }
+                // Reject if fill char on right (should only be on left)
+                if has_trailing_fill {
+                    return false;
+                }
+                // Reject if content exceeds precision
+                if content_len > prec {
+                    return false;
+                }
+                // Reject if width is specified and total width exceeds it
+                // When width is specified with precision, total should not exceed width
                 if let Some(width) = spec.width {
-                    if value.len() == width {
-                        return true; // Valid: empty content, all fill, total = width
-                    }
-                }
-                return false; // Invalid: all fill but doesn't match width
-            }
-
-            match align {
-                '>' => {
-                    // Right-aligned: fill chars should only be on the left
-                    // Reject if fill char on both sides (invalid) - but only if there's actual content
-                    if has_leading_fill && has_trailing_fill {
+                    if value.len() > width {
                         return false;
                     }
-                    // Reject if fill char on right (should only be on left)
-                    if has_trailing_fill {
-                        return false;
-                    }
-                    // Reject if content exceeds precision
-                    if content_len > prec {
-                        return false;
-                    }
-                    // Reject if width is specified and total width exceeds it
-                    // When width is specified with precision, total should not exceed width
-                    if let Some(width) = spec.width {
-                        if value.len() > width {
-                            return false;
-                        }
-                    } else {
-                        // No width specified, but precision is: reject if fill enables extra content
-                        if has_leading_fill && value.len() > prec {
-                            let leading_count = value.chars().take_while(|&c| c == fill_ch).count();
-                            let content_len = value.len() - leading_count;
-                            if content_len > prec {
-                                return false;
-                            }
-                        }
-                    }
-                }
-                '<' => {
-                    // Left-aligned: fill chars should only be on the right
-                    // Reject if fill char on left (should only be on right)
-                    if has_leading_fill {
-                        return false;
-                    }
-                    // Reject if content exceeds precision
-                    if content_len > prec {
-                        return false;
-                    }
-                    // Reject if width is specified and total width exceeds it
-                    if let Some(width) = spec.width {
-                        if value.len() > width {
-                            return false;
-                        }
-                    } else {
-                        // No width specified, but precision is: reject if fill enables extra content
-                        if has_trailing_fill && value.len() > prec {
-                            let trailing_count =
-                                value.chars().rev().take_while(|&c| c == fill_ch).count();
-                            let content_len = value.len() - trailing_count;
-                            if content_len > prec {
-                                return false;
-                            }
-                        }
-                    }
-                }
-                '^' => {
-                    // Center-aligned: reject if content exceeds precision
-                    if content_len > prec {
-                        return false;
-                    }
-                    // Reject if width is specified and total width exceeds it
-                    if let Some(width) = spec.width {
-                        if value.len() > width {
-                            return false;
-                        }
-                    } else {
-                        // No width specified, but precision is: reject if content exceeds precision
+                } else {
+                    // No width specified, but precision is: reject if fill enables extra content
+                    if has_leading_fill && value.len() > prec {
+                        let leading_count = value.chars().take_while(|&c| c == fill_ch).count();
+                        let content_len = value.len() - leading_count;
                         if content_len > prec {
                             return false;
                         }
                     }
                 }
-                _ => {}
             }
+            '<' => {
+                // Left-aligned: fill chars should only be on the right
+                // Reject if fill char on left (should only be on right)
+                if has_leading_fill {
+                    return false;
+                }
+                // Reject if content exceeds precision
+                if content_len > prec {
+                    return false;
+                }
+                // Reject if width is specified and total width exceeds it
+                if let Some(width) = spec.width {
+                    if value.len() > width {
+                        return false;
+                    }
+                } else {
+                    // No width specified, but precision is: reject if fill enables extra content
+                    if has_trailing_fill && value.len() > prec {
+                        let trailing_count =
+                            value.chars().rev().take_while(|&c| c == fill_ch).count();
+                        let content_len = value.len() - trailing_count;
+                        if content_len > prec {
+                            return false;
+                        }
+                    }
+                }
+            }
+            '^' => {
+                // Center-aligned: reject if content exceeds precision
+                if content_len > prec {
+                    return false;
+                }
+                // Reject if width is specified and total width exceeds it
+                if let Some(width) = spec.width {
+                    if value.len() > width {
+                        return false;
+                    }
+                } else {
+                    // No width specified, but precision is: reject if content exceeds precision
+                    if content_len > prec {
+                        return false;
+                    }
+                }
+            }
+            _ => {}
         }
     }
     true
+}
+
+/// Trim fill / whitespace for string-like fields that support alignment (``String``, ``Multiline``, ``IndentBlock``).
+pub(crate) fn trim_string_or_multiline_value<'a>(
+    spec: &FieldSpec,
+    value: &'a str,
+) -> std::borrow::Cow<'a, str> {
+    use std::borrow::Cow;
+    if spec.alignment.is_none() {
+        return Cow::Borrowed(value);
+    }
+    let trimmed = match spec.alignment {
+        Some('<') => {
+            if spec.width.is_some() {
+                value
+            } else if let Some(fill_ch) = spec.fill {
+                value.trim_end_matches(fill_ch).trim_end()
+            } else {
+                value.trim_end()
+            }
+        }
+        Some('>') => {
+            if spec.fill == Some('0')
+                && spec.width == spec.precision
+                && spec.width == Some(value.len())
+            {
+                value
+            } else if let Some(fill_ch) = spec.fill {
+                value.trim_start_matches(fill_ch).trim_start()
+            } else {
+                value.trim_start()
+            }
+        }
+        Some('^') => {
+            if let Some(fill_ch) = spec.fill {
+                value.trim_matches(fill_ch).trim()
+            } else {
+                value.trim()
+            }
+        }
+        _ => value,
+    };
+    Cow::Borrowed(trimmed)
 }
 
 pub fn convert_value(
@@ -168,6 +215,7 @@ pub fn convert_value(
             FieldType::DateTimeStrftime => "strftime",
             FieldType::BracedContent => "brace",
             FieldType::Multiline => "ml",
+            FieldType::IndentBlock => "blk",
         };
 
         // If there's a custom converter for this type name, use it instead of built-in
@@ -179,50 +227,21 @@ pub fn convert_value(
 
     // Use built-in conversion
     match &spec.field_type {
-        FieldType::String | FieldType::Multiline => {
-            // Fast path: no alignment means no trimming needed
+        FieldType::String => {
             if spec.alignment.is_none() {
                 Ok(value.into_py_any(py)?)
             } else {
-                // Strip fill characters and whitespace based on alignment
-                let trimmed = match spec.alignment {
-                    Some('<') => {
-                        // With a fixed width, the capture includes intentional trailing
-                        // fill (often spaces); match parse and keep it (issue #39).
-                        // Without width, strip trailing fill / spaces like parse does.
-                        if spec.width.is_some() {
-                            value
-                        } else if let Some(fill_ch) = spec.fill {
-                            value.trim_end_matches(fill_ch).trim_end()
-                        } else {
-                            value.trim_end()
-                        }
-                    }
-                    Some('>') => {
-                        // Zero-filled right align, fixed cell: keep full capture (issue #40, parse parity).
-                        if spec.fill == Some('0')
-                            && spec.width == spec.precision
-                            && spec.width == Some(value.len())
-                        {
-                            value
-                        } else if let Some(fill_ch) = spec.fill {
-                            value.trim_start_matches(fill_ch).trim_start()
-                        } else {
-                            value.trim_start()
-                        }
-                    }
-                    Some('^') => {
-                        // Center-aligned: strip both leading and trailing fill chars, then spaces
-                        if let Some(fill_ch) = spec.fill {
-                            value.trim_matches(fill_ch).trim()
-                        } else {
-                            value.trim()
-                        }
-                    }
-                    _ => value, // No alignment: keep as-is
-                };
+                let trimmed = trim_string_or_multiline_value(spec, value);
                 Ok(trimmed.into_py_any(py)?)
             }
+        }
+        FieldType::Multiline => {
+            let trimmed = trim_string_or_multiline_value(spec, value);
+            Ok(trimmed.into_py_any(py)?)
+        }
+        FieldType::IndentBlock => {
+            let trimmed = trim_string_or_multiline_value(spec, value);
+            Ok(formatparse_core::strip_common_indent(trimmed.as_ref()).into_py_any(py)?)
         }
         FieldType::Integer => {
             // Fast path: common case - decimal integer, no special formatting

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -14,6 +14,16 @@ and fill are supported like plain string fields (see `GitHub issue #70
 <https://github.com/eddiethedean/formatparse/issues/70>`_); sign, zero-padding, and
 ``=`` alignment are not supported with ``:ml``.
 
+**Indented blocks:** use ``{name:blk}`` when content is written as an indented block
+under a header: matching uses the same rules as ``:ml`` (non-greedy up to the next
+literal or field), then the captured text is **dedented** by removing the largest
+common prefix of spaces and tabs from each line (blank lines do not contribute to
+that margin; tabs count as single characters). See `GitHub issue #69
+<https://github.com/eddiethedean/formatparse/issues/69>`_. If a pattern literal ends
+with trailing whitespace before ``{...:blk}``, it is compiled as ``\\s+`` and may
+consume the block's leading spaces—keep the newline outside that literal chunk when
+you need a margin (e.g. ``key:{body:blk}\\nEND`` rather than ``key:\\n{body:blk}``).
+
 **Long patterns:** a backslash immediately before the end of a line continues the
 pattern on the next line (``\\r\\n`` or ``\\n``); doubled backslashes keep a literal
 newline. Leading spaces and tabs on the continued line are stripped (see `GitHub

--- a/tests/test_indent_block.py
+++ b/tests/test_indent_block.py
@@ -1,0 +1,55 @@
+"""Indent-block field type ``:blk`` (GitHub issue #69).
+
+Avoid a newline immediately before ``{...:blk}`` in the *same* literal chunk: literals
+that end with trailing whitespace are compiled as ``\\s+``, which would consume the
+block's leading indentation. Prefer ``key:{body:blk}`` (then ``\\n`` / ``END`` in later
+literals) so the first line of the capture participates in the margin.
+"""
+
+import pytest
+
+from formatparse import compile, parse
+
+
+def test_blk_strips_common_indent():
+    r = parse("key:{body:blk}\nEND", "key:\n  line1\n  line2\nEND")
+    assert r.named["body"] == "line1\nline2"
+
+
+def test_blk_blank_lines_in_block():
+    r = parse("H:{body:blk}\nX", "H:\n  a\n\n  b\nX")
+    assert r.named["body"] == "a\n\nb"
+
+
+def test_blk_crlf_input():
+    r = parse("H:{body:blk}\r\nX", "H:\r\n  a\r\n  b\r\nX")
+    assert r.named["body"] == "a\nb"
+
+
+def test_blk_tabs_in_indent():
+    r = parse("H:{body:blk}\nX", "H:\n\tx\n\ty\nX")
+    assert r.named["body"] == "x\ny"
+
+
+def test_blk_same_boundaries_as_ml():
+    text = "BEGIN\n  one\n  two\nEND"
+    ml = parse("BEGIN{body:ml}\nEND", text)
+    blk = parse("BEGIN{body:blk}\nEND", text)
+    assert ml.named["body"] == "\n  one\n  two"
+    assert blk.named["body"] == "one\ntwo"
+
+
+def test_compile_blk():
+    p = compile("{x:blk}")
+    r = p.parse("\n  hi\n  there")
+    assert r.named["x"] == "hi\nthere"
+
+
+def test_blk_rejects_sign():
+    with pytest.raises(ValueError, match=":blk"):
+        compile("{x:+blk}")
+
+
+def test_blk_rejects_equals_alignment():
+    with pytest.raises(ValueError, match=":blk"):
+        compile("{x:=10blk}")


### PR DESCRIPTION
## Summary
Implements **`{name:blk}`** for indentation-style blocks ([\#69](https://github.com/eddiethedean/formatparse/issues/69)).

- **Matching:** Same `[\s\S]+?`-style fragments as `:ml` (width / precision / alignment / fill supported; sign, zero-padding, and `=` rejected the same way).
- **Value:** `formatparse_core::strip_common_indent` removes the minimum leading space/tab run on each non-blank line; blank lines do not set the margin; CRLF segments normalized per line; leading newlines trimmed after dedent so `key:{body:blk}` captures work as expected.
- **Docs:** Module blurb in `formatparse/__init__.py` (`:blk` vs `:ml`, and the existing literal trailing-whitespace → `\s+` caveat).

## Tests
- Rust: `indent_block` unit tests + regex parity test for `IndentBlock` vs `Multiline`.
- Python: `tests/test_indent_block.py`.

Fixes #69.