### PR TITLE
feat: nested format patterns in field specs (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nested format patterns** in a field's format specification (e.g. ``{outer:{inner:d}}``): the inner ``{…}`` is compiled as its own pattern, the outer capture is parsed again, and nested values appear as ``ParseResult`` objects under ``named`` (issue `#12 <https://github.com/eddiethedean/formatparse/issues/12>`_; upstream `parse#206 <https://github.com/r1chardj0n3s/parse/issues/206>`_). Brace-balanced scanning applies in the spec after ``:``; nesting depth is capped at 10; ``findall`` and ``FindallIter`` use the Python match path when nested fields are present (same rule as nested dict field names).
 - **Input line continuations** for ``:ml`` and ``:blk`` captures: a backslash before end-of-line in the matched text joins lines (same odd/even backslash rules as pattern continuations in #68); leading spaces and tabs on the continued line are stripped (#80).
 
 ### Fixed

--- a/docs/user_guides/patterns.rst
+++ b/docs/user_guides/patterns.rst
@@ -86,6 +86,26 @@ Pattern literals still use doubled braces ``{{`` and ``}}`` for a single
 literal brace in the *pattern* string; ``:brace`` is only for matching
 brace-wrapped **payload** in the **input**.
 
+Nested format patterns in a field spec (``#12``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the text after ``:`` is itself a balanced brace pattern that looks like a
+mini format field (for example ``{inner:d}``), formatparse compiles it as an
+inner pattern, matches it as part of the outer field, then parses the captured
+substring again. Nested values show up as :class:`ParseResult` instances under
+the outer field name (``result.named["outer"].named["inner"]``). Nesting depth
+when compiling is capped at 10; ``{{`` / ``}}`` in the **pattern** string still
+denote literal braces in pattern text—inside the nested spec substring, a ``}``
+that closes an inner field is **not** merged with the following ``}`` that
+closes the outer field.
+
+.. doctest::
+
+   >>> from formatparse import parse
+   >>> r = parse("{outer:{inner:d}}", "42")
+   >>> r.named["outer"].named["inner"]
+   42
+
 Format Specifiers
 -----------------
 

--- a/formatparse-core/src/types/definitions.rs
+++ b/formatparse-core/src/types/definitions.rs
@@ -32,6 +32,8 @@ pub enum FieldType {
     /// Indented block: same match boundaries as ``:ml``, then strip common leading spaces/tabs
     /// per line (issue #69). Format specifier ``:blk``.
     IndentBlock,
+    /// Entire format spec is a nested brace pattern (e.g. ``{outer:{inner:d}}``); see formatparse#12.
+    Nested,
     Custom(String),
 }
 
@@ -47,6 +49,10 @@ pub struct FieldSpec {
     pub zero_pad: bool,
     pub strftime_format: Option<String>, // For strftime-style patterns
     pub original_type_char: Option<char>, // Original type character (e.g., 'b', 'o', 'x' for binary/octal/hex)
+    /// When ``field_type`` is ``Nested``: inner pattern text (e.g. ``"{inner:d}"``).
+    pub nested_subpattern: Option<String>,
+    /// Unanchored regex body for the inner pattern (filled after recursive compile; issue #12).
+    pub nested_regex_body: Option<String>,
 }
 
 impl Default for FieldSpec {
@@ -62,6 +68,8 @@ impl Default for FieldSpec {
             zero_pad: false,
             strftime_format: None,
             original_type_char: None,
+            nested_subpattern: None,
+            nested_regex_body: None,
         }
     }
 }
@@ -147,6 +155,8 @@ mod tests {
             zero_pad: true,
             strftime_format: Some("%Y-%m-%d".to_string()),
             original_type_char: Some('d'),
+            nested_subpattern: None,
+            nested_regex_body: None,
         };
 
         assert_eq!(spec.name, Some("test".to_string()));

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -453,6 +453,11 @@ impl FieldSpec {
                 // Placeholder: named patterns use special regex in the PyO3 pattern compiler.
                 r".*?".to_string()
             }
+            FieldType::Nested => self
+                .nested_regex_body
+                .as_deref()
+                .unwrap_or(r"[\s\S]*?")
+                .to_string(),
             FieldType::Boolean => {
                 "true|false|True|False|TRUE|FALSE|1|0|yes|no|Yes|No|YES|NO|on|off|On|Off|ON|OFF"
                     .to_string()

--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -345,8 +345,16 @@ fn findall(
         .map(|et| !et.is_empty())
         .unwrap_or(false);
     let has_nested_dicts = parser.has_nested_dict_fields.iter().any(|&b| b);
+    let has_nested_format_fields = parser
+        .field_specs
+        .iter()
+        .any(|s| matches!(s.field_type, FieldType::Nested));
 
-    if !has_custom_converters && evaluate_result && !has_nested_dicts {
+    if !has_custom_converters
+        && evaluate_result
+        && !has_nested_dicts
+        && !has_nested_format_fields
+    {
         // Use raw matching path: collect all raw data first (NO GIL), then batch convert
         let mut raw_results = Vec::new();
         let search_regex = parser.get_search_regex(case_sensitive);
@@ -374,6 +382,7 @@ fn findall(
                     normalized_names: &parser.normalized_names,
                     custom_type_groups: &parser.custom_type_groups,
                     has_nested_dict_fields: &parser.has_nested_dict_fields,
+                    nested_parsers: &parser.nested_parsers,
                 },
             ) {
                 raw_results.push(raw_data);
@@ -427,6 +436,7 @@ fn findall(
                         normalized_names: &parser.normalized_names,
                         custom_type_groups: &parser.custom_type_groups,
                         has_nested_dict_fields: &parser.has_nested_dict_fields,
+                        nested_parsers: &parser.nested_parsers,
                     },
                     py,
                     custom_converters: extra_types_ref,

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -2,9 +2,10 @@ use crate::error;
 use crate::parser::matching::{
     match_with_captures, match_with_captures_raw, CapturedMatchContext, FieldCaptureSlices,
 };
+use crate::result::ParseResult;
 use formatparse_core::count_capturing_groups;
 use formatparse_core::parser::{validate_input_length, MAX_FIELDS};
-use formatparse_core::FieldSpec;
+use formatparse_core::{FieldSpec, FieldType};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyString, PyTuple};
@@ -45,6 +46,8 @@ pub struct FormatParser {
     pub(crate) field_count: usize,             // Cached field count for fast path optimizations
     pub(crate) has_nested_dict_fields: Vec<bool>, // Cached flags: does field name contain '[' (nested dict)?
     allows_empty_default_string_match: bool, // True iff parse("") can use empty-field fast path (issue #16)
+    /// Per-field compiled parsers when ``field_type`` is ``Nested`` (issue #12).
+    pub(crate) nested_parsers: Vec<Option<Arc<FormatParser>>>,
 }
 
 impl FormatParser {
@@ -86,6 +89,7 @@ impl FormatParser {
             extra_types.as_ref(),
             &custom_patterns,
             true,
+            0,
         )?;
 
         // Search/findall use a separate compile path without "empty delimited" `.*?` groups so
@@ -95,6 +99,7 @@ impl FormatParser {
             extra_types.as_ref(),
             &custom_patterns,
             false,
+            0,
         )?;
 
         // Validate field count
@@ -106,6 +111,27 @@ impl FormatParser {
             )));
         }
 
+        let nested_parsers: Vec<Option<Arc<FormatParser>>> = Python::with_gil(|py| -> PyResult<_> {
+            let mut out = Vec::with_capacity(field_specs.len());
+            for spec in &field_specs {
+                if matches!(spec.field_type, FieldType::Nested) {
+                    let sub = spec.nested_subpattern.as_ref().ok_or_else(|| {
+                        PyValueError::new_err("internal error: nested field missing subpattern")
+                    })?;
+                    let cloned_et = extra_types.as_ref().map(|m| {
+                        m.iter()
+                            .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                            .collect::<HashMap<_, _>>()
+                    });
+                    out.push(Some(Arc::new(FormatParser::new_with_extra_types(
+                        sub, cloned_et,
+                    )?)));
+                } else {
+                    out.push(None);
+                }
+            }
+            Ok(out)
+        })?;
         // Pre-compute custom type validation results (pattern_groups per field)
         // This avoids calling validate_custom_type_pattern for every match
         let custom_type_groups = Python::with_gil(|py| -> PyResult<Vec<usize>> {
@@ -117,16 +143,21 @@ impl FormatParser {
                 .unwrap_or(&empty_map);
 
             for spec in &field_specs {
-                if !custom_converters.is_empty() {
-                    let pattern_groups = crate::parser::matching::validate_custom_type_pattern(
+                let pattern_groups = if matches!(spec.field_type, FieldType::Nested) {
+                    spec.nested_regex_body
+                        .as_ref()
+                        .map(|b| count_capturing_groups(b))
+                        .unwrap_or(0)
+                } else if !custom_converters.is_empty() {
+                    crate::parser::matching::validate_custom_type_pattern(
                         spec,
                         custom_converters,
                         py,
-                    )?;
-                    groups.push(pattern_groups);
+                    )?
                 } else {
-                    groups.push(0);
-                }
+                    0
+                };
+                groups.push(pattern_groups);
             }
             Ok(groups)
         })?;
@@ -171,6 +202,7 @@ impl FormatParser {
             field_count: field_specs.len(), // Cache field count for fast path
             has_nested_dict_fields,         // Cache nested dict flags
             allows_empty_default_string_match,
+            nested_parsers,
         })
     }
 
@@ -205,6 +237,7 @@ impl FormatParser {
                         field_specs: &self.field_specs,
                         field_names: &self.field_names,
                         normalized_names: &self.normalized_names,
+                        nested_parsers: &self.nested_parsers,
                         py,
                         custom_converters: extra_types_ref,
                         evaluate_result,
@@ -258,6 +291,7 @@ impl FormatParser {
                     field_specs: &self.field_specs,
                     field_names: &self.field_names,
                     normalized_names: &self.normalized_names,
+                    nested_parsers: &self.nested_parsers,
                     py,
                     custom_converters: extra_types_ref,
                     evaluate_result,
@@ -291,6 +325,34 @@ impl FormatParser {
                 .unwrap_or(&self.search_regex)
         }
     }
+
+    /// Parse one capture slice with this parser's pattern (nested fields, issue #12).
+    pub(crate) fn parse_nested_capture(
+        &self,
+        py: Python<'_>,
+        slice: &str,
+        custom_converters: &HashMap<String, PyObject>,
+    ) -> PyResult<Option<Py<ParseResult>>> {
+        use pyo3::types::PyAnyMethods;
+        let mut merged = HashMap::new();
+        if let Some(ref stored) = self.stored_extra_types {
+            for (k, v) in stored {
+                merged.insert(k.clone(), v.clone_ref(py));
+            }
+        }
+        for (k, v) in custom_converters {
+            merged.insert(k.clone(), v.clone_ref(py));
+        }
+        let opt = self.parse_internal(slice, true, Some(&merged), true)?;
+        let Some(obj) = opt else {
+            return Ok(None);
+        };
+        let bound = obj.bind(py);
+        let pr = bound.downcast::<ParseResult>().map_err(|_| {
+            PyValueError::new_err("internal error: nested parse did not return ParseResult")
+        })?;
+        Ok(Some(pr.clone().unbind()))
+    }
 }
 
 impl Clone for FormatParser {
@@ -315,6 +377,7 @@ impl Clone for FormatParser {
             field_count: self.field_count,
             has_nested_dict_fields: self.has_nested_dict_fields.clone(),
             allows_empty_default_string_match: self.allows_empty_default_string_match,
+            nested_parsers: self.nested_parsers.clone(),
         })
     }
 }
@@ -350,6 +413,7 @@ impl FormatParser {
                     field_count: 0,
                     has_nested_dict_fields: Vec::new(),
                     allows_empty_default_string_match: false,
+                    nested_parsers: Vec::new(),
                 })
             }
         }
@@ -673,7 +737,14 @@ impl FindallIter {
     ) -> Self {
         let has_custom_converters = !extra_types.is_empty();
         let has_nested_dicts = parser.has_nested_dict_fields.iter().any(|&b| b);
-        let fast_path = !has_custom_converters && evaluate_result && !has_nested_dicts;
+        let has_nested_format_fields = parser
+            .field_specs
+            .iter()
+            .any(|s| matches!(s.field_type, FieldType::Nested));
+        let fast_path = !has_custom_converters
+            && evaluate_result
+            && !has_nested_dicts
+            && !has_nested_format_fields;
         Self {
             parser,
             haystack,
@@ -718,6 +789,7 @@ impl FindallIter {
                     normalized_names: &slf.parser.normalized_names,
                     custom_type_groups: &slf.parser.custom_type_groups,
                     has_nested_dict_fields: &slf.parser.has_nested_dict_fields,
+                    nested_parsers: &slf.parser.nested_parsers,
                 };
 
                 match match_with_captures_raw(&caps, &slf.haystack, match_start, &slices) {
@@ -763,6 +835,7 @@ impl FindallIter {
                     normalized_names: &slf.parser.normalized_names,
                     custom_type_groups: &slf.parser.custom_type_groups,
                     has_nested_dict_fields: &slf.parser.has_nested_dict_fields,
+                    nested_parsers: &slf.parser.nested_parsers,
                 },
                 py,
                 custom_converters: &slf.extra_types,

--- a/formatparse-pyo3/src/parser/matching.rs
+++ b/formatparse-pyo3/src/parser/matching.rs
@@ -1,5 +1,6 @@
 use crate::error;
 use crate::match_rs::{Match, MatchInit};
+use crate::parser::format_parser::FormatParser;
 use crate::parser::raw_match::{RawMatchData, RawValue};
 use crate::result::ParseResult;
 use formatparse_core::{count_capturing_groups, FieldSpec, FieldType};
@@ -8,6 +9,7 @@ use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 use regex::{Captures, Regex};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// String stored on `Match` when `evaluate_result` is false: fold input continuations for `:ml` / `:blk`.
 fn capture_string_for_match_storage(spec: &FieldSpec, raw: &str) -> String {
@@ -28,6 +30,7 @@ pub struct FieldCaptureSlices<'a> {
     pub normalized_names: &'a [Option<String>],
     pub custom_type_groups: &'a [usize],
     pub has_nested_dict_fields: &'a [bool],
+    pub nested_parsers: &'a [Option<Arc<FormatParser>>],
 }
 
 /// Pattern, field layout, and Python conversion context for [`match_with_captures`].
@@ -46,6 +49,7 @@ pub struct RegexMatchContext<'a> {
     pub field_specs: &'a [FieldSpec],
     pub field_names: &'a [Option<String>],
     pub normalized_names: &'a [Option<String>],
+    pub nested_parsers: &'a [Option<Arc<FormatParser>>],
     pub py: Python<'a>,
     pub custom_converters: &'a HashMap<String, PyObject>,
     pub evaluate_result: bool,
@@ -203,6 +207,11 @@ fn per_field_capture_geometry(
     for (i, spec) in field_specs.iter().enumerate() {
         let pattern_groups = if let Some(pc) = precomputed_pattern_groups {
             pc.get(i).copied().unwrap_or(0)
+        } else if matches!(spec.field_type, FieldType::Nested) {
+            spec.nested_regex_body
+                .as_ref()
+                .map(|b| count_capturing_groups(b))
+                .unwrap_or(0)
         } else if !custom_converters.is_empty() {
             validate_custom_type_pattern(spec, custom_converters, py)?
         } else {
@@ -262,6 +271,9 @@ pub fn validate_custom_type_pattern(
     custom_converters: &HashMap<String, PyObject>,
     py: Python,
 ) -> PyResult<usize> {
+    if matches!(&field_spec.field_type, FieldType::Nested) {
+        return Ok(0);
+    }
     let mut pattern_groups = 0;
 
     if let formatparse_core::FieldType::Custom(type_name) = &field_spec.field_type {
@@ -346,6 +358,10 @@ pub fn match_with_captures_raw(
 
     for (i, spec) in field_specs.iter().enumerate() {
         let pattern_groups = custom_type_groups.get(i).copied().unwrap_or(0);
+
+        if matches!(spec.field_type, FieldType::Nested) {
+            return Err("Nested format fields require Python conversion".to_string());
+        }
 
         let cap = extract_capture(
             captures,
@@ -582,12 +598,29 @@ pub fn match_with_captures(
                         fixed.push(converted);
                     }
                 } else {
-                    let converted = crate::types::conversion::convert_value(
-                        spec,
-                        value_str,
-                        py,
-                        custom_converters,
-                    )?;
+                    let converted: PyObject = if matches!(spec.field_type, FieldType::Nested) {
+                        let nested_arc = ctx
+                            .fields
+                            .nested_parsers
+                            .get(i)
+                            .and_then(|x| x.as_ref())
+                            .ok_or_else(|| {
+                                pyo3::exceptions::PyValueError::new_err(
+                                    "internal error: nested parser missing",
+                                )
+                            })?;
+                        match nested_arc.parse_nested_capture(py, value_str, custom_converters)? {
+                            Some(pr) => pr.into_py_any(py)?,
+                            None => return Ok(None),
+                        }
+                    } else {
+                        crate::types::conversion::convert_value(
+                            spec,
+                            value_str,
+                            py,
+                            custom_converters,
+                        )?
+                    };
 
                     // Use original field name (with hyphens/dots) for the result
                     if let Some(ref original_name) = field_names[i] {
@@ -690,6 +723,7 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
     let py = ctx.py;
     let custom_converters = ctx.custom_converters;
     let evaluate_result = ctx.evaluate_result;
+    let nested_parsers = ctx.nested_parsers;
 
     if let Some(captures) = regex.captures(string) {
         // Pre-allocate with capacity based on expected field count
@@ -714,8 +748,13 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
         let mut actual_capture_index = 1; // Start at 1 (group 0 is full match)
 
         for (i, spec) in field_specs.iter().enumerate() {
-            // Validate regex_group_count for custom types with capturing groups (only if custom types exist)
-            let pattern_groups = if !custom_converters.is_empty() {
+            // Capturing groups inside this field's regex fragment (custom converters or nested).
+            let pattern_groups = if matches!(spec.field_type, FieldType::Nested) {
+                spec.nested_regex_body
+                    .as_ref()
+                    .map(|b| count_capturing_groups(b))
+                    .unwrap_or(0)
+            } else if !custom_converters.is_empty() {
                 validate_custom_type_pattern(spec, custom_converters, py)?
             } else {
                 0
@@ -847,12 +886,26 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                             fixed_index += 1;
                         }
                     } else {
-                        let converted = crate::types::conversion::convert_value(
-                            spec,
-                            value_str,
-                            py,
-                            custom_converters,
-                        )?;
+                        let converted: PyObject = if matches!(spec.field_type, FieldType::Nested) {
+                            let nested_arc = nested_parsers.get(i).and_then(|x| x.as_ref()).ok_or_else(
+                                || {
+                                    pyo3::exceptions::PyValueError::new_err(
+                                        "internal error: nested parser missing",
+                                    )
+                                },
+                            )?;
+                            match nested_arc.parse_nested_capture(py, value_str, custom_converters)? {
+                                Some(pr) => pr.into_py_any(py)?,
+                                None => return Ok(None),
+                            }
+                        } else {
+                            crate::types::conversion::convert_value(
+                                spec,
+                                value_str,
+                                py,
+                                custom_converters,
+                            )?
+                        };
 
                         // Use original field name (with hyphens/dots) for the result
                         if let Some(ref original_name) = field_names[i] {

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -4,6 +4,12 @@ use pyo3::prelude::*;
 use regex;
 use std::collections::HashMap;
 
+/// Maximum recursive depth when compiling nested format patterns (GitHub issue #12).
+pub const MAX_NESTED_FORMAT_DEPTH: usize = 10;
+
+/// Maximum brace nesting **within** one field's format specification (safety cap).
+const MAX_BRACE_DEPTH_IN_FORMAT_SPEC: i32 = 10;
+
 /// Result tuple from [`parse_pattern`]: compiled pattern string, search regex string, field
 /// specs, original and normalized field names, normalized-to-original name map, and whether
 /// `""` may match when every field is a default unconstrained string.
@@ -20,6 +26,103 @@ pub type ParsedPatternParts = (
 /// True when `s` contains at least one non-whitespace character (trim is non-empty).
 fn literal_delimits_empty_field(s: &str) -> bool {
     !s.trim().is_empty()
+}
+
+/// Collect the format-spec substring after `:` until the matching `}` that closes this
+/// field, honoring nested `{`…`}` and doubled `{{` / `}}` escapes (formatparse#12).
+fn collect_balanced_format_spec(
+    chars: &mut std::iter::Peekable<std::str::Chars>,
+) -> PyResult<String> {
+    let mut out = String::new();
+    let mut depth = 0i32;
+    loop {
+        let Some(&ch) = chars.peek() else {
+            return Err(error::pattern_error(
+                "Unclosed '{' in pattern: expected '}' to close the field",
+            ));
+        };
+        if ch == '}' && depth == 0 {
+            break;
+        }
+        let c = chars.next().unwrap();
+        match c {
+            '{' => {
+                if chars.peek() == Some(&'{') {
+                    chars.next();
+                    out.push('{');
+                    out.push('{');
+                } else {
+                    depth += 1;
+                    if depth > MAX_BRACE_DEPTH_IN_FORMAT_SPEC {
+                        return Err(error::pattern_error(
+                            "Format specification has too many nested '{' (max 10)",
+                        ));
+                    }
+                    out.push('{');
+                }
+            }
+            // A lone `}` closes one `{…}` nesting level inside the spec. Do **not** merge two
+            // consecutive `}` into the `}}` escape here: in `{outer:{inner:d}}` the first `}`
+            // closes the inner field and the second closes the outer field (formatparse#12).
+            '}' => {
+                depth -= 1;
+                if depth < 0 {
+                    return Err(error::pattern_error(
+                        "Unexpected '}' in format specification",
+                    ));
+                }
+                out.push('}');
+            }
+            _ => out.push(c),
+        }
+    }
+    Ok(out)
+}
+
+fn brace_balance_valid_for_nested_candidate(s: &str) -> bool {
+    let mut depth = 0i32;
+    let mut it = s.chars().peekable();
+    while let Some(c) = it.next() {
+        match c {
+            '{' => {
+                if it.peek() == Some(&'{') {
+                    it.next();
+                    continue;
+                }
+                depth += 1;
+            }
+            '}' => {
+                depth -= 1;
+                if depth < 0 {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+    depth == 0
+}
+
+/// True when `trimmed` should be compiled as a nested brace pattern (not a classic
+/// ``[[fill]align]…[type]]`` format spec).
+fn is_nested_format_spec_candidate(trimmed: &str) -> bool {
+    if trimmed.len() < 2 {
+        return false;
+    }
+    if !trimmed.starts_with('{') || trimmed.starts_with("{{") {
+        return false;
+    }
+    if !trimmed.ends_with('}') {
+        return false;
+    }
+    brace_balance_valid_for_nested_candidate(trimmed)
+}
+
+/// Strip a leading ``^`` and trailing ``$`` from an anchored full-pattern regex string.
+fn strip_regex_anchors(anchored: &str) -> String {
+    let s = anchored.strip_prefix('^').unwrap_or(anchored);
+    let s = s.strip_suffix('$').unwrap_or(s);
+    s.to_string()
 }
 
 /// After [`parse_field`], `chars` is at optional whitespace then the closing `}`.
@@ -71,6 +174,7 @@ pub fn parse_pattern(
     extra_types: Option<&HashMap<String, PyObject>>,
     custom_patterns: &HashMap<String, String>,
     allow_empty_delimited_default_string: bool,
+    nesting_depth: usize,
 ) -> PyResult<ParsedPatternParts> {
     // Pre-allocate with estimated capacity based on pattern length
     let estimated_fields = pattern.matches('{').count();
@@ -117,7 +221,27 @@ pub fn parse_pattern(
                 }
 
                 // Parse field specification
-                let (spec, name) = parse_field(&mut chars, extra_types)?;
+                let (mut spec, name) = parse_field(&mut chars, extra_types, nesting_depth)?;
+
+                if matches!(spec.field_type, FieldType::Nested) {
+                    if nesting_depth >= MAX_NESTED_FORMAT_DEPTH {
+                        return Err(error::pattern_error(
+                            "Nested format patterns exceed max depth (10)",
+                        ));
+                    }
+                    let inner = spec.nested_subpattern.as_ref().ok_or_else(|| {
+                        error::pattern_error("Internal error: nested field missing subpattern")
+                    })?;
+                    let (inner_anchored, _, _, _, _, _, _) = parse_pattern(
+                        inner,
+                        extra_types,
+                        custom_patterns,
+                        allow_empty_delimited_default_string,
+                        nesting_depth + 1,
+                    )?;
+                    spec.nested_regex_body = Some(strip_regex_anchors(&inner_anchored));
+                }
+
                 if !spec.is_default_unconstrained_string() {
                     allows_empty_default_string_match = false;
                 }
@@ -447,10 +571,10 @@ pub fn parse_field_path(field_name: &str) -> Vec<String> {
 pub fn parse_field(
     chars: &mut std::iter::Peekable<std::str::Chars>,
     extra_types: Option<&HashMap<String, PyObject>>,
+    nesting_depth: usize,
 ) -> PyResult<(FieldSpec, Option<String>)> {
     let mut spec = FieldSpec::new();
     let mut field_name = String::new();
-    let mut format_spec = String::new();
     let mut in_name = true;
 
     // Parse field name (before colon or conversion)
@@ -506,20 +630,23 @@ pub fn parse_field(
         }
     }
 
-    // Parse format spec (everything after colon until closing brace)
+    // Parse format spec (after colon until closing `}` that ends this field)
     if !in_name {
-        while let Some(&ch) = chars.peek() {
-            if ch == '}' {
-                break;
+        let format_spec = collect_balanced_format_spec(chars)?;
+        let trimmed = format_spec.trim();
+        if is_nested_format_spec_candidate(trimmed) {
+            if nesting_depth >= MAX_NESTED_FORMAT_DEPTH {
+                return Err(error::pattern_error(
+                    "Nested format patterns exceed max depth (10)",
+                ));
             }
-            format_spec.push(ch);
-            chars.next();
+            spec.field_type = FieldType::Nested;
+            spec.nested_subpattern = Some(trimmed.to_string());
+        } else {
+            parse_format_spec(&format_spec, &mut spec, extra_types);
         }
+        validate_multiline_mvp(&spec)?;
     }
-
-    // Parse format spec to extract alignment, width, precision, type, etc.
-    parse_format_spec(&format_spec, &mut spec, extra_types);
-    validate_multiline_mvp(&spec)?;
 
     let name = if field_name.is_empty() {
         None
@@ -685,5 +812,33 @@ pub fn parse_format_spec(
                 c => FieldType::Custom(c.to_string()),
             }
         };
+    }
+}
+
+#[cfg(test)]
+mod nested_candidate_tests {
+    use super::*;
+    use pyo3::Python;
+
+    #[test]
+    fn nested_candidate_accepts_inner_field_pattern() {
+        let s = "{inner:d}";
+        assert!(is_nested_format_spec_candidate(s.trim()));
+    }
+
+    #[test]
+    fn parse_nested_outer_field_type() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|_| {
+            let r = parse_pattern("{outer:{inner:d}}", None, &HashMap::new(), true, 0)
+                .expect("parse_pattern");
+            let specs = &r.2;
+            assert_eq!(specs.len(), 1);
+            assert!(
+                matches!(specs[0].field_type, FieldType::Nested),
+                "expected Nested, got {:?}",
+                specs[0].field_type
+            );
+        });
     }
 }

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -230,6 +230,7 @@ pub fn convert_value(
             FieldType::BracedContent => "brace",
             FieldType::Multiline => "ml",
             FieldType::IndentBlock => "blk",
+            FieldType::Nested => "nested",
         };
 
         // If there's a custom converter for this type name, use it instead of built-in
@@ -452,6 +453,10 @@ pub fn convert_value(
             }
         }
         FieldType::BracedContent => Ok(value.into_py_any(py)?),
+        FieldType::Nested => Err(error::conversion_error(
+            value,
+            "nested format (handled by parser, not convert_value)",
+        )),
         FieldType::Custom(_) => {
             // Already handled above
             Ok(value.into_py_any(py)?)

--- a/formatparse/__init__.py
+++ b/formatparse/__init__.py
@@ -53,6 +53,15 @@ unchanged (only the parent pattern string is restored); re-supply ``extra_types`
 after unpickling, including any composed child parsers (see `GitHub issue #7
 <https://github.com/eddiethedean/formatparse/issues/7>`_).
 
+**Nested brace patterns in a field spec:** when the substring after ``:`` is a
+balanced nested field pattern (for example ``{outer:{inner:d}}``), the inner
+pattern is compiled and matched as part of the outer capture, then parsed
+again; nested groups appear as :class:`ParseResult` objects under
+``ParseResult.named`` (see `GitHub issue #12
+<https://github.com/eddiethedean/formatparse/issues/12>`_ and upstream
+`parse#206 <https://github.com/r1chardj0n3s/parse/issues/206>`_). Maximum
+nesting depth is 10.
+
 **Post-parse validators:** after :func:`parse` or :meth:`FormatParser.parse`, run
 callables with :func:`apply_validators`, or pass ``validators=`` / ``pipeline=`` to
 :func:`parse`, or use :func:`parse_with_validation` with a compiled parser and a

--- a/tests/test_nested_format.py
+++ b/tests/test_nested_format.py
@@ -1,0 +1,47 @@
+"""Nested format patterns in field specs (GitHub issue #12; upstream parse#206)."""
+
+from __future__ import annotations
+
+import pytest
+
+import formatparse
+
+
+def test_nested_named_integer() -> None:
+    r = formatparse.parse("{outer:{inner:d}}", "42")
+    assert r is not None
+    outer = r.named["outer"]
+    assert isinstance(outer, formatparse.ParseResult)
+    assert outer.named["inner"] == 42
+
+
+def test_nested_compile_regex_contains_inner_named_group() -> None:
+    p = formatparse.compile("{outer:{inner:d}}")
+    assert "(?P<inner>" in p.regex_subpattern
+
+
+def test_nested_findall() -> None:
+    matches = formatparse.findall("{a:{b:d}}", "x12y34")
+    assert len(matches) == 2
+    assert matches[0].named["a"].named["b"] == 12
+    assert matches[1].named["a"].named["b"] == 34
+
+
+def test_nested_max_depth_compile_error() -> None:
+    # `MAX_NESTED_FORMAT_DEPTH` is 10: nested `parse_pattern` runs at depth 10 for `{leaf:d}`
+    # only when there are ten wrappers (depths 0..9 inclusive, then leaf). An eleventh
+    # wrapper forces nested compilation at depth 10 and triggers the cap.
+    def chain(n: int) -> str:
+        body = "{leaf:d}"
+        for i in range(n):
+            body = "{a%d:" % i + body + "}"
+        return body
+
+    formatparse.compile(chain(10))
+    with pytest.raises(ValueError, match="max depth|too many nested"):
+        formatparse.compile(chain(11))
+
+
+def test_unclosed_nested_spec_pattern_error() -> None:
+    with pytest.raises(ValueError, match="Unclosed"):
+        formatparse.compile("{a:{b:d}")


### PR DESCRIPTION
## Summary
Implements nested brace format specifications (issue #12; upstream [parse#206](https://github.com/r1chardj0n3s/parse/issues/206)): brace-balanced specs after `:`, recursive inner compile/match, nested values as `ParseResult` under `named`.

## Semantics
- Format spec after `:` is scanned with brace depth until depth returns to 0 at the field’s closing `}`.
- Inner `{…}` that passes `is_nested_format_spec_candidate` is compiled as a nested pattern; max depth **10**.
- Consecutive `}` no longer merge as `}}` when the first closes an inner nested field and the second closes the outer field.
- `findall` / `FindallIter` skip the raw fast path when any field is `Nested`.

## Migration
Patterns that accidentally relied on the old `}}` merge inside nested specs may change; typical `{outer:{inner:d}}`-style patterns now work.

## Tests
- `cargo test` (core + pyo3)
- `make test` (pytest)

Refs #12.