### PR TITLE
fix(ci): PyPy pympler skip + 500ms regex compile cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI:** Skip pympler-based memory tests on **PyPy** (`SummaryTracker` / `asizeof` raises `KeyError` on PyPy 3.11).
+- **CI / ReDoS guard:** Raise the post-regex-compile wall-clock cap from **200ms to 500ms** so slow shared runners (e.g. macOS Intel) do not spuriously reject valid patterns; documentation updated accordingly.
+
 - **Pattern LRU cache:** after a hash hit, the entry is checked against the full normalized pattern and ``extra_types`` fingerprint so a colliding key cannot return the wrong compiled parser.
 
 - **Fixed-width string fields with literals beside the field** (e.g. ``"{s:<5.5} "`` vs ``"abc   "``): when width and precision are equal, the compiled fragment is exactly ``prec`` characters so trailing (or leading) pattern space is not pulled into the capture (#97). **Right-aligned** fields with that same equal width and precision also accept an opaque fixed-width capture (including trailing spaces) so post-capture validation matches **parse** for those cells (#97).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,19 +73,19 @@ The library implements the following security limits:
 - Maximum input string length: 10,000,000 characters (10MB)
 - Maximum number of fields: 100
 - Maximum field name length: 200 characters
-- After each successful regex compilation, the library checks that compilation took at most 200ms of wall-clock time (see ReDoS section below; this is not a match-time bound)
+- After each successful regex compilation, the library checks that compilation took at most 500ms of wall-clock time (see ReDoS section below; this is not a match-time bound)
 
 If you encounter these limits and need to adjust them for your use case, please open an issue to discuss.
 
 ### Regular Expression Denial of Service (ReDoS)
 
-**Compilation vs matching:** The 200ms check runs only *after* `Regex::new` returns. It does not interrupt compilation in progress, and it does **not** bound **matching** time (`parse`, `search`, `findall`, etc.). Pathological patterns and inputs can still spend a long time in the matching engine even when compilation succeeds quickly.
+**Compilation vs matching:** The 500ms check runs only *after* `Regex::new` returns. It does not interrupt compilation in progress, and it does **not** bound **matching** time (`parse`, `search`, `findall`, etc.). Pathological patterns and inputs can still spend a long time in the matching engine even when compilation succeeds quickly.
 
 The library still helps by enforcing pattern and input size limits and rejecting some invalid patterns early. For untrusted patterns or text you should:
 
 - Prefer simple patterns and validate pattern source where possible
 - Monitor wall-clock time at the application level if you process untrusted input
-- Avoid relying on the 200ms post-compile check as full ReDoS protection
+- Avoid relying on the 500ms post-compile check as full ReDoS protection
 
 ### `findall` and many matches
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -50,12 +50,12 @@ The library includes built-in limits to help protect against malicious patterns:
 - Maximum pattern length: 10,000 characters
 - Maximum input length: 10MB
 - Maximum fields: 100
-- After each successful regex compilation, the library checks that compilation took at most 200ms of wall-clock time (this does not bound matching time; see below)
+- After each successful regex compilation, the library checks that compilation took at most 500ms of wall-clock time (this does not bound matching time; see below)
 
 Regular Expression Denial of Service (ReDoS)
 --------------------------------------------
 
-**Compilation vs matching:** The 200ms check runs only *after* regex compilation completes. It does not interrupt compilation in progress, and it does **not** bound **matching** time for ``parse``, ``search``, ``findall``, or similar calls. Use application-level timeouts and simple patterns for untrusted input.
+**Compilation vs matching:** The 500ms check runs only *after* regex compilation completes. It does not interrupt compilation in progress, and it does **not** bound **matching** time for ``parse``, ``search``, ``findall``, or similar calls. Use application-level timeouts and simple patterns for untrusted input.
 
 **``findall``:** There is no fixed cap on how many matches can be returned within the maximum input length; consider bounding match count in your application when inputs are untrusted.
 
@@ -96,7 +96,7 @@ The library enforces the following limits:
 - **Input length**: 10,000,000 characters (10MB) maximum
 - **Field count**: 100 fields maximum
 - **Field name length**: 200 characters maximum
-- **Post-compile timing check**: After each successful regex compilation, the library rejects the build if compilation took more than 200ms of wall-clock time (this is not a match-time or interruptible compile timeout; see the ReDoS section above)
+- **Post-compile timing check**: After each successful regex compilation, the library rejects the build if compilation took more than 500ms of wall-clock time (this is not a match-time or interruptible compile timeout; see the ReDoS section above)
 
 If you need different limits for your use case, consider:
 

--- a/formatparse-core/src/parser/regex.rs
+++ b/formatparse-core/src/parser/regex.rs
@@ -7,7 +7,10 @@ use std::time::Instant;
 /// This is checked **after** `Regex::new` returns (wall-clock elapsed time). It does not
 /// interrupt compilation in progress and does not bound **matching** time. See project
 /// security documentation for ReDoS considerations.
-const MAX_REGEX_COMPILATION_TIME_MS: u128 = 200;
+///
+/// Set to 500ms so legitimate patterns still fail closed on extreme stalls while tolerating
+/// slow shared CI hosts (e.g. macOS Intel runners) that can exceed a tighter budget sporadically.
+const MAX_REGEX_COMPILATION_TIME_MS: u128 = 500;
 
 /// Build a regex from a pattern string with DOTALL flag
 /// Includes timeout protection against ReDoS attacks

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4,9 +4,17 @@ These tests ensure that repeated operations don't leak memory,
 which is especially important for PyO3 bindings.
 """
 
-import pytest
 import gc
+import sys
+
+import pytest
 from formatparse import parse, compile, BidirectionalPattern
+
+
+def _skip_pympler_on_pypy() -> None:
+    """pympler's SummaryTracker uses asizeof paths that break on PyPy (KeyError on typedef)."""
+    if sys.implementation.name == "pypy":
+        pytest.skip("pympler tracker is not compatible with PyPy")
 
 
 def test_repeated_parsing_no_leak():
@@ -68,6 +76,7 @@ def test_bidirectional_pattern_reuse_no_leak():
 @pytest.mark.slow
 def test_long_running_operation_memory():
     """Test memory usage in long-running operations"""
+    _skip_pympler_on_pypy()
     try:
         from pympler import tracker
 
@@ -98,6 +107,7 @@ def test_long_running_operation_memory():
 @pytest.mark.slow
 def test_findall_memory_usage():
     """Test memory usage with findall operations"""
+    _skip_pympler_on_pypy()
     try:
         from pympler import tracker
         from formatparse import findall


### PR DESCRIPTION
## Context

[CI run 25894907543](https://github.com/eddiethedean/formatparse/actions/runs/25894907543) failed on:

1. **PyPy 3.11 / Ubuntu** — `tests/test_memory.py` (`test_long_running_operation_memory`, `test_findall_memory_usage`): pympler `SummaryTracker` / `asizeof` raises `KeyError` on PyPy (known incompatibility).
2. **macOS 15 Intel / Python 3.10** — `test_precision_basic`: post-compile wall-clock check rejected a valid pattern at **277ms** (> **200ms**).

## Changes

- Skip pympler-based memory tests when `sys.implementation.name == "pypy"`.
- Raise `MAX_REGEX_COMPILATION_TIME_MS` from **200** to **500** in `formatparse-core` (still a hard cap after `Regex::new`); update **SECURITY.md** and **docs/security.rst**.
- **CHANGELOG** under [Unreleased] Fixed.