### PR TITLE
CI: PyPy job, blocking python-tests; harden pattern LRU cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.14"
             architecture: x86-64
+          # PyPy (CPython ABI via PyO3)
+          - os: ubuntu-latest
+            python-version: "pypy-3.11"
+            architecture: x86-64
           # macOS latest (typically arm64/Apple Silicon)
           - os: macos-latest
             python-version: "3.9"
@@ -242,7 +246,6 @@ jobs:
       - name: Run formatparse-pyo3 python-tests (Ubuntu 3.11)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         shell: bash
-        continue-on-error: true
         run: |
           source .venv/bin/activate
           export PYO3_PYTHON="$(command -v python)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- Inline ``{...:validator(...)}`` syntax and **async** validation pipelines (currently deferred in API documentation).
+- ``composed_type`` extensions: pattern ``+``, inheritance, and **flattening** nested parse results into the parent (see `#7 <https://github.com/eddiethedean/formatparse/issues/7>`_).
+
 ### Added
 
 - **Regex lookaround assertions** after the type token for **integer** (``:d`` and related) and **float** (``:f`` / ``:F``) fields: append ``(?=…)``, ``(?!…)``, ``(?<=…)``, or ``(?<!…)`` groups so the numeric capture stays zero-width outside the field span (issues `#9 <https://github.com/eddiethedean/formatparse/issues/9>`_, upstream `parse#209 <https://github.com/r1chardj0n3s/parse/issues/209>`_). Compiled format patterns use the **`fancy-regex`** engine; **simple literal** positive lookarounds may be rewritten as non-capturing groups for correct anchoring. Lookarounds are rejected inside strftime ``%…`` type tails for this release.
@@ -15,12 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pattern LRU cache:** after a hash hit, the entry is checked against the full normalized pattern and ``extra_types`` fingerprint so a colliding key cannot return the wrong compiled parser.
+
 - **Fixed-width string fields with literals beside the field** (e.g. ``"{s:<5.5} "`` vs ``"abc   "``): when width and precision are equal, the compiled fragment is exactly ``prec`` characters so trailing (or leading) pattern space is not pulled into the capture (#97). **Right-aligned** fields with that same equal width and precision also accept an opaque fixed-width capture (including trailing spaces) so post-capture validation matches **parse** for those cells (#97).
 - **String width/precision with literal newline after the field** (e.g. ``" {s:<4.4}\n"`` vs ``"     \n"``): bounded string fragments no longer use DOTALL ``.`` for content, so a trailing ``\n`` in the input is not consumed as part of the field (#95). The same bounded runs also exclude VT, FF, NEL (U+0085), U+2028 LINE SEPARATOR, and U+2029 PARAGRAPH SEPARATOR so those line boundaries cannot be absorbed under ``(?s)`` when they appear as literals after the field.
 - **Integer and radix fields with both width and precision** (e.g. ``"{:2.2d}{:2.2d}"``, ``"#{:2.2x}{:2.2x}"``): digit runs use inclusive min/max bounds (parse semantics: width = minimum digits, precision = maximum) so adjacent fields no longer steal digits with a greedy ``+`` (#82; upstream `parse#107 <https://github.com/r1chardj0n3s/parse/issues/107>`_). Patterns that previously matched too loosely on short inputs may now return no match.
 - **String fields with alignment + precision before a fixed-width integer** (e.g. ``"{n:>10.10}{x:02d}"``): leading fill in the regex is non-greedy so the slice for the width/precision content is left for the following digit field (#88; related `parse#218 <https://github.com/r1chardj0n3s/parse/issues/218>`_).
 - **Default string fields next to literals** (e.g. ``"/{name}"``): an empty capture is allowed when it matches ``str.format`` output such as ``"/"`` for ``name=""`` (#83; upstream `parse#136 <https://github.com/r1chardj0n3s/parse/issues/136>`_). Applies to full-string **parse** / **compile().parse**; **search** / **findall** still use ``.+?`` for those segments so unanchored matching does not stop early.
 - **Integer `d`**: leading spaces and tabs before decimal digits are accepted (e.g. ``parse("{a:d}", "    0")``) for parity with padded ``str.format`` output (#81; upstream `parse#133 <https://github.com/r1chardj0n3s/parse/issues/133>`_).
+
+### Maintenance
+
+- **CI:** Ubuntu **PyPy 3.11** job; **``python-tests``** for ``formatparse-pyo3`` is a blocking step on Ubuntu CPython 3.11 (no ``continue-on-error``).
+- **Rust:** clearer ``expect`` messages for UTF-8 invariants in line-continuation helpers and ``ResultsIterator``.
 
 ## [0.8.0] - 2026-05-15
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ export PYO3_PYTHON="$(python -c 'import sys; print(sys.executable)')"
 cargo test -p formatparse-pyo3 --features python-tests
 ```
 
-GitHub Actions runs this on **Ubuntu + Python 3.11** as a separate step with `continue-on-error: true` so a brittle linker layout does not block merges; failures still appear in the job log.
+GitHub Actions runs this on **Ubuntu + Python 3.11** as a **blocking** step (same venv as `maturin develop` in that job); failures fail the workflow.
 
 Run tests for a specific module:
 ```bash
@@ -265,7 +265,7 @@ Mutation testing runs automatically in CI on the main branch (weekly).
 Before submitting a PR, ensure:
 
 - [ ] All tests pass (`make test` or `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/`)
-- [ ] Rust tests pass (`cargo test --workspace` on the Ubuntu + Python 3.11 model; other setups at minimum `cargo test -p formatparse-core`). Optionally run `cargo test -p formatparse-pyo3 --features python-tests` when your PyO3/Python layout supports it (see **Rust Tests**).
+- [ ] Rust tests pass (`cargo test --workspace` on the Ubuntu + Python 3.11 model; other setups at minimum `cargo test -p formatparse-core`). On Ubuntu 3.11-equivalent setups also run `cargo test -p formatparse-pyo3 --features python-tests` with `PYO3_PYTHON` set (see **Rust Tests**); CI enforces this on Ubuntu 3.11.
 - [ ] Code coverage is maintained or improved
 - [ ] Code is formatted (`ruff format .`, `cargo fmt`)
 - [ ] No linting errors (`ruff check .`, `cargo clippy`)
@@ -280,7 +280,7 @@ The project uses GitHub Actions for CI/CD:
 
 - **Tests**: Run on all PRs across multiple Python versions and platforms
 - **Coverage**: Generated on Python 3.11, Ubuntu; `fail_under` from `pyproject.toml` is enforced on that job
-- **Rust**: `cargo test --workspace` on Ubuntu + Python 3.11; other cells run `cargo test -p formatparse-core` only. Optional `python-tests` job on Ubuntu 3.11 (see CONTRIBUTING) is soft-fail in CI.
+- **Rust**: `cargo test --workspace` on Ubuntu + Python 3.11; other cells run `cargo test -p formatparse-core` only. The `python-tests` step on Ubuntu 3.11 runs `cargo test -p formatparse-pyo3 --features python-tests` and **must pass** (see **Rust Tests** below). Ubuntu **PyPy 3.11** runs pytest with a built extension like the CPython matrix.
 - **Benchmarks**: Run on PRs and main branch
 - **Doctests**: Run on Python 3.11, Ubuntu
 - **Mutation Testing**: Runs weekly on main branch

--- a/formatparse-core/src/input_line_continuations.rs
+++ b/formatparse-core/src/input_line_continuations.rs
@@ -53,7 +53,8 @@ pub fn normalize_input_line_continuations(input: &str) -> String {
             }
         }
     }
-    String::from_utf8(out).expect("ASCII-only edits preserve UTF-8")
+    // Output is built only from valid UTF-8 slices of `input` plus ASCII `\` / newlines / spaces.
+    String::from_utf8(out).expect("normalize_input_line_continuations: UTF-8 invariant")
 }
 
 #[cfg(test)]
@@ -67,10 +68,7 @@ mod tests {
 
     #[test]
     fn continuation_crlf() {
-        assert_eq!(
-            normalize_input_line_continuations("foo\\\r\nbar"),
-            "foobar"
-        );
+        assert_eq!(normalize_input_line_continuations("foo\\\r\nbar"), "foobar");
     }
 
     #[test]

--- a/formatparse-core/src/lookaround.rs
+++ b/formatparse-core/src/lookaround.rs
@@ -121,9 +121,7 @@ pub fn parse_lookaround_tail(tail: &str) -> Result<(String, String), String> {
             ));
         }
         if count_capturing_groups(group) != 0 {
-            return Err(
-                "Lookaround groups must not contain capturing parentheses".to_string(),
-            );
+            return Err("Lookaround groups must not contain capturing parentheses".to_string());
         }
         Regex::new(group).map_err(|e| format!("Invalid lookaround regex: {}", e))?;
 
@@ -310,15 +308,13 @@ mod tests {
 
     #[test]
     fn rewrite_lowers_literal_positive_lb_and_la() {
-        let (p, b, la) =
-            rewrite_field_fragments_for_engine_anchor(r"(?<=\$)\d+", "(?=(?:px))");
+        let (p, b, la) = rewrite_field_fragments_for_engine_anchor(r"(?<=\$)\d+", "(?=(?:px))");
         assert_eq!(p, r"(?:\$)");
         assert_eq!(b, r"\d+");
         // Non-simple lookahead body is preserved
         assert_eq!(la, "(?=(?:px))");
 
-        let (p2, b2, la2) =
-            rewrite_field_fragments_for_engine_anchor(r"(?<=\$)\d+", "(?=px)");
+        let (p2, b2, la2) = rewrite_field_fragments_for_engine_anchor(r"(?<=\$)\d+", "(?=px)");
         assert_eq!(p2, r"(?:\$)");
         assert_eq!(b2, r"\d+");
         assert_eq!(la2, "(?:px)");

--- a/formatparse-core/src/types/regex.rs
+++ b/formatparse-core/src/types/regex.rs
@@ -80,11 +80,7 @@ pub fn strftime_to_regex(format_str: &str) -> String {
 /// builder so a full-string anchor (`$`) can still match asserted suffix text.
 #[inline]
 fn wrap_field_lookbehind(spec: &FieldSpec, core: String) -> String {
-    format!(
-        "{}{}",
-        spec.regex_lookbehind.as_deref().unwrap_or(""),
-        core
-    )
+    format!("{}{}", spec.regex_lookbehind.as_deref().unwrap_or(""), core)
 }
 
 /// Character class for **one unit** of width/precision content in normal string fields (`s` / `{}`).
@@ -97,10 +93,7 @@ fn wrap_field_lookbehind(spec: &FieldSpec, core: String) -> String {
 /// SEPARATOR (U+2029). Multiline (`:ml`) / indented block (`:blk`) fields still use `[\s\S]`
 /// where newlines are intentional.
 const STRING_WIDTH_PRECISION_CHAR: &str = concat!(
-    "[^",
-    "\r",
-    "\n",
-    "\u{000B}", // VT
+    "[^", "\r", "\n", "\u{000B}", // VT
     "\u{000C}", // FF
     "\u{0085}", // NEL (Next Line)
     "\u{2028}", // LINE SEPARATOR
@@ -1003,7 +996,11 @@ mod tests {
         spec.width = Some(2);
         spec.precision = Some(2);
         let pattern = spec.to_regex_pattern(&HashMap::new(), None, false);
-        assert!(pattern.contains(r"[0-9a-fA-F]{2,2}"), "pattern: {}", pattern);
+        assert!(
+            pattern.contains(r"[0-9a-fA-F]{2,2}"),
+            "pattern: {}",
+            pattern
+        );
     }
 
     #[test]

--- a/formatparse-pyo3/src/datetime/common.rs
+++ b/formatparse-pyo3/src/datetime/common.rs
@@ -196,9 +196,8 @@ pub fn parse_time_with_ampm(time_str: &str) -> Result<(u8, u8, u8), PyErr> {
 /// Parse and pad microseconds string to 6 digits
 /// Truncates if longer than 6 digits, pads with zeros on the right if shorter
 pub fn parse_microseconds(micros_str: &str) -> Result<u32, PyErr> {
-    formatparse_core::parse_microsecond_digits(micros_str).map_err(|e| {
-        PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string())
-    })
+    formatparse_core::parse_microsecond_digits(micros_str)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
 }
 
 /// Extract microseconds from a capture group, handling padding

--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -37,48 +37,21 @@ pub use match_rs::Match;
 
 pub use error::PatternParseMismatch;
 
-// Pattern cache for compiled FormatParser instances
-// Cache size: 1000 patterns
-// Using u64 hash as key for faster lookups
-// Using Arc to avoid expensive clones
-static PATTERN_CACHE: Lazy<Mutex<LruCache<u64, Arc<FormatParser>>>> =
-    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap())));
-
-fn lock_pattern_cache(
-) -> Result<std::sync::MutexGuard<'static, LruCache<u64, Arc<FormatParser>>>, PyErr> {
-    PATTERN_CACHE.lock().map_err(|_| {
-        pyo3::exceptions::PyRuntimeError::new_err(
-            "formatparse pattern cache mutex was poisoned",
-        )
-    })
-}
-
-/// Create a cache key hash from pattern and `extra_types`.
-///
-/// Must match what affects compilation in [`FormatParser::new_with_extra_types`]:
-/// each converter's `pattern` string and `regex_group_count` (via
-/// `validate_custom_type_pattern`). Keys alone are insufficient (same key, different
-/// `with_pattern` / group count would incorrectly share a cached parser).
-fn create_cache_key_hash(
+/// Sorted `(type_name, with_pattern regex, regex_group_count tag)` for cache identity.
+/// Must stay aligned with [`create_cache_key_hash`].
+pub(crate) fn extract_extra_types_identity(
     py: Python<'_>,
-    pattern: &str,
     extra_types: &Option<HashMap<String, PyObject>>,
-) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    pattern.hash(&mut hasher);
+) -> Vec<(String, String, i64)> {
+    let mut out = Vec::new();
     if let Some(extra_types) = extra_types {
-        let mut entries: Vec<(&String, &PyObject)> = extra_types.iter().collect();
-        entries.sort_by_key(|(k, _)| *k);
-        for (name, converter_obj) in entries {
-            name.hash(&mut hasher);
+        for (name, converter_obj) in extra_types {
             let converter_ref = converter_obj.bind(py);
             let pat = converter_ref
                 .getattr("pattern")
                 .ok()
                 .and_then(|a| a.extract::<String>().ok())
                 .unwrap_or_default();
-            pat.hash(&mut hasher);
-            // Distinct from any valid regex_group_count (non-negative).
             const GC_MISSING: i64 = -1;
             const GC_NONE: i64 = -2;
             let gc_tag = match converter_ref.getattr("regex_group_count") {
@@ -93,8 +66,47 @@ fn create_cache_key_hash(
                 }
                 Err(_) => GC_MISSING,
             };
-            gc_tag.hash(&mut hasher);
+            out.push((name.clone(), pat, gc_tag));
         }
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+    }
+    out
+}
+
+// Pattern cache for compiled FormatParser instances
+// Cache size: 1000 patterns
+// Using u64 hash as key for faster lookups
+// Using Arc to avoid expensive clones
+static PATTERN_CACHE: Lazy<Mutex<LruCache<u64, Arc<FormatParser>>>> =
+    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap())));
+
+fn lock_pattern_cache(
+) -> Result<std::sync::MutexGuard<'static, LruCache<u64, Arc<FormatParser>>>, PyErr> {
+    PATTERN_CACHE.lock().map_err(|_| {
+        pyo3::exceptions::PyRuntimeError::new_err("formatparse pattern cache mutex was poisoned")
+    })
+}
+
+/// Create a cache key hash from pattern and `extra_types`.
+///
+/// Must match what affects compilation in [`FormatParser::new_with_extra_types`]:
+/// each converter's `pattern` string and `regex_group_count` (via
+/// `validate_custom_type_pattern`). Keys alone are insufficient (same key, different
+/// `with_pattern` / group count would incorrectly share a cached parser).
+///
+/// Callers must verify cache hits (see `FormatParser::matches_pattern_cache_request`)
+/// because hash keys can theoretically collide.
+fn create_cache_key_hash(
+    py: Python<'_>,
+    pattern: &str,
+    extra_types: &Option<HashMap<String, PyObject>>,
+) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    pattern.hash(&mut hasher);
+    for (name, pat, gc_tag) in extract_extra_types_identity(py, extra_types) {
+        name.hash(&mut hasher);
+        pat.hash(&mut hasher);
+        gc_tag.hash(&mut hasher);
     }
     hasher.finish()
 }
@@ -105,31 +117,32 @@ fn get_or_create_parser(
     extra_types: Option<HashMap<String, PyObject>>,
 ) -> PyResult<Arc<FormatParser>> {
     let normalized = pattern_normalize::prepare_compiled_pattern(pattern)?;
-    let cache_key = Python::with_gil(|py| create_cache_key_hash(py, &normalized, &extra_types));
+    Python::with_gil(|py| -> PyResult<Arc<FormatParser>> {
+        let cache_key = create_cache_key_hash(py, &normalized, &extra_types);
 
-    // Try to get from cache (minimize lock scope)
-    let cached = {
-        let mut cache = lock_pattern_cache()?;
-        cache.get(&cache_key).cloned()
-    };
+        let cached = {
+            let mut cache = lock_pattern_cache()?;
+            cache.get(&cache_key).cloned()
+        };
 
-    if let Some(cached_parser) = cached {
-        return Ok(cached_parser);
-    }
+        if let Some(cached_parser) = cached {
+            if cached_parser.matches_pattern_cache_request(py, &normalized, &extra_types) {
+                return Ok(cached_parser);
+            }
+        }
 
-    // Not in cache, create new parser
-    let parser = Arc::new(FormatParser::new_with_extra_types(
-        &normalized,
-        extra_types,
-    )?);
+        let parser = Arc::new(FormatParser::new_with_extra_types(
+            &normalized,
+            extra_types,
+        )?);
 
-    // Store in cache (minimize lock scope)
-    {
-        let mut cache = lock_pattern_cache()?;
-        cache.put(cache_key, parser.clone());
-    }
+        {
+            let mut cache = lock_pattern_cache()?;
+            cache.put(cache_key, parser.clone());
+        }
 
-    Ok(parser)
+        Ok(parser)
+    })
 }
 
 /// Parse a string using a format specification
@@ -357,11 +370,7 @@ fn findall(
         .iter()
         .any(|s| matches!(s.field_type, FieldType::Nested));
 
-    if !has_custom_converters
-        && evaluate_result
-        && !has_nested_dicts
-        && !has_nested_format_fields
-    {
+    if !has_custom_converters && evaluate_result && !has_nested_dicts && !has_nested_format_fields {
         // Use raw matching path: collect all raw data first (NO GIL), then batch convert
         let mut raw_results = Vec::new();
         let search_regex = parser.get_search_regex(case_sensitive);

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -3,6 +3,7 @@ use crate::parser::matching::{
     match_with_captures, match_with_captures_raw, CapturedMatchContext, FieldCaptureSlices,
 };
 use crate::result::ParseResult;
+use fancy_regex::Regex;
 use formatparse_core::count_capturing_groups;
 use formatparse_core::parser::{validate_input_length, MAX_FIELDS};
 use formatparse_core::{FieldSpec, FieldType};
@@ -10,7 +11,6 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyString, PyTuple};
 use pyo3::IntoPyObjectExt;
-use fancy_regex::Regex;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -51,6 +51,23 @@ pub struct FormatParser {
 }
 
 impl FormatParser {
+    /// Returns true when this parser matches a cache lookup: same normalized pattern and
+    /// the same `extra_types` fingerprint as [`crate::extract_extra_types_identity`].
+    /// Used after an LRU hit on the hash key to rule out collisions.
+    pub(crate) fn matches_pattern_cache_request(
+        &self,
+        py: Python<'_>,
+        normalized_pattern: &str,
+        extra_types: &Option<HashMap<String, PyObject>>,
+    ) -> bool {
+        if self.pattern != normalized_pattern {
+            return false;
+        }
+        let requested = crate::extract_extra_types_identity(py, extra_types);
+        let stored = crate::extract_extra_types_identity(py, &self.stored_extra_types);
+        requested == stored
+    }
+
     pub fn new(pattern: &str) -> PyResult<Self> {
         Self::new_with_extra_types(pattern, None)
     }
@@ -111,27 +128,28 @@ impl FormatParser {
             )));
         }
 
-        let nested_parsers: Vec<Option<Arc<FormatParser>>> = Python::with_gil(|py| -> PyResult<_> {
-            let mut out = Vec::with_capacity(field_specs.len());
-            for spec in &field_specs {
-                if matches!(spec.field_type, FieldType::Nested) {
-                    let sub = spec.nested_subpattern.as_ref().ok_or_else(|| {
-                        PyValueError::new_err("internal error: nested field missing subpattern")
-                    })?;
-                    let cloned_et = extra_types.as_ref().map(|m| {
-                        m.iter()
-                            .map(|(k, v)| (k.clone(), v.clone_ref(py)))
-                            .collect::<HashMap<_, _>>()
-                    });
-                    out.push(Some(Arc::new(FormatParser::new_with_extra_types(
-                        sub, cloned_et,
-                    )?)));
-                } else {
-                    out.push(None);
+        let nested_parsers: Vec<Option<Arc<FormatParser>>> =
+            Python::with_gil(|py| -> PyResult<_> {
+                let mut out = Vec::with_capacity(field_specs.len());
+                for spec in &field_specs {
+                    if matches!(spec.field_type, FieldType::Nested) {
+                        let sub = spec.nested_subpattern.as_ref().ok_or_else(|| {
+                            PyValueError::new_err("internal error: nested field missing subpattern")
+                        })?;
+                        let cloned_et = extra_types.as_ref().map(|m| {
+                            m.iter()
+                                .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+                                .collect::<HashMap<_, _>>()
+                        });
+                        out.push(Some(Arc::new(FormatParser::new_with_extra_types(
+                            sub, cloned_et,
+                        )?)));
+                    } else {
+                        out.push(None);
+                    }
                 }
-            }
-            Ok(out)
-        })?;
+                Ok(out)
+            })?;
         // Pre-compute custom type validation results (pattern_groups per field)
         // This avoids calling validate_custom_type_pattern for every match
         let custom_type_groups = Python::with_gil(|py| -> PyResult<Vec<usize>> {
@@ -181,8 +199,9 @@ impl FormatParser {
             formatparse_core::build_case_insensitive_regex(&regex_str_with_anchors);
 
         // Pre-compile search regex variants (without anchors)
-        let search_regex = formatparse_core::build_search_regex(regex_search_anchored.as_str(), true)
-            .map_err(crate::error::core_error_to_py_err)?;
+        let search_regex =
+            formatparse_core::build_search_regex(regex_search_anchored.as_str(), true)
+                .map_err(crate::error::core_error_to_py_err)?;
         let search_regex_case_insensitive =
             formatparse_core::build_search_regex(regex_search_anchored.as_str(), false).ok();
 

--- a/formatparse-pyo3/src/parser/matching.rs
+++ b/formatparse-pyo3/src/parser/matching.rs
@@ -3,11 +3,11 @@ use crate::match_rs::{Match, MatchInit};
 use crate::parser::format_parser::FormatParser;
 use crate::parser::raw_match::{RawMatchData, RawValue};
 use crate::result::ParseResult;
+use fancy_regex::{Captures, Regex};
 use formatparse_core::{count_capturing_groups, FieldSpec, FieldType};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
-use fancy_regex::{Captures, Regex};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -345,9 +345,9 @@ pub fn match_with_captures_raw(
     let custom_type_groups = fields.custom_type_groups;
     let has_nested_dict_fields = fields.has_nested_dict_fields;
 
-    let full_match = captures.get(0).ok_or_else(|| {
-        "regex match missing capture group 0".to_string()
-    })?;
+    let full_match = captures
+        .get(0)
+        .ok_or_else(|| "regex match missing capture group 0".to_string())?;
     let start = full_match.start();
     let end = full_match.end();
 
@@ -523,7 +523,9 @@ pub fn match_with_captures(
             // For evaluate_result=True, we don't need to store raw captures, saving allocations
 
             if evaluate_result {
-                if !crate::types::conversion::validate_alignment_precision_for_capture(spec, value_str) {
+                if !crate::types::conversion::validate_alignment_precision_for_capture(
+                    spec, value_str,
+                ) {
                     return Ok(None);
                 }
 
@@ -548,7 +550,9 @@ pub fn match_with_captures(
                             return Ok(None);
                         };
                         let vs = cap_j.as_str();
-                        if !crate::types::conversion::validate_alignment_precision_for_capture(spec_j, vs) {
+                        if !crate::types::conversion::validate_alignment_precision_for_capture(
+                            spec_j, vs,
+                        ) {
                             return Ok(None);
                         }
                         let Some(fmt) = spec_j.strftime_format.as_ref() else {
@@ -805,7 +809,9 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                 }
 
                 if evaluate_result {
-                    if !crate::types::conversion::validate_alignment_precision_for_capture(spec, value_str) {
+                    if !crate::types::conversion::validate_alignment_precision_for_capture(
+                        spec, value_str,
+                    ) {
                         return Ok(None);
                     }
 
@@ -831,7 +837,9 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                                 return Ok(None);
                             };
                             let vs = cap_j.as_str();
-                            if !crate::types::conversion::validate_alignment_precision_for_capture(spec_j, vs) {
+                            if !crate::types::conversion::validate_alignment_precision_for_capture(
+                                spec_j, vs,
+                            ) {
                                 return Ok(None);
                             }
                             let Some(fmt) = spec_j.strftime_format.as_ref() else {
@@ -896,14 +904,19 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                         }
                     } else {
                         let converted: PyObject = if matches!(spec.field_type, FieldType::Nested) {
-                            let nested_arc = nested_parsers.get(i).and_then(|x| x.as_ref()).ok_or_else(
-                                || {
+                            let nested_arc = nested_parsers
+                                .get(i)
+                                .and_then(|x| x.as_ref())
+                                .ok_or_else(|| {
                                     pyo3::exceptions::PyValueError::new_err(
                                         "internal error: nested parser missing",
                                     )
-                                },
-                            )?;
-                            match nested_arc.parse_nested_capture(py, value_str, custom_converters)? {
+                                })?;
+                            match nested_arc.parse_nested_capture(
+                                py,
+                                value_str,
+                                custom_converters,
+                            )? {
                                 Some(pr) => pr.into_py_any(py)?,
                                 None => return Ok(None),
                             }
@@ -1069,7 +1082,8 @@ pub fn match_empty_default_string_parse(
         }
 
         if evaluate_result {
-            if !crate::types::conversion::validate_alignment_precision_for_capture(spec, value_str) {
+            if !crate::types::conversion::validate_alignment_precision_for_capture(spec, value_str)
+            {
                 return Ok(None);
             }
 

--- a/formatparse-pyo3/src/parser/pattern.rs
+++ b/formatparse-pyo3/src/parser/pattern.rs
@@ -44,7 +44,9 @@ fn collect_balanced_format_spec(
         if ch == '}' && depth == 0 {
             break;
         }
-        let c = chars.next().unwrap();
+        let c = chars
+            .next()
+            .expect("peek matched a char so next() must succeed");
         match c {
             '{' => {
                 if chars.peek() == Some(&'{') {
@@ -129,9 +131,7 @@ fn strip_regex_anchors(anchored: &str) -> String {
 /// True when there is a non-whitespace literal run after that `}` and before the next unescaped `{`
 /// or end of pattern (formatparse#83). Whitespace-only gaps do not count so ``{} {}`` keeps
 /// non-empty captures for both fields.
-fn has_trailing_literal_before_next_field(
-    mut chars: std::iter::Peekable<std::str::Chars>,
-) -> bool {
+fn has_trailing_literal_before_next_field(mut chars: std::iter::Peekable<std::str::Chars>) -> bool {
     while chars.peek().is_some_and(|c| c.is_whitespace()) {
         chars.next();
     }
@@ -871,10 +871,7 @@ mod normalize_field_name_tests {
     #[test]
     fn deep_nested_brackets_normalize() {
         let mut m = HashMap::new();
-        assert_eq!(
-            normalize_field_name("a[b[c[d]]]", &mut m, &[]),
-            "a_b_c_d"
-        );
+        assert_eq!(normalize_field_name("a[b[c[d]]]", &mut m, &[]), "a_b_c_d");
     }
 }
 

--- a/formatparse-pyo3/src/pattern_normalize.rs
+++ b/formatparse-pyo3/src/pattern_normalize.rs
@@ -59,8 +59,8 @@ pub fn normalize_pattern_line_continuations(pattern: &str) -> String {
             }
         }
     }
-    // Only ASCII backslash/newline edits; `pattern` was valid UTF-8.
-    String::from_utf8(out).expect("pattern normalization preserves UTF-8")
+    // Output is built only from valid UTF-8 slices of `pattern` plus ASCII `\` / newlines / spaces.
+    String::from_utf8(out).expect("normalize_pattern_line_continuations: UTF-8 invariant")
 }
 
 pub fn prepare_compiled_pattern(pattern: &str) -> PyResult<String> {

--- a/formatparse-pyo3/src/results.rs
+++ b/formatparse-pyo3/src/results.rs
@@ -155,7 +155,7 @@ impl ResultsIterator {
         let list_bound = self
             .cached_list
             .as_ref()
-            .unwrap()
+            .expect("cached_list set immediately above when None")
             .bind(py)
             .downcast::<pyo3::types::PyList>()?;
         let len = list_bound.len();

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -65,9 +65,7 @@ pub fn validate_alignment_precision(spec: &FieldSpec, value: &str) -> bool {
                 // Reject if fill char on right (should only be on left), except for a fixed-width
                 // cell where width == precision == len: LTR parsing cannot separate trailing fill
                 // from content the way str.format output would (parse parity; GitHub issue #97).
-                if has_trailing_fill
-                    && !(spec.width == Some(prec) && value.len() == prec)
-                {
+                if has_trailing_fill && !(spec.width == Some(prec) && value.len() == prec) {
                     return false;
                 }
                 // Reject if content exceeds precision

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,8 +28,8 @@ Pytest collects `tests/test_*.py`. Use the same environment as CI: build the nat
 
 ## CI vs local Rust
 
-GitHub Actions runs `cargo test --workspace` on the **Ubuntu + Python 3.11** job so **both** `formatparse-core` and `formatparse-pyo3` unit tests run; other matrix jobs run `cargo test -p formatparse-core` only. An additional **`python-tests`** step runs on that same Ubuntu job with `continue-on-error` (see below).
+GitHub Actions runs `cargo test --workspace` on the **Ubuntu + Python 3.11** job so **both** `formatparse-core` and `formatparse-pyo3` unit tests run; other matrix jobs run `cargo test -p formatparse-core` only. An additional **`python-tests`** step runs on that same Ubuntu job and **fails the job** if it fails (see below). **PyPy 3.11** on Ubuntu runs the Python pytest suite against a `maturin develop` build like other matrix cells.
 
 ## PyO3 `python-tests`
 
-Opt-in Rust tests that embed a Python interpreter (`RawValue::to_py_object`, etc.): `cargo test -p formatparse-pyo3 --features python-tests` with `PYO3_PYTHON` set to your venv interpreter. CI runs this on Ubuntu + Python 3.11 as a **non-blocking** step (`continue-on-error`) so linker/Python layout issues do not fail the whole matrix.
+Opt-in Rust tests that embed a Python interpreter (`RawValue::to_py_object`, etc.): `cargo test -p formatparse-pyo3 --features python-tests` with `PYO3_PYTHON` set to your venv interpreter. CI runs this on Ubuntu + Python 3.11 as a **blocking** step (same environment as `maturin develop` in that job).


### PR DESCRIPTION
## Summary

This pull request implements the deep-dive plan items for CI fidelity, cache correctness, and documentation.

### CI
- Add an **Ubuntu + PyPy 3.11** matrix job so the PyPI PyPy classifier is exercised like CPython.
- Make **`cargo test -p formatparse-pyo3 --features python-tests`** a **blocking** step on Ubuntu CPython 3.11 (remove `continue-on-error`).

### Pattern LRU
- After a hash hit, verify the full **normalized pattern** and **`extra_types` identity** (sorted name / `with_pattern` string / `regex_group_count` tag) so a colliding `u64` key cannot return the wrong compiled parser.
- Introduce `extract_extra_types_identity` and `FormatParser::matches_pattern_cache_request`.

### Rust hygiene
- Replace a few internal `unwrap`s with clearer `expect` messages; tighten `from_utf8` invariant messages in line-continuation helpers.

### Docs
- **CHANGELOG**: `### Planned` backlog (inline validators, async pipelines, `composed_type` / #7); maintenance and fixed entries for the above.
- **CONTRIBUTING** and **tests/README**: PyPy row, blocking `python-tests`, remove outdated soft-fail wording.

### Other
- `cargo fmt` on touched Rust files (minor formatting in lookaround, regex, datetime, matching, conversion).