### PR TITLE
Fix #95: string width/precision must not consume trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **String width/precision with literal newline after the field** (e.g. ``" {s:<4.4}\n"`` vs ``"     \n"``): bounded string fragments no longer use DOTALL ``.`` for content, so a trailing ``\n`` in the input is not consumed as part of the field (#95).
 - **Integer and radix fields with both width and precision** (e.g. ``"{:2.2d}{:2.2d}"``, ``"#{:2.2x}{:2.2x}"``): digit runs use inclusive min/max bounds (parse semantics: width = minimum digits, precision = maximum) so adjacent fields no longer steal digits with a greedy ``+`` (#82; upstream `parse#107 <https://github.com/r1chardj0n3s/parse/issues/107>`_). Patterns that previously matched too loosely on short inputs may now return no match.
-- **String fields with alignment + precision before a fixed-width integer** (e.g. ``"{n:>10.10}{x:02d}"``): leading fill in the regex is non-greedy so the slice for ``.{precision}`` is left for the following digit field (#88; related `parse#218 <https://github.com/r1chardj0n3s/parse/issues/218>`_).
+- **String fields with alignment + precision before a fixed-width integer** (e.g. ``"{n:>10.10}{x:02d}"``): leading fill in the regex is non-greedy so the slice for the width/precision content is left for the following digit field (#88; related `parse#218 <https://github.com/r1chardj0n3s/parse/issues/218>`_).
 - **Default string fields next to literals** (e.g. ``"/{name}"``): an empty capture is allowed when it matches ``str.format`` output such as ``"/"`` for ``name=""`` (#83; upstream `parse#136 <https://github.com/r1chardj0n3s/parse/issues/136>`_). Applies to full-string **parse** / **compile().parse**; **search** / **findall** still use ``.+?`` for those segments so unanchored matching does not stop early.
 - **Integer `d`**: leading spaces and tabs before decimal digits are accepted (e.g. ``parse("{a:d}", "    0")``) for parity with padded ``str.format`` output (#81; upstream `parse#133 <https://github.com/r1chardj0n3s/parse/issues/133>`_).
 

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -97,6 +97,10 @@ impl FieldSpec {
         next_field_is_greedy: Option<bool>,
         allow_empty_delimited: bool,
     ) -> String {
+        // Width/precision string fragments are spliced into a regex built with `(?s)` (DOTALL).
+        // A bare `.` would match newlines, so a literal `\n` after the field can be consumed as
+        // "content" and the remainder no longer matches (GitHub issue #95).
+        const FMT_CHAR: &str = "[^\\r\\n]";
         let base_pattern = match &self.field_type {
             FieldType::String => {
                 // Handle alignment and width for strings
@@ -109,24 +113,27 @@ impl FieldSpec {
                         match align {
                             '<' => {
                                 // Left-aligned: content (precision chars) + optional trailing fill chars
-                                format!(".{{{}}}(?:{}*)", prec, fill_escaped)
+                                format!("{}{{{}}}(?:{}*)", FMT_CHAR, prec, fill_escaped)
                             }
                             '>' => {
                                 // Right-aligned: optional leading fill + exactly `prec` characters.
                                 // Leading fill must be non-greedy so we do not consume the entire slice
                                 // before `.{{prec}}` when another field follows (issue #88 / parse#218).
-                                format!("(?:{}*?).{{{}}}", fill_escaped, prec)
+                                format!("(?:{}*?){}{{{}}}", fill_escaped, FMT_CHAR, prec)
                             }
                             '^' => {
                                 // Center-aligned: optional leading fill + content + optional trailing fill.
                                 // Non-greedy leading fill for the same boundary reason as `>`.
-                                format!("(?:{}*?).{{{}}}(?:{}*)", fill_escaped, prec, fill_escaped)
+                                format!(
+                                    "(?:{}*?){}{{{}}}(?:{}*)",
+                                    fill_escaped, FMT_CHAR, prec, fill_escaped
+                                )
                             }
-                            _ => format!(".{{{}}}", prec),
+                            _ => format!("{}{{{}}}", FMT_CHAR, prec),
                         }
                     } else {
                         // Precision only, no alignment: match exactly 'precision' characters
-                        format!(".{{{}}}", prec)
+                        format!("{}{{{}}}", FMT_CHAR, prec)
                     }
                 } else if let Some(width) = self.width {
                     // Width only (no precision):
@@ -134,8 +141,8 @@ impl FieldSpec {
                     // - If there's a next field without precision (like {}), use exact width
                     // - If it's the last field, use greedy (at least width)
                     match next_field_is_greedy {
-                        Some(false) => format!(".{{{}}}", width), // Exact when followed by non-greedy field
-                        _ => format!(".{{{},}}", width), // Greedy when followed by greedy field or last field
+                        Some(false) => format!("{}{{{}}}", FMT_CHAR, width), // Exact when followed by non-greedy field
+                        _ => format!("{}{{{},}}", FMT_CHAR, width), // Greedy when followed by greedy field or last field
                     }
                 } else if self.alignment.is_some() {
                     // Alignment specified but no width - match with optional surrounding whitespace
@@ -611,7 +618,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.precision = Some(5);
         let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
-        assert_eq!(pattern, r".{5}");
+        assert_eq!(pattern, r"[^\r\n]{5}");
     }
 
     #[test]
@@ -619,7 +626,7 @@ mod tests {
         let mut spec = FieldSpec::new();
         spec.width = Some(10);
         let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
-        assert_eq!(pattern, r".{10,}");
+        assert_eq!(pattern, r"[^\r\n]{10,}");
     }
 
     #[test]
@@ -628,7 +635,7 @@ mod tests {
         spec.width = Some(10);
         // When next field is greedy, use greedy pattern
         let pattern = spec.to_regex_pattern(&HashMap::new(), Some(true), false);
-        assert_eq!(pattern, r".{10,}");
+        assert_eq!(pattern, r"[^\r\n]{10,}");
     }
 
     #[test]
@@ -637,7 +644,7 @@ mod tests {
         spec.width = Some(10);
         // When next field is non-greedy (like {}), use exact width
         let pattern = spec.to_regex_pattern(&HashMap::new(), Some(false), false);
-        assert_eq!(pattern, r".{10}");
+        assert_eq!(pattern, r"[^\r\n]{10}");
     }
 
     #[test]
@@ -671,7 +678,7 @@ mod tests {
         spec.alignment = Some('<');
         spec.fill = Some('x');
         let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
-        assert!(pattern.contains(".{5}"));
+        assert!(pattern.contains(r"[^\r\n]{5}"));
         assert!(pattern.contains("x*"));
     }
 

--- a/tests/test_alignment_precision.py
+++ b/tests/test_alignment_precision.py
@@ -171,3 +171,11 @@ def test_issue88_aligned_string_then_zero_padded_int():
     assert r.named["s"] == "0000bbbb  "
     assert r.named["n"] == "0000010000"
     assert r.named["x"] == 99
+
+
+def test_issue95_leading_space_trailing_lf_after_width_precision_string():
+    """Regression: literal newline after field must not be eaten by DOTALL `.` (issue #95)."""
+    r = parse(" {s:<4.4}\n", "     \n")
+    assert r is not None
+    assert r.span == (0, 6)
+    assert r.named["s"] == "    "


### PR DESCRIPTION
## Summary
Fixes [issue #95](https://github.com/eddiethedean/formatparse/issues/95): patterns like `" {s:<4.4}\\n"` against `"     \\n"` returned `None` while the reference `parse` library matches.

## Root cause
Full parse regexes are compiled with `(?s)` (DOTALL). Bounded string fragments used `.` for the width/precision character runs, so `.` could match the final newline in the input and the literal `\\n` in the pattern no longer aligned.

## Change
- In `formatparse-core` `FieldType::String` width/precision branches, use `[^\\r\\n]` instead of `.` for those quantified runs. `:ml` / `:blk` already use `[\\s\\S]` where newlines are intended.
- Regression test in `tests/test_alignment_precision.py`.
- Changelog under **Unreleased**.

## Testing
- `cargo test --workspace`
- `pytest tests/test_alignment_precision.py` (with native extension rebuilt via `maturin develop`).