### PR TITLE
fix: literal + empty default string field (closes #83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Default string fields next to literals** (e.g. ``"/{name}"``): an empty capture is allowed when it matches ``str.format`` output such as ``"/"`` for ``name=""`` (#83; upstream `parse#136 <https://github.com/r1chardj0n3s/parse/issues/136>`_). Applies to full-string **parse** / **compile().parse**; **search** / **findall** still use ``.+?`` for those segments so unanchored matching does not stop early.
 - **Integer `d`**: leading spaces and tabs before decimal digits are accepted (e.g. ``parse("{a:d}", "    0")``) for parity with padded ``str.format`` output (#81; upstream `parse#133 <https://github.com/r1chardj0n3s/parse/issues/133>`_).
 
 ## [0.8.0] - 2026-05-15

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -43,10 +43,14 @@ pub fn strftime_to_regex(format_str: &str) -> String {
 }
 
 impl FieldSpec {
+    /// `allow_empty_delimited`: for default unconstrained string fields only (no width,
+    /// precision, alignment), use `.*?` instead of `.+?` so an empty capture is allowed when
+    /// the field is delimited by pattern literals (formatparse#83 / parse#136 remainder).
     pub fn to_regex_pattern(
         &self,
         custom_patterns: &HashMap<String, String>,
         next_field_is_greedy: Option<bool>,
+        allow_empty_delimited: bool,
     ) -> String {
         let base_pattern = match &self.field_type {
             FieldType::String => {
@@ -100,9 +104,14 @@ impl FieldSpec {
                         _ => r"[^\{\}]+?".to_string(),
                     }
                 } else {
-                    // For empty {} fields, match any characters including newlines (non-greedy)
-                    // Use .+? to match the original parse library behavior
-                    r".+?".to_string()
+                    // For empty {} fields, match any characters including newlines (non-greedy).
+                    // Delimited default strings may match empty (issue #83); otherwise require
+                    // at least one character like the original parse library.
+                    if allow_empty_delimited {
+                        r".*?".to_string()
+                    } else {
+                        r".+?".to_string()
+                    }
                 }
             }
             FieldType::Multiline | FieldType::IndentBlock => {
@@ -443,16 +452,23 @@ mod tests {
         blk.width = Some(3);
         let custom = HashMap::new();
         assert_eq!(
-            ml.to_regex_pattern(&custom, None),
-            blk.to_regex_pattern(&custom, None)
+            ml.to_regex_pattern(&custom, None, false),
+            blk.to_regex_pattern(&custom, None, false)
         );
     }
 
     #[test]
     fn test_field_spec_string_default() {
         let spec = FieldSpec::new();
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r".+?");
+    }
+
+    #[test]
+    fn test_field_spec_string_delimited_allows_empty_capture() {
+        let spec = FieldSpec::new();
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, true);
+        assert_eq!(pattern, r".*?");
     }
 
     #[test]
@@ -460,7 +476,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Multiline;
         spec.width = Some(3);
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r"[\s\S]{3,}");
     }
 
@@ -469,7 +485,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Multiline;
         spec.width = Some(4);
-        let pattern = spec.to_regex_pattern(&HashMap::new(), Some(false));
+        let pattern = spec.to_regex_pattern(&HashMap::new(), Some(false), false);
         assert_eq!(pattern, r"[\s\S]{4}");
     }
 
@@ -478,7 +494,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Multiline;
         spec.alignment = Some('>');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r" *([\s\S]+?)");
     }
 
@@ -489,7 +505,7 @@ mod tests {
         spec.precision = Some(3);
         spec.alignment = Some('<');
         spec.fill = Some('.');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r"[\s\S]{3}(?:\.*)");
     }
 
@@ -497,7 +513,7 @@ mod tests {
     fn test_field_spec_string_with_precision() {
         let mut spec = FieldSpec::new();
         spec.precision = Some(5);
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r".{5}");
     }
 
@@ -505,7 +521,7 @@ mod tests {
     fn test_field_spec_string_with_width() {
         let mut spec = FieldSpec::new();
         spec.width = Some(10);
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r".{10,}");
     }
 
@@ -514,7 +530,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.width = Some(10);
         // When next field is greedy, use greedy pattern
-        let pattern = spec.to_regex_pattern(&HashMap::new(), Some(true));
+        let pattern = spec.to_regex_pattern(&HashMap::new(), Some(true), false);
         assert_eq!(pattern, r".{10,}");
     }
 
@@ -523,7 +539,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.width = Some(10);
         // When next field is non-greedy (like {}), use exact width
-        let pattern = spec.to_regex_pattern(&HashMap::new(), Some(false));
+        let pattern = spec.to_regex_pattern(&HashMap::new(), Some(false), false);
         assert_eq!(pattern, r".{10}");
     }
 
@@ -531,7 +547,7 @@ mod tests {
     fn test_field_spec_string_with_alignment_left() {
         let mut spec = FieldSpec::new();
         spec.alignment = Some('<');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"([^\{\}\s]+"));
     }
 
@@ -539,7 +555,7 @@ mod tests {
     fn test_field_spec_string_with_alignment_right() {
         let mut spec = FieldSpec::new();
         spec.alignment = Some('>');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r" *(.+?)");
     }
 
@@ -547,7 +563,7 @@ mod tests {
     fn test_field_spec_string_with_alignment_center() {
         let mut spec = FieldSpec::new();
         spec.alignment = Some('^');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"([^\{\}\s]+"));
     }
 
@@ -557,7 +573,7 @@ mod tests {
         spec.precision = Some(5);
         spec.alignment = Some('<');
         spec.fill = Some('x');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(".{5}"));
         assert!(pattern.contains("x*"));
     }
@@ -566,7 +582,7 @@ mod tests {
     fn test_field_spec_integer() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Integer;
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"[+-]?"));
         assert!(pattern.contains(r"\s*[0-9]+") || pattern.contains(r"[0-9]+"));
     }
@@ -575,7 +591,7 @@ mod tests {
     fn test_field_spec_integer_decimal_leading_whitespace_before_digits() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Integer;
-        let p = spec.to_regex_pattern(&HashMap::new(), None);
+        let p = spec.to_regex_pattern(&HashMap::new(), None, false);
         let re = Regex::new(&format!("^{}$", p)).unwrap();
         assert!(re.is_match("    0"));
         assert!(re.is_match("  42"));
@@ -587,7 +603,7 @@ mod tests {
         spec.field_type = FieldType::Integer;
         spec.zero_pad = true;
         spec.width = Some(5);
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains("[0-9]{1,5}"));
     }
 
@@ -596,7 +612,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Integer;
         spec.original_type_char = Some('x');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains("0[xX]"));
         assert!(pattern.contains("[0-9a-fA-F]+"));
     }
@@ -606,7 +622,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Integer;
         spec.original_type_char = Some('o');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains("0[oO]"));
         assert!(pattern.contains("[0-7]+"));
     }
@@ -616,7 +632,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Integer;
         spec.original_type_char = Some('b');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains("0[bB]"));
         assert!(pattern.contains("[01]+"));
     }
@@ -625,7 +641,7 @@ mod tests {
     fn test_field_spec_float() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Float;
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"[+-]?"));
         assert!(pattern.contains(r"\d+\.\d+"));
     }
@@ -635,7 +651,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Float;
         spec.precision = Some(2);
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"\.\d{2}"));
     }
 
@@ -645,7 +661,7 @@ mod tests {
         spec.field_type = FieldType::Float;
         spec.precision = Some(0);
         spec.width = Some(2);
-        let p = spec.to_regex_pattern(&HashMap::new(), None);
+        let p = spec.to_regex_pattern(&HashMap::new(), None, false);
         let re = Regex::new(&format!("^{}$", p)).unwrap();
         assert!(re.is_match("20"));
         assert!(re.is_match(" 20"));
@@ -656,7 +672,7 @@ mod tests {
     fn test_field_spec_boolean() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Boolean;
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains("true"));
         assert!(pattern.contains("false"));
         assert!(pattern.contains("1"));
@@ -667,7 +683,7 @@ mod tests {
     fn test_field_spec_letters() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Letters;
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r"[a-zA-Z]+");
     }
 
@@ -675,7 +691,7 @@ mod tests {
     fn test_field_spec_word() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Word;
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r"\w+");
     }
 
@@ -683,7 +699,7 @@ mod tests {
     fn test_field_spec_datetime_iso() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::DateTimeISO;
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"\d{4}-\d{2}-\d{2}"));
     }
 
@@ -692,7 +708,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::DateTimeStrftime;
         spec.strftime_format = Some("%Y-%m-%d".to_string());
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"\d{4}"));
         assert!(pattern.contains(r"\d{1,2}"));
     }
@@ -703,7 +719,7 @@ mod tests {
         spec.field_type = FieldType::Custom("MyType".to_string());
         let mut custom_patterns = HashMap::new();
         custom_patterns.insert("MyType".to_string(), r"\d+".to_string());
-        let pattern = spec.to_regex_pattern(&custom_patterns, None);
+        let pattern = spec.to_regex_pattern(&custom_patterns, None, false);
         assert_eq!(pattern, r"\d+");
     }
 
@@ -711,7 +727,7 @@ mod tests {
     fn test_field_spec_custom_type_no_pattern() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Custom("MyType".to_string());
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         // Should default to non-whitespace
         assert_eq!(pattern, r"\S+");
     }
@@ -720,7 +736,7 @@ mod tests {
     fn test_field_spec_braced_content_placeholder_regex() {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::BracedContent;
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert_eq!(pattern, r".*?");
     }
 
@@ -729,7 +745,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Integer;
         spec.sign = Some('+');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"\+?"));
     }
 
@@ -738,7 +754,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.field_type = FieldType::Integer;
         spec.sign = Some(' ');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         assert!(pattern.contains(r"[- ]?"));
     }
 
@@ -748,7 +764,7 @@ mod tests {
         spec.field_type = FieldType::Integer;
         spec.fill = Some('x');
         spec.alignment = Some('=');
-        let pattern = spec.to_regex_pattern(&HashMap::new(), None);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         // Should have fill pattern between sign and digits
         assert!(pattern.contains("x*"));
     }

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -85,6 +85,16 @@ impl FormatParser {
             &pattern_owned,
             extra_types.as_ref(),
             &custom_patterns,
+            true,
+        )?;
+
+        // Search/findall use a separate compile path without "empty delimited" `.*?` groups so
+        // unanchored matching does not stop early (e.g. `{}, {}` on "Hello, World").
+        let (regex_str_search_anchored, _, _, _, _, _, _) = crate::parser::pattern::parse_pattern(
+            &pattern_owned,
+            extra_types.as_ref(),
+            &custom_patterns,
+            false,
         )?;
 
         // Validate field count
@@ -132,15 +142,18 @@ impl FormatParser {
         let regex = formatparse_core::build_regex(&regex_str_with_anchors)
             .map_err(crate::error::core_error_to_py_err)?;
 
+        let regex_search_anchored = formatparse_core::build_regex(&regex_str_search_anchored)
+            .map_err(crate::error::core_error_to_py_err)?;
+
         // Build case-insensitive regex
         let regex_case_insensitive =
             formatparse_core::build_case_insensitive_regex(&regex_str_with_anchors);
 
         // Pre-compile search regex variants (without anchors)
-        let search_regex = formatparse_core::build_search_regex(regex.as_str(), true)
+        let search_regex = formatparse_core::build_search_regex(regex_search_anchored.as_str(), true)
             .map_err(crate::error::core_error_to_py_err)?;
         let search_regex_case_insensitive =
-            formatparse_core::build_search_regex(regex.as_str(), false).ok();
+            formatparse_core::build_search_regex(regex_search_anchored.as_str(), false).ok();
 
         Ok(Self {
             pattern: pattern_owned,

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -17,11 +17,60 @@ pub type ParsedPatternParts = (
     bool,
 );
 
+/// True when `s` contains at least one non-whitespace character (trim is non-empty).
+fn literal_delimits_empty_field(s: &str) -> bool {
+    !s.trim().is_empty()
+}
+
+/// After [`parse_field`], `chars` is at optional whitespace then the closing `}`.
+/// True when there is a non-whitespace literal run after that `}` and before the next unescaped `{`
+/// or end of pattern (formatparse#83). Whitespace-only gaps do not count so ``{} {}`` keeps
+/// non-empty captures for both fields.
+fn has_trailing_literal_before_next_field(
+    mut chars: std::iter::Peekable<std::str::Chars>,
+) -> bool {
+    while chars.peek().is_some_and(|c| c.is_whitespace()) {
+        chars.next();
+    }
+    if chars.next() != Some('}') {
+        return false;
+    }
+    while chars.peek().is_some_and(|c| c.is_whitespace()) {
+        chars.next();
+    }
+    let mut literal = String::new();
+    loop {
+        match chars.next() {
+            None => return literal_delimits_empty_field(&literal),
+            Some('{') => {
+                if chars.peek() == Some(&'{') {
+                    chars.next();
+                    literal.push('{');
+                } else {
+                    return literal_delimits_empty_field(&literal);
+                }
+            }
+            Some('}') => {
+                if chars.peek() == Some(&'}') {
+                    chars.next();
+                    literal.push('}');
+                } else {
+                    literal.push('}');
+                }
+            }
+            Some(c) => literal.push(c),
+        }
+    }
+}
+
 /// Parse a format pattern string into regex parts, field specs, and names
+/// `allow_empty_delimited_default_string`: when false, default string fields always use `.+?`
+/// (used for the unanchored search regex so search/findall do not stop early).
 pub fn parse_pattern(
     pattern: &str,
     extra_types: Option<&HashMap<String, PyObject>>,
     custom_patterns: &HashMap<String, String>,
+    allow_empty_delimited_default_string: bool,
 ) -> PyResult<ParsedPatternParts> {
     // Pre-allocate with estimated capacity based on pattern length
     let estimated_fields = pattern.matches('{').count();
@@ -44,6 +93,8 @@ pub fn parse_pattern(
                     literal.push('{');
                     continue;
                 }
+
+                let had_leading_literal = !literal.trim().is_empty();
 
                 // Flush literal part
                 if !literal.is_empty() {
@@ -70,6 +121,8 @@ pub fn parse_pattern(
                 if !spec.is_default_unconstrained_string() {
                     allows_empty_default_string_match = false;
                 }
+
+                let has_trailing_literal = has_trailing_literal_before_next_field(chars.clone());
 
                 // Check if the next field (if any) is empty {} (non-greedy)
                 // This affects width-only string patterns: exact when followed by {}, greedy otherwise
@@ -146,7 +199,14 @@ pub fn parse_pattern(
                     }
                 };
 
-                let pattern = spec.to_regex_pattern(custom_patterns, next_field_is_greedy);
+                let allow_empty_delimited = allow_empty_delimited_default_string
+                    && spec.is_default_unconstrained_string()
+                    && (had_leading_literal || has_trailing_literal);
+                let pattern = spec.to_regex_pattern(
+                    custom_patterns,
+                    next_field_is_greedy,
+                    allow_empty_delimited,
+                );
 
                 // Validate repeated field names have same type
                 if let Some(ref original_name) = name {

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -168,3 +168,28 @@ def test_empty_string_default_string_fields_formatparse_issue16():
     assert r is not None
     assert r.named["a"] == "x"
     assert r.named["b"] == "y"
+
+
+def test_literal_plus_empty_default_string_formatparse_issue83():
+    """Parity with parse (parse#136 remainder): literal + default string may capture empty (#83)."""
+    r = parse.parse("/{url1}", "/")
+    assert r is not None
+    assert r.named["url1"] == ""
+
+    r = parse.parse("{path}/", "/")
+    assert r is not None
+    assert r.named["path"] == ""
+
+    r = parse.parse("a{}b", "ab")
+    assert r is not None
+    assert r[0] == ""
+
+    r = parse.parse("/{a}/{b}", "//")
+    assert r is not None
+    assert r.named["a"] == ""
+    assert r.named["b"] == ""
+
+    r = parse.parse("{}{}", "ab")
+    assert r is not None
+    assert r[0] == "a"
+    assert r[1] == "b"


### PR DESCRIPTION
## Summary

Implements [issue #83](https://github.com/eddiethedean/formatparse/issues/83) / upstream [parse#136](https://github.com/r1chardj0n3s/parse/issues/136): patterns like `"/{url1}"` now match `"/"` with `url1 == ""`, consistent with `str.format`.

## Behavior

- Default unconstrained string fields (`{}` / `{name}` with no width, precision, or alignment) compile to `.*?` instead of `.+?` when the field is adjacent to a **significant** pattern literal (trimmed literal non-empty), so empty segments next to slashes or other non-whitespace delimiters work.
- Whitespace-only literals between fields (for example the space in `"{} {}"`) do **not** enable empty capture, preserving splits like `"Hello, World"` on `"{}, {}"`.
- **parse** / **compile().parse** use the new fragments; **search** / **findall** still compile those segments as `.+?` so unanchored matching does not end after the first delimiter with an empty group.

## Tests

- Rust: `to_regex_pattern(..., true)` yields `.*?`.
- Pytest: `tests/test_bugs.py` covers `/{url1}`, `{path}/`, `a{}b`, `/{a}/{b}` on `"//"`, and `"{}{}"` on `"ab"`.

Closes #83.