### PR TITLE
fix: {:d} accepts leading whitespace before digits (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Integer `d`**: leading spaces and tabs before decimal digits are accepted (e.g. ``parse("{a:d}", "    0")``) for parity with padded ``str.format`` output (#81; upstream `parse#133 <https://github.com/r1chardj0n3s/parse/issues/133>`_).
+
 ## [0.8.0] - 2026-05-15
 
 ### Added

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -195,9 +195,11 @@ impl FieldSpec {
                             format!("{}{}{}(?:0[bB][01]+|[01]+)", sign, fill_prefix, fill_suffix)
                         }
                         _ => {
-                            // Decimal: match decimal digits, or hex/octal/binary with prefix
+                            // Decimal: optional leading whitespace before digits (parse#133 / #81)
+                            // so values like "    0" match like str.format padding, without widening
+                            // the 0x/0o/0b branches.
                             format!(
-                                "{}{}{}(?:0[xX][0-9a-fA-F]+|0[oO][0-7]+|0[bB][01]+|[0-9]+)",
+                                "{}{}{}(?:0[xX][0-9a-fA-F]+|0[oO][0-7]+|0[bB][01]+|\\s*[0-9]+)",
                                 sign, fill_prefix, fill_suffix
                             )
                         }
@@ -566,7 +568,17 @@ mod tests {
         spec.field_type = FieldType::Integer;
         let pattern = spec.to_regex_pattern(&HashMap::new(), None);
         assert!(pattern.contains(r"[+-]?"));
-        assert!(pattern.contains(r"[0-9]+"));
+        assert!(pattern.contains(r"\s*[0-9]+") || pattern.contains(r"[0-9]+"));
+    }
+
+    #[test]
+    fn test_field_spec_integer_decimal_leading_whitespace_before_digits() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Integer;
+        let p = spec.to_regex_pattern(&HashMap::new(), None);
+        let re = Regex::new(&format!("^{}$", p)).unwrap();
+        assert!(re.is_match("    0"));
+        assert!(re.is_match("  42"));
     }
 
     #[test]

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -34,6 +34,10 @@ issue #68 <https://github.com/eddiethedean/formatparse/issues/68>`_).
 integer-like text as well as forms with a trailing dot or trailing fractional zeros
 (see `GitHub issue #84 <https://github.com/eddiethedean/formatparse/issues/84>`_).
 
+**Integer decimal ``d``:** optional leading spaces and tabs are allowed before the digit
+run so values such as ``"    0"`` match ``{a:d}`` when they mirror padded numeric output
+(see `GitHub issue #81 <https://github.com/eddiethedean/formatparse/issues/81>`_).
+
 **Composition (sub-parsers):** use :func:`composed_type` to wrap a compiled
 :class:`FormatParser` and pass it in ``extra_types`` so one field is parsed by the
 child parser and returns a nested :class:`ParseResult`. The parent pickle story is

--- a/tests/test_integer_leading_spaces.py
+++ b/tests/test_integer_leading_spaces.py
@@ -1,0 +1,32 @@
+"""Integer {:d} with leading whitespace before digits (GitHub issue #81, parse#133)."""
+
+from formatparse import parse
+
+
+def test_decimal_d_allows_multiple_leading_spaces_before_zero():
+    assert parse("{a:d}", "0").named["a"] == 0
+    assert parse("{a:d}", " 0").named["a"] == 0
+    assert parse("{a:d}", "   0").named["a"] == 0
+    assert parse("{a:d}", "    0").named["a"] == 0
+
+
+def test_decimal_d_leading_spaces_before_nonzero():
+    assert parse("{a:d}", "   42").named["a"] == 42
+
+
+def test_decimal_d_tabs_and_spaces():
+    r = parse("{a:d}", "  \t 9")
+    assert r is not None
+    assert r.named["a"] == 9
+
+
+def test_hex_field_unprefixed_still_parses():
+    r = parse("{h:x}", "ff")
+    assert r is not None
+    assert r.named["h"] == 255
+
+
+def test_literal_then_field_still_requires_digits_after_literal():
+    r = parse("x{a:d}", "x  3")
+    assert r is not None
+    assert r.named["a"] == 3


### PR DESCRIPTION
## Summary

Fixes [GitHub issue #81](https://github.com/eddiethedean/formatparse/issues/81) / upstream [parse#133](https://github.com/r1chardj0n3s/parse/issues/133): `parse("{a:d}", "    0")` now returns `a == 0`, consistent with padded numeric output from `str.format`.

## Changes

- **formatparse-core:** in the default decimal `:d` branch, the plain-decimal alternative is `\s*[0-9]+` so spaces/tabs may precede digits (hex/octal/binary prefixed branches unchanged).
- **Tests:** `tests/test_integer_leading_spaces.py`; Rust `test_field_spec_integer_decimal_leading_whitespace_before_digits`.
- **Docs:** module docstring + `[Unreleased]` changelog entry.

## Verification

`cargo test --workspace`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `pytest tests` (with `maturin develop --features extension-module`).

Closes #81.