### PR TITLE
fix: integer width + precision bounded digit runs (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Integer and radix fields with both width and precision** (e.g. ``"{:2.2d}{:2.2d}"``, ``"#{:2.2x}{:2.2x}"``): digit runs use inclusive min/max bounds (parse semantics: width = minimum digits, precision = maximum) so adjacent fields no longer steal digits with a greedy ``+`` (#82; upstream `parse#107 <https://github.com/r1chardj0n3s/parse/issues/107>`_). Patterns that previously matched too loosely on short inputs may now return no match.
 - **String fields with alignment + precision before a fixed-width integer** (e.g. ``"{n:>10.10}{x:02d}"``): leading fill in the regex is non-greedy so the slice for ``.{precision}`` is left for the following digit field (#88; related `parse#218 <https://github.com/r1chardj0n3s/parse/issues/218>`_).
 - **Default string fields next to literals** (e.g. ``"/{name}"``): an empty capture is allowed when it matches ``str.format`` output such as ``"/"`` for ``name=""`` (#83; upstream `parse#136 <https://github.com/r1chardj0n3s/parse/issues/136>`_). Applies to full-string **parse** / **compile().parse**; **search** / **findall** still use ``.+?`` for those segments so unanchored matching does not stop early.
 - **Integer `d`**: leading spaces and tabs before decimal digits are accepted (e.g. ``parse("{a:d}", "    0")``) for parity with padded ``str.format`` output (#81; upstream `parse#133 <https://github.com/r1chardj0n3s/parse/issues/133>`_).

--- a/docs/user_guides/patterns.rst
+++ b/docs/user_guides/patterns.rst
@@ -141,6 +141,23 @@ You can combine alignment, width, and precision:
    >>> result.named['value']
    'Hello'
 
+Integer width and precision (``#82`` / ``parse#107``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Python’s ``str.format`` does not allow a ``.precision`` on integer ``d`` presentation types.
+formatparse still accepts ``width.precision`` in patterns: **width** is treated as a **minimum**
+number of significant digits and **precision** as a **maximum** (inclusive), matching the
+`parse <https://github.com/r1chardj0n3s/parse>`_ library documentation. That yields bounded
+digit runs so several adjacent integer fields do not consume the string greedily.
+
+.. code-block:: python
+
+   from formatparse import parse
+
+   assert parse("#{:2.2x}{:2.2x}{:2.2x}", "#FFFFFF").fixed == (255, 255, 255)
+   assert parse("{:2.2d}{:2.2d}{:2.2d}", "123456").fixed == (12, 34, 56)
+   assert parse("{:2.2d}{:2.2d}{:2.2d}", "9999") is None
+
 Positional vs Named Fields
 --------------------------
 

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -2,6 +2,39 @@ use crate::types::definitions::{FieldSpec, FieldType};
 use regex;
 use std::collections::HashMap;
 
+/// When [`FieldSpec::width`] and [`FieldSpec::precision`] are both set on integer fields
+/// (`d` / `i` / `x` / `X` / `o` / `b`), the significant digit run uses a bounded repetition
+/// `{min_digits,max_digits}` (inclusive).
+///
+/// This follows the **parse** library documentation (`parse#107`): width is a **minimum**
+/// number of digits and precision a **maximum**. Python’s `str.format` rejects `.precision`
+/// on integer `d` presentation types; formatparse still accepts it in patterns and applies
+/// these bounds so adjacent numeric fields do not greedily consume more digits than the
+/// maximum. The `next_field_is_greedy` hint used for width-only **string** fields does not
+/// apply here—the digit count is already capped by `precision`.
+///
+/// Returns [`None`] when the pair should fall back to legacy rules: missing width or
+/// precision, or **zero-padded** fields with `width > precision` (treated as width-only
+/// `{1,width}` so wide zero-filled fields are not collapsed to `precision` digits).
+///
+/// For non-zero-padded fields with `width > precision` (an inconsistent min/max pair), the
+/// quantifier degenerates to exactly `precision` digits.
+fn int_width_precision_bounds(
+    width: Option<usize>,
+    precision: Option<usize>,
+    zero_pad: bool,
+) -> Option<(usize, usize)> {
+    let w = width?;
+    let p = precision?;
+    if w <= p {
+        Some((w, p))
+    } else if zero_pad {
+        None
+    } else {
+        Some((p, p))
+    }
+}
+
 /// Convert strftime format string to regex pattern
 pub fn strftime_to_regex(format_str: &str) -> String {
     let mut regex_parts = Vec::new();
@@ -177,13 +210,56 @@ impl FieldSpec {
                         (String::new(), String::new())
                     };
 
+                let width_precision =
+                    int_width_precision_bounds(self.width, self.precision, self.zero_pad);
+
                 let base_pattern = if self.zero_pad {
-                    // Zero-padded: if width is specified, match 1 to width digits
-                    // This allows unpadded values (e.g., '9' for {c:02d}) but rejects values exceeding width
-                    if let Some(width) = self.width {
+                    if let Some((lo, hi)) = width_precision {
+                        // Both width and precision: bounded digit count (formatparse#82 / parse#107).
+                        format!(
+                            "{}{}{}[0-9]{{{},{}}}",
+                            sign, fill_prefix, fill_suffix, lo, hi
+                        )
+                    } else if let Some(width) = self.width {
+                        // Zero-padded: if width is specified, match 1 to width digits
+                        // This allows unpadded values (e.g., '9' for {c:02d}) but rejects values exceeding width
                         format!("{}{}{}[0-9]{{1,{}}}", sign, fill_prefix, fill_suffix, width)
                     } else {
                         format!("{}{}{}[0-9]+", sign, fill_prefix, fill_suffix)
+                    }
+                } else if let Some((lo, hi)) = width_precision {
+                    let q_hex = format!("[0-9a-fA-F]{{{},{}}}", lo, hi);
+                    let q_oct = format!("[0-7]{{{},{}}}", lo, hi);
+                    let q_bin = format!("[01]{{{},{}}}", lo, hi);
+                    let q_dec = format!("[0-9]{{{},{}}}", lo, hi);
+                    match self.original_type_char {
+                        Some('x') | Some('X') => {
+                            // Hex: bounded digit run after optional 0x (parse#107 / #82).
+                            format!(
+                                "{}{}{}(?:0[xX]{}|{})",
+                                sign, fill_prefix, fill_suffix, q_hex, q_hex
+                            )
+                        }
+                        Some('o') => {
+                            format!(
+                                "{}{}{}(?:0[oO]{}|{})",
+                                sign, fill_prefix, fill_suffix, q_oct, q_oct
+                            )
+                        }
+                        Some('b') => {
+                            format!(
+                                "{}{}{}(?:0[bB]{}|{})",
+                                sign, fill_prefix, fill_suffix, q_bin, q_bin
+                            )
+                        }
+                        _ => {
+                            // Decimal `d` / `i`: optional leading whitespace before digits (#81);
+                            // each radix branch uses the same inclusive min/max digit count.
+                            format!(
+                                "{}{}{}(?:0[xX]{}|0[oO]{}|0[bB]{}|\\s*{})",
+                                sign, fill_prefix, fill_suffix, q_hex, q_oct, q_bin, q_dec
+                            )
+                        }
                     }
                 } else {
                     // Check original type to determine what digits to match
@@ -770,5 +846,60 @@ mod tests {
         let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
         // Should have fill pattern between sign and digits
         assert!(pattern.contains("x*"));
+    }
+
+    #[test]
+    fn test_field_spec_integer_decimal_width_and_precision_bounded() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Integer;
+        spec.width = Some(2);
+        spec.precision = Some(2);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
+        assert!(pattern.contains(r"[0-9]{2,2}"), "pattern: {}", pattern);
+        let re = Regex::new(&format!("^{}$", pattern)).unwrap();
+        assert!(re.is_match("99"));
+        assert!(!re.is_match("999"));
+    }
+
+    #[test]
+    fn test_field_spec_integer_hex_width_and_precision_bounded() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Integer;
+        spec.original_type_char = Some('x');
+        spec.width = Some(2);
+        spec.precision = Some(2);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
+        assert!(pattern.contains(r"[0-9a-fA-F]{2,2}"), "pattern: {}", pattern);
+    }
+
+    #[test]
+    fn test_field_spec_integer_width_gt_precision_nonzero_pad_degenerates() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Integer;
+        spec.width = Some(5);
+        spec.precision = Some(2);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
+        assert!(pattern.contains(r"[0-9]{2,2}"), "pattern: {}", pattern);
+    }
+
+    #[test]
+    fn test_field_spec_integer_width_gt_precision_zero_pad_uses_width_only() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Integer;
+        spec.zero_pad = true;
+        spec.width = Some(30);
+        spec.precision = Some(2);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
+        assert!(pattern.contains("[0-9]{1,30}"), "pattern: {}", pattern);
+    }
+
+    #[test]
+    fn test_field_spec_integer_decimal_width_2_precision_5() {
+        let mut spec = FieldSpec::new();
+        spec.field_type = FieldType::Integer;
+        spec.width = Some(2);
+        spec.precision = Some(5);
+        let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
+        assert!(pattern.contains(r"[0-9]{2,5}"), "pattern: {}", pattern);
     }
 }

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -40,7 +40,11 @@ integer-like text as well as forms with a trailing dot or trailing fractional ze
 
 **Integer decimal ``d``:** optional leading spaces and tabs are allowed before the digit
 run so values such as ``"    0"`` match ``{a:d}`` when they mirror padded numeric output
-(see `GitHub issue #81 <https://github.com/eddiethedean/formatparse/issues/81>`_).
+(see `GitHub issue #81 <https://github.com/eddiethedean/formatparse/issues/81>`_). When
+both **width** and **.precision** are present on integer or radix fields (e.g. ``{:2.2d}``,
+``{:2.2x}``), the digit run is bounded: at least ``width`` digits and at most ``precision``
+(`GitHub issue #82 <https://github.com/eddiethedean/formatparse/issues/82>`_; `parse#107
+<https://github.com/r1chardj0n3s/parse/issues/107>`_).
 
 **Composition (sub-parsers):** use :func:`composed_type` to wrap a compiled
 :class:`FormatParser` and pass it in ``extra_types`` so one field is parsed by the

--- a/tests/test_integer_width_precision.py
+++ b/tests/test_integer_width_precision.py
@@ -1,0 +1,58 @@
+"""Integer (and radix) fields with both width and precision (GitHub #82, parse#107)."""
+
+from formatparse import parse
+
+
+def test_issue82_hex_white_six_nibbles_three_fields():
+    r = parse("#{:2.2x}{:2.2x}{:2.2x}", "#FFFFFF")
+    assert r is not None
+    assert r.fixed == (255, 255, 255)
+
+
+def test_issue82_decimal_six_digits_three_fields():
+    r = parse("{:2.2d}{:2.2d}{:2.2d}", "123456")
+    assert r is not None
+    assert r.fixed == (12, 34, 56)
+
+
+def test_issue82_decimal_four_digits_insufficient_for_three_fields():
+    assert parse("{:2.2d}{:2.2d}{:2.2d}", "9999") is None
+
+
+def test_issue82_hex_four_nibbles_insufficient_for_three_fields():
+    assert parse("#{:2.2x}{:2.2x}{:2.2x}", "#FFFF") is None
+
+
+def test_issue82_hex_three_nibbles_insufficient_for_three_fields():
+    assert parse("#{:2.2x}{:2.2x}{:2.2x}", "#FFF") is None
+
+
+def test_issue82_binary_adjacent_bounded():
+    r = parse("{:2.2b}{:2.2b}", "1111")
+    assert r is not None
+    assert r.fixed == (3, 3)
+
+
+def test_issue82_octal_adjacent_bounded():
+    r = parse("{:2.2o}{:2.2o}", "7777")
+    assert r is not None
+    assert r.fixed == (63, 63)
+
+
+def test_issue82_zero_pad_width_and_precision():
+    r = parse("v:{n:02.2d}", "v:99")
+    assert r is not None
+    assert r.named["n"] == 99
+    assert parse("v:{n:02.2d}", "v:999") is None
+
+
+def test_issue82_width_2_precision_5_allows_three_digit_decimal():
+    r = parse("n:{n:2.5d}", "n:999")
+    assert r is not None
+    assert r.named["n"] == 999
+
+
+def test_issue82_regression_leading_space_decimal_still_allowed():
+    r = parse("x:{a:2.2d}", "x:  99")
+    assert r is not None
+    assert r.named["a"] == 99


### PR DESCRIPTION
## Summary

Implements [GitHub issue #82](https://github.com/eddiethedean/formatparse/issues/82) / [parse#107](https://github.com/r1chardj0n3s/parse/issues/107): when **both** width and precision are set on integer and radix fields (`d` / `i` / `x` / `X` / `o` / `b`), the digit run uses an inclusive `{width,precision}` quantifier instead of a greedy `+`, so adjacent fields get predictable boundaries.

## Semantics

- Follows the **parse** documentation: **width** = minimum digits, **precision** = maximum digits (inclusive). Python `str.format` rejects `.precision` on integer `d`; formatparse documents this extension in `docs/user_guides/patterns.rst`, the `formatparse` package docstring, and comments on `int_width_precision_bounds` in `formatparse-core/src/types/regex.rs`.
- **`next_field_is_greedy`** (used for width-only string fields) does not apply: the digit count is already capped by `precision`.
- **Zero-pad** with `width > precision`: fall back to legacy width-only `[0-9]{1,width}` so wide zero-filled fields are not collapsed to `precision` digits.
- **Non-zero-pad** with `width > precision`: degenerate to exactly `precision` digits (invalid min/max pair).

## Migration

Patterns that relied on greedy digit consumption (e.g. three `{:2.2d}` fields on `"9999"`) may now return **no match** where every field cannot satisfy `width`–`precision` bounds.

## Tests

- `cargo test` (formatparse-core + formatparse-pyo3)
- `make test` (full pytest)

Closes #82