### PR TITLE
feat: input line continuations for :ml and :blk (closes #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Input line continuations** for ``:ml`` and ``:blk`` captures: a backslash before end-of-line in the matched text joins lines (same odd/even backslash rules as pattern continuations in #68); leading spaces and tabs on the continued line are stripped (#80).
+
 ### Fixed
 
 - **String fields with alignment + precision before a fixed-width integer** (e.g. ``"{n:>10.10}{x:02d}"``): leading fill in the regex is non-greedy so the slice for ``.{precision}`` is left for the following digit field (#88; related `parse#218 <https://github.com/r1chardj0n3s/parse/issues/218>`_).

--- a/formatparse-core/src/input_line_continuations.rs
+++ b/formatparse-core/src/input_line_continuations.rs
@@ -1,0 +1,106 @@
+//! Backslash–newline continuations in **matched input** for `:ml` / `:blk` fields (GitHub issue #80).
+//!
+//! Same rules as format **pattern** continuations (issue #68): a run of `k` backslashes immediately
+//! before a line ending (`\n` or `\r\n`) — if `k` is odd, the line continues (the last backslash
+//! plus the line break are removed, and `floor((k-1)/2)` literal backslashes are kept); if `k` is
+//! even, `k/2` literal backslashes are kept and the line break is preserved. After a continuation,
+//! ASCII spaces and tabs at the start of the next physical line are stripped.
+
+/// Fold backslash line continuations in captured multiline / indent-block text.
+pub fn normalize_input_line_continuations(input: &str) -> String {
+    let b = input.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0usize;
+    while i < b.len() {
+        let start = i;
+        let mut j = i;
+        while j < b.len() && b[j] != b'\n' && b[j] != b'\r' {
+            j += 1;
+        }
+        let seg = &b[start..j];
+        if j == b.len() {
+            out.extend_from_slice(seg);
+            break;
+        }
+        let mut k = 0usize;
+        let mut p = seg.len();
+        while p > 0 && seg[p - 1] == b'\\' {
+            k += 1;
+            p -= 1;
+        }
+        let prefix_end = seg.len().saturating_sub(k);
+        if k % 2 == 1 {
+            out.extend_from_slice(&seg[..prefix_end]);
+            let emit = (k - 1) / 2;
+            out.extend(std::iter::repeat_n(b'\\', emit));
+            if b[j] == b'\r' && j + 1 < b.len() && b[j + 1] == b'\n' {
+                i = j + 2;
+            } else {
+                i = j + 1;
+            }
+            while i < b.len() && matches!(b[i], b' ' | b'\t') {
+                i += 1;
+            }
+        } else {
+            out.extend_from_slice(seg);
+            if b[j] == b'\r' && j + 1 < b.len() && b[j + 1] == b'\n' {
+                out.push(b'\r');
+                out.push(b'\n');
+                i = j + 2;
+            } else {
+                out.push(b[j]);
+                i = j + 1;
+            }
+        }
+    }
+    String::from_utf8(out).expect("ASCII-only edits preserve UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn continuation_joins_lines() {
+        assert_eq!(normalize_input_line_continuations("foo\\\nbar"), "foobar");
+    }
+
+    #[test]
+    fn continuation_crlf() {
+        assert_eq!(
+            normalize_input_line_continuations("foo\\\r\nbar"),
+            "foobar"
+        );
+    }
+
+    #[test]
+    fn even_backslashes_keep_newline() {
+        assert_eq!(
+            normalize_input_line_continuations("foo\\\\\nbar"),
+            "foo\\\\\nbar"
+        );
+    }
+
+    #[test]
+    fn odd_three_backslashes() {
+        assert_eq!(normalize_input_line_continuations("a\\\\\\\nb"), "a\\b");
+    }
+
+    #[test]
+    fn literal_newline_unchanged() {
+        assert_eq!(normalize_input_line_continuations("a\nb"), "a\nb");
+    }
+
+    #[test]
+    fn empty() {
+        assert_eq!(normalize_input_line_continuations(""), "");
+    }
+
+    #[test]
+    fn continuation_strips_spaces_tabs_on_next_line() {
+        assert_eq!(
+            normalize_input_line_continuations("foo\\\n  \t  bar"),
+            "foobar"
+        );
+    }
+}

--- a/formatparse-core/src/lib.rs
+++ b/formatparse-core/src/lib.rs
@@ -5,10 +5,12 @@
 
 pub mod error;
 pub mod indent_block;
+pub mod input_line_continuations;
 pub mod parser;
 pub mod types;
 
 pub use indent_block::strip_common_indent;
+pub use input_line_continuations::normalize_input_line_continuations;
 pub use parser::{
     count_capturing_groups, validate_field_name, validate_input_length, validate_pattern_length,
     MAX_FIELDS, MAX_FIELD_NAME_LENGTH, MAX_INPUT_LENGTH, MAX_PATTERN_LENGTH,

--- a/formatparse-pyo3/src/parser/matching.rs
+++ b/formatparse-pyo3/src/parser/matching.rs
@@ -9,6 +9,18 @@ use pyo3::IntoPyObjectExt;
 use regex::{Captures, Regex};
 use std::collections::HashMap;
 
+/// String stored on `Match` when `evaluate_result` is false: fold input continuations for `:ml` / `:blk`.
+fn capture_string_for_match_storage(spec: &FieldSpec, raw: &str) -> String {
+    if matches!(
+        spec.field_type,
+        FieldType::Multiline | FieldType::IndentBlock
+    ) {
+        formatparse_core::normalize_input_line_continuations(raw)
+    } else {
+        raw.to_string()
+    }
+}
+
 /// Precomputed field metadata slices passed into capture-based match helpers.
 pub struct FieldCaptureSlices<'a> {
     pub field_specs: &'a [FieldSpec],
@@ -480,15 +492,18 @@ pub fn match_with_captures(
             // Store raw capture for Match object (only if needed)
             // Only allocate strings when evaluate_result=False (Match objects need owned strings)
             if !evaluate_result {
-                captures_vec.push(Some(value_str.to_string()));
+                captures_vec.push(Some(capture_string_for_match_storage(spec, value_str)));
                 if let Some(norm_name) = normalized_names.get(i).and_then(|n| n.as_ref()) {
-                    named_captures.insert(norm_name.clone(), value_str.to_string());
+                    named_captures.insert(
+                        norm_name.clone(),
+                        capture_string_for_match_storage(spec, value_str),
+                    );
                 }
             }
             // For evaluate_result=True, we don't need to store raw captures, saving allocations
 
             if evaluate_result {
-                if !crate::types::conversion::validate_alignment_precision(spec, value_str) {
+                if !crate::types::conversion::validate_alignment_precision_for_capture(spec, value_str) {
                     return Ok(None);
                 }
 
@@ -513,7 +528,7 @@ pub fn match_with_captures(
                             return Ok(None);
                         };
                         let vs = cap_j.as_str();
-                        if !crate::types::conversion::validate_alignment_precision(spec_j, vs) {
+                        if !crate::types::conversion::validate_alignment_precision_for_capture(spec_j, vs) {
                             return Ok(None);
                         }
                         let Some(fmt) = spec_j.strftime_format.as_ref() else {
@@ -730,16 +745,19 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                 let field_start = cap.start();
                 let field_end = cap.end();
 
-                // Store raw capture for Match object (only if needed)
+                // Store capture for Match object (only if needed); fold input continuations for :ml/:blk
                 if !evaluate_result {
-                    captures_vec.push(Some(value_str.to_string()));
+                    captures_vec.push(Some(capture_string_for_match_storage(spec, value_str)));
                     if let Some(norm_name) = normalized_names.get(i).and_then(|n| n.as_ref()) {
-                        named_captures.insert(norm_name.clone(), value_str.to_string());
+                        named_captures.insert(
+                            norm_name.clone(),
+                            capture_string_for_match_storage(spec, value_str),
+                        );
                     }
                 }
 
                 if evaluate_result {
-                    if !crate::types::conversion::validate_alignment_precision(spec, value_str) {
+                    if !crate::types::conversion::validate_alignment_precision_for_capture(spec, value_str) {
                         return Ok(None);
                     }
 
@@ -765,7 +783,7 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                                 return Ok(None);
                             };
                             let vs = cap_j.as_str();
-                            if !crate::types::conversion::validate_alignment_precision(spec_j, vs) {
+                            if !crate::types::conversion::validate_alignment_precision_for_capture(spec_j, vs) {
                                 return Ok(None);
                             }
                             let Some(fmt) = spec_j.strftime_format.as_ref() else {
@@ -989,7 +1007,7 @@ pub fn match_empty_default_string_parse(
         }
 
         if evaluate_result {
-            if !crate::types::conversion::validate_alignment_precision(spec, value_str) {
+            if !crate::types::conversion::validate_alignment_precision_for_capture(spec, value_str) {
                 return Ok(None);
             }
 

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -51,12 +51,18 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
     // For now, only handle built-in types
 
     match &spec.field_type {
-        FieldType::String | FieldType::Multiline => {
+        FieldType::String => {
             let t = crate::types::conversion::trim_string_or_multiline_value(spec, value);
             Ok(RawValue::String(t.into_owned()))
         }
+        FieldType::Multiline => {
+            let folded = formatparse_core::normalize_input_line_continuations(value);
+            let t = crate::types::conversion::trim_string_or_multiline_value(spec, folded.as_str());
+            Ok(RawValue::String(t.into_owned()))
+        }
         FieldType::IndentBlock => {
-            let t = crate::types::conversion::trim_string_or_multiline_value(spec, value);
+            let folded = formatparse_core::normalize_input_line_continuations(value);
+            let t = crate::types::conversion::trim_string_or_multiline_value(spec, folded.as_str());
             Ok(RawValue::String(formatparse_core::strip_common_indent(
                 t.as_ref(),
             )))

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -137,6 +137,20 @@ pub fn validate_alignment_precision(spec: &FieldSpec, value: &str) -> bool {
     true
 }
 
+/// Like [`validate_alignment_precision`], but for captures that may include backslash line
+/// continuations: multiline and indent-block slices are folded first (issue #80).
+pub(crate) fn validate_alignment_precision_for_capture(spec: &FieldSpec, raw: &str) -> bool {
+    if matches!(
+        spec.field_type,
+        FieldType::Multiline | FieldType::IndentBlock
+    ) {
+        let folded = formatparse_core::normalize_input_line_continuations(raw);
+        validate_alignment_precision(spec, folded.as_str())
+    } else {
+        validate_alignment_precision(spec, raw)
+    }
+}
+
 /// Trim fill / whitespace for string-like fields that support alignment (``String``, ``Multiline``, ``IndentBlock``).
 pub(crate) fn trim_string_or_multiline_value<'a>(
     spec: &FieldSpec,
@@ -236,11 +250,13 @@ pub fn convert_value(
             }
         }
         FieldType::Multiline => {
-            let trimmed = trim_string_or_multiline_value(spec, value);
+            let folded = formatparse_core::normalize_input_line_continuations(value);
+            let trimmed = trim_string_or_multiline_value(spec, folded.as_str());
             Ok(trimmed.into_py_any(py)?)
         }
         FieldType::IndentBlock => {
-            let trimmed = trim_string_or_multiline_value(spec, value);
+            let folded = formatparse_core::normalize_input_line_continuations(value);
+            let trimmed = trim_string_or_multiline_value(spec, folded.as_str());
             Ok(formatparse_core::strip_common_indent(trimmed.as_ref()).into_py_any(py)?)
         }
         FieldType::Integer => {

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -12,14 +12,18 @@ with :func:`with_pattern`. See :func:`compile` and the `Custom types user guide
 capture is non-greedy up to the next literal or field. Width, precision, alignment,
 and fill are supported like plain string fields (see `GitHub issue #70
 <https://github.com/eddiethedean/formatparse/issues/70>`_); sign, zero-padding, and
-``=`` alignment are not supported with ``:ml``.
+``=`` alignment are not supported with ``:ml``. Inside the matched text, a backslash
+immediately before end-of-line continues the line (same rules as long **patterns** in
+issue #68); doubled backslashes keep a literal newline (see `GitHub issue #80
+<https://github.com/eddiethedean/formatparse/issues/80>`_).
 
 **Indented blocks:** use ``{name:blk}`` when content is written as an indented block
 under a header: matching uses the same rules as ``:ml`` (non-greedy up to the next
 literal or field), then the captured text is **dedented** by removing the largest
 common prefix of spaces and tabs from each line (blank lines do not contribute to
 that margin; tabs count as single characters). See `GitHub issue #69
-<https://github.com/eddiethedean/formatparse/issues/69>`_. If a pattern literal ends
+<https://github.com/eddiethedean/formatparse/issues/69>`_. The same backslash line
+continuation rules as for ``:ml`` apply to matched input (issue #80). If a pattern literal ends
 with trailing whitespace before ``{...:blk}``, it is compiled as ``\\s+`` and may
 consume the block's leading spaces—keep the newline outside that literal chunk when
 you need a margin (e.g. ``key:{body:blk}\\nEND`` rather than ``key:\\n{body:blk}``).

--- a/tests/test_indent_block.py
+++ b/tests/test_indent_block.py
@@ -53,3 +53,9 @@ def test_blk_rejects_sign():
 def test_blk_rejects_equals_alignment():
     with pytest.raises(ValueError, match=":blk"):
         compile("{x:=10blk}")
+
+
+def test_blk_input_line_continuation_then_dedent_issue80():
+    """Input continuations run before :blk dedent (issue #80)."""
+    r = parse("BEGIN\n{body:blk}\nEND", "BEGIN\n  x\\\n  y\nEND")
+    assert r.named["body"] == "xy"

--- a/tests/test_multiline.py
+++ b/tests/test_multiline.py
@@ -89,3 +89,15 @@ def test_plain_brace_newline_regression():
     """Unchanged: default ``{}`` between anchors still parses across newlines."""
     r = parse("X{}Y", "Xa\nbY")
     assert r.fixed[0] == "a\nb"
+
+
+def test_ml_input_line_continuation_issue80():
+    """Backslash at end of line inside the capture joins lines (issue #80)."""
+    r = parse("BEGIN\n{body:ml}\nEND", "BEGIN\nalpha\\\nbeta\nEND")
+    assert r.named["body"] == "alphabeta"
+
+    r = parse("BEGIN\n{body:ml}\nEND", "BEGIN\nalpha\\\\\nbeta\nEND")
+    assert r.named["body"] == "alpha\\\\\nbeta"
+
+    r = parse("BEGIN\n{body:ml}\nEND", "BEGIN\nalpha\\\n  beta\nEND")
+    assert r.named["body"] == "alphabeta"


### PR DESCRIPTION
## Summary

Implements [issue #80](https://github.com/eddiethedean/formatparse/issues/80): backslash-at-end-of-line inside **matched input** for ``:ml`` and ``:blk`` fields, using the same odd/even backslash rules as **pattern** continuations ([#68](https://github.com/eddiethedean/formatparse/issues/68)): join lines when the count of trailing ``\`` before ``\n`` / ``\r\n`` is odd; strip leading ASCII spaces/tabs on the continued line; doubled backslashes keep a literal newline.

## Scope

- **Field types:** ``FieldType::Multiline`` and ``FieldType::IndentBlock`` only (plain ``String`` unchanged).
- **Order:** fold continuations on the capture **before** alignment trim and **before** ``:blk`` dedent.

## Code

- New [`formatparse-core/src/input_line_continuations.rs`](formatparse-core/src/input_line_continuations.rs): ``normalize_input_line_continuations``.
- Wired in [`formatparse-pyo3/src/types/conversion.rs`](formatparse-pyo3/src/types/conversion.rs) (``convert_value`` + ``validate_alignment_precision_for_capture``), [`raw_match.rs`](formatparse-pyo3/src/parser/raw_match.rs), and [`matching.rs`](formatparse-pyo3/src/parser/matching.rs) (``Match`` string storage when ``evaluate_result`` is false).

## Tests / docs

- [`tests/test_multiline.py`](tests/test_multiline.py), [`tests/test_indent_block.py`](tests/test_indent_block.py)
- [`CHANGELOG.md`](CHANGELOG.md), [`formatparse/__init__.py`](formatparse/__init__.py) module doc

Closes #80.