### PR TITLE
fix: aligned string + precision before fixed-width int (closes #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **String fields with alignment + precision before a fixed-width integer** (e.g. ``"{n:>10.10}{x:02d}"``): leading fill in the regex is non-greedy so the slice for ``.{precision}`` is left for the following digit field (#88; related `parse#218 <https://github.com/r1chardj0n3s/parse/issues/218>`_).
 - **Default string fields next to literals** (e.g. ``"/{name}"``): an empty capture is allowed when it matches ``str.format`` output such as ``"/"`` for ``name=""`` (#83; upstream `parse#136 <https://github.com/r1chardj0n3s/parse/issues/136>`_). Applies to full-string **parse** / **compile().parse**; **search** / **findall** still use ``.+?`` for those segments so unanchored matching does not stop early.
 - **Integer `d`**: leading spaces and tabs before decimal digits are accepted (e.g. ``parse("{a:d}", "    0")``) for parity with padded ``str.format`` output (#81; upstream `parse#133 <https://github.com/r1chardj0n3s/parse/issues/133>`_).
 

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -67,12 +67,15 @@ impl FieldSpec {
                                 format!(".{{{}}}(?:{}*)", prec, fill_escaped)
                             }
                             '>' => {
-                                // Right-aligned: optional leading fill chars + content (precision chars)
-                                format!("(?:{}*).{{{}}}", fill_escaped, prec)
+                                // Right-aligned: optional leading fill + exactly `prec` characters.
+                                // Leading fill must be non-greedy so we do not consume the entire slice
+                                // before `.{{prec}}` when another field follows (issue #88 / parse#218).
+                                format!("(?:{}*?).{{{}}}", fill_escaped, prec)
                             }
                             '^' => {
-                                // Center-aligned: optional leading fill + content + optional trailing fill
-                                format!("(?:{}*).{{{}}}(?:{}*)", fill_escaped, prec, fill_escaped)
+                                // Center-aligned: optional leading fill + content + optional trailing fill.
+                                // Non-greedy leading fill for the same boundary reason as `>`.
+                                format!("(?:{}*?).{{{}}}(?:{}*)", fill_escaped, prec, fill_escaped)
                             }
                             _ => format!(".{{{}}}", prec),
                         }
@@ -124,9 +127,9 @@ impl FieldSpec {
                         let fill_escaped = regex::escape(&fill_ch.to_string());
                         match align {
                             '<' => format!("{}{{{}}}(?:{}*)", ML, prec, fill_escaped),
-                            '>' => format!("(?:{}*){}{{{}}}", fill_escaped, ML, prec),
+                            '>' => format!("(?:{}*?){}{{{}}}", fill_escaped, ML, prec),
                             '^' => format!(
-                                "(?:{}*){}{{{}}}(?:{}*)",
+                                "(?:{}*?){}{{{}}}(?:{}*)",
                                 fill_escaped, ML, prec, fill_escaped
                             ),
                             _ => format!("{}{{{}}}", ML, prec),

--- a/tests/test_alignment_precision.py
+++ b/tests/test_alignment_precision.py
@@ -147,3 +147,27 @@ def test_alignment_without_precision():
     result = parse("{s:<10}", "hello     ")
     assert result is not None
     assert result.named["s"] == "hello     "
+
+
+def test_issue88_aligned_string_then_zero_padded_int():
+    """Regression: right/zero-filled width+precision string + ``{:02d}`` (GitHub issue #88)."""
+    r = parse("{n:>10.10}{x:02d}", "000001000099")
+    assert r is not None
+    assert r.named["n"] == "0000010000"
+    assert r.named["x"] == 99
+
+    r = parse("{n:>10.10}{x:02d}", "     1000099")
+    assert r is not None
+    assert r.named["x"] == 99
+    assert r.named["n"] == "10000"
+
+    r = parse("{n:0>10.10}{x:02d}", "000001000099")
+    assert r is not None
+    assert r.named["n"] == "0000010000"
+    assert r.named["x"] == 99
+
+    r = parse("{s:<10.10}{n:0>10.10}{x:02d}", "0000bbbb  000001000099")
+    assert r is not None
+    assert r.named["s"] == "0000bbbb  "
+    assert r.named["n"] == "0000010000"
+    assert r.named["x"] == 99


### PR DESCRIPTION
## Summary

Fixes [issue #88](https://github.com/eddiethedean/formatparse/issues/88): patterns such as `"{n:>10.10}{x:02d}"` and `"{n:0>10.10}{x:02d}"` returned `None` for valid-looking input because the regex used **greedy** leading fill (`(?:fill*)`) before the fixed `.{precision}` slice, so all fill characters were consumed and fewer than `precision` characters remained for `.{}` (no match with the following `{:02d}`).

## Change

- In [`formatparse-core/src/types/regex.rs`](formatparse-core/src/types/regex.rs), use **non-greedy** leading fill (`*?`) for string (and `:ml` / `:blk`) patterns with **right** (`>`) and **center** (`^`) alignment when both alignment and precision are set.

## Tests

- [`tests/test_alignment_precision.py`](tests/test_alignment_precision.py): `test_issue88_aligned_string_then_zero_padded_int` covers the repro strings from the issue plus the already-working `000001000099` case.

Closes #88.