### PR TITLE
deps: Dependabot batch (PyO3 0.28, docs, CI, Rust crates)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Store benchmark results
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
           path: benchmark_results.json

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -77,7 +77,7 @@ jobs:
           mutmut results || echo "No mutation results available"
 
       - name: Upload mutation results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: mutation-results
           path: .mutmut-cache/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -192,7 +192,7 @@ jobs:
         run: cd formatparse-pyo3 && maturin build --out ../dist --strip --release --features extension-module
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ matrix.os }}-${{ matrix.architecture }}-py${{ matrix.python }}
           path: dist/*.whl
@@ -239,7 +239,7 @@ jobs:
           rm -rf "$EXTRACT_DIR"
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -328,14 +328,14 @@ jobs:
       id-token: write  # Required for trusted publishing
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: wheel-*
           merge-multiple: true
           path: artifacts/wheels
 
       - name: Download sdist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: sdist
           merge-multiple: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +55,26 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -99,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -122,6 +148,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -133,7 +165,7 @@ dependencies = [
  "fancy-regex",
  "once_cell",
  "proptest",
- "rand",
+ "rand 0.10.1",
  "regex",
 ]
 
@@ -159,19 +191,42 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.1"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -181,13 +236,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
- "rustversion",
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -202,12 +278,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
-name = "lru"
-version = "0.16.4"
+name = "log"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -215,15 +297,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "num-traits"
@@ -256,6 +329,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,7 +357,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -285,37 +368,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -323,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -335,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -368,13 +446,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.3"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -384,7 +479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -393,8 +488,14 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -402,14 +503,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -468,12 +569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +579,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -516,6 +617,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,7 +653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -558,10 +672,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unindent"
-version = "0.2.4"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "wait-timeout"
@@ -578,7 +692,50 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -603,6 +760,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,3 +866,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/formatparse.svg)](https://badge.fury.io/py/formatparse)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.83+-orange.svg)](https://www.rust-lang.org/)
 [![Documentation](https://readthedocs.org/projects/formatparse/badge/?version=latest)](https://formatparse.readthedocs.io/)
 
 A high-performance, Rust-backed implementation of the [parse](https://github.com/r1chardj0n3s/parse) library for Python. `formatparse` provides the same API as the original `parse` library but with **significant performance improvements** (up to **80x faster**) thanks to Rust's zero-cost abstractions and optimized regex engine.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,6 +31,6 @@ Requirements
 ------------
 
 - Python 3.8+
-- Rust 1.70+ (for building from source)
+- Rust 1.83+ (for building from source)
 - maturin (for building from source)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx>=7.0,<8.0
-sphinx-rtd-theme>=2.0
-sphinx-autodoc-typehints>=2.0
+sphinx>=7.4.7,<8.0
+sphinx-rtd-theme>=3.1.0
+sphinx-autodoc-typehints>=2.3.0
 sphinx-copybutton>=0.5.2
-myst-parser>=2.0,<3
+myst-parser>=3.0.1,<4

--- a/formatparse-core/Cargo.toml
+++ b/formatparse-core/Cargo.toml
@@ -12,18 +12,18 @@ description = "Core Rust library for parsing strings using Python format() synta
 documentation = "https://docs.rs/formatparse-core"
 keywords = ["parse", "format", "string", "regex", "datetime"]
 categories = ["parser-implementations", "text-processing"]
-rust-version = "1.74"
+rust-version = "1.83"
 
 [package.metadata.docs.rs]
 all-features = false
 
 [dependencies]
 regex = "1.12.3"
-fancy-regex = "0.14"
+fancy-regex = "0.17"
 once_cell = "1.21.4"
 
 [dev-dependencies]
 proptest = "1.10.0"
-# Floor for RUSTSEC-2026-0097 (proptest pulls rand 0.9; 0.9.2 is affected).
-rand = "0.9.3"
+# Direct dev-dep; proptest may still pull rand 0.9 transitively.
+rand = "0.10.1"
 

--- a/formatparse-pyo3/Cargo.toml
+++ b/formatparse-pyo3/Cargo.toml
@@ -11,7 +11,7 @@ description = "PyO3 bindings for formatparse (native _formatparse extension; use
 documentation = "https://docs.rs/formatparse-pyo3"
 keywords = ["pyo3", "python", "parse", "format", "formatparse"]
 categories = ["api-bindings", "parser-implementations"]
-rust-version = "1.74"
+rust-version = "1.83"
 
 [package.metadata.docs.rs]
 all-features = false
@@ -29,11 +29,11 @@ python-tests = []
 
 [dependencies]
 formatparse-core.workspace = true
-pyo3 = { version = "0.24", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.28", default-features = false, features = ["macros"] }
 regex = "1.12.3"
-fancy-regex = "0.14"
+fancy-regex = "0.17"
 serde = { version = "1.0", features = ["derive"] }
-lru = "0.16.3"
+lru = "0.18.0"
 once_cell = "1.21.4"
-rayon = "1.8"
+rayon = "1.12"
 

--- a/formatparse-pyo3/src/datetime/common.rs
+++ b/formatparse-pyo3/src/datetime/common.rs
@@ -73,7 +73,7 @@ pub fn get_abbreviated_month_map() -> HashMap<&'static str, u8> {
 }
 
 /// Create a FixedTzOffset from offset minutes
-pub fn create_fixed_tz(py: Python, offset_minutes: i32, name: &str) -> PyResult<PyObject> {
+pub fn create_fixed_tz(py: Python, offset_minutes: i32, name: &str) -> PyResult<Py<PyAny>> {
     let fixed_tz_module = py.import("formatparse")?;
     let fixed_tz_class = fixed_tz_module.getattr("FixedTzOffset")?;
     let tz = fixed_tz_class.call1((offset_minutes, name.to_string()))?;
@@ -82,7 +82,7 @@ pub fn create_fixed_tz(py: Python, offset_minutes: i32, name: &str) -> PyResult<
 
 /// Parse timezone string into FixedTzOffset
 /// Handles formats: +1:00, +10:00, +10:30, +1000, etc.
-pub fn parse_timezone(py: Python, tz_str: &str) -> PyResult<PyObject> {
+pub fn parse_timezone(py: Python, tz_str: &str) -> PyResult<Py<PyAny>> {
     // Handle formats: +1:00, +10:00, +10:30, +1000, etc.
     if let Some(caps) = RE_TZ_COLON.captures(tz_str) {
         if let (Some(sign_match), Some(hour_match), Some(min_match)) =

--- a/formatparse-pyo3/src/datetime/ctime.rs
+++ b/formatparse-pyo3/src/datetime/ctime.rs
@@ -10,7 +10,7 @@ static RE_CTIME_DATETIME: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Parse ctime() format: Mon Nov 21 10:21:36 2011
-pub fn parse_ctime_datetime(py: Python, value: &str) -> PyResult<PyObject> {
+pub fn parse_ctime_datetime(py: Python, value: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
 

--- a/formatparse-pyo3/src/datetime/fixed_tz.rs
+++ b/formatparse-pyo3/src/datetime/fixed_tz.rs
@@ -33,7 +33,7 @@ impl FixedTzOffset {
     }
 
     fn __eq__(&self, other: &Bound<'_, PyAny>) -> PyResult<bool> {
-        if let Ok(other_tz) = other.downcast::<Self>() {
+        if let Ok(other_tz) = other.cast::<Self>() {
             Ok(self.offset_seconds == other_tz.borrow().offset_seconds
                 && self.name == other_tz.borrow().name)
         } else {
@@ -58,7 +58,7 @@ impl FixedTzOffset {
     }
 
     /// tzinfo.utcoffset() - returns timedelta for offset
-    fn utcoffset(&self, py: Python, _dt: Option<&Bound<'_, PyAny>>) -> PyResult<PyObject> {
+    fn utcoffset(&self, py: Python, _dt: Option<&Bound<'_, PyAny>>) -> PyResult<Py<PyAny>> {
         let datetime_module = py.import("datetime")?;
         let timedelta_class = datetime_module.getattr("timedelta")?;
         // timedelta(seconds=offset_seconds)
@@ -67,7 +67,7 @@ impl FixedTzOffset {
     }
 
     /// tzinfo.dst() - returns None (no DST)
-    fn dst(&self, py: Python, _dt: Option<&Bound<'_, PyAny>>) -> PyResult<PyObject> {
+    fn dst(&self, py: Python, _dt: Option<&Bound<'_, PyAny>>) -> PyResult<Py<PyAny>> {
         Ok(py.None())
     }
 

--- a/formatparse-pyo3/src/datetime/global.rs
+++ b/formatparse-pyo3/src/datetime/global.rs
@@ -14,14 +14,14 @@ static RE_GLOBAL_NAMED: Lazy<Regex> = Lazy::new(|| {
 
 /// Parse Global (day/month) datetime format
 /// Formats: 21/11/2011, 21-11-2011, 21-Nov-2011, 21-November-2011
-pub fn parse_global_datetime(py: Python, value: &str) -> PyResult<PyObject> {
+pub fn parse_global_datetime(py: Python, value: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
 
     let month_map = get_month_map();
 
     // Helper to parse timezone - use common function
-    let parse_tz = |tz_str: &str| -> PyResult<PyObject> { parse_timezone(py, tz_str) };
+    let parse_tz = |tz_str: &str| -> PyResult<Py<PyAny>> { parse_timezone(py, tz_str) };
 
     // Helper to parse AM/PM - use common function
     let parse_time_with_ampm = |time_str: &str| -> Result<(u8, u8, u8), PyErr> {

--- a/formatparse-pyo3/src/datetime/http.rs
+++ b/formatparse-pyo3/src/datetime/http.rs
@@ -10,7 +10,7 @@ static RE_HTTP_DATETIME: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Parse HTTP log format: 21/Nov/2011:10:21:36 +1000
-pub fn parse_http_datetime(py: Python, value: &str) -> PyResult<PyObject> {
+pub fn parse_http_datetime(py: Python, value: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
 

--- a/formatparse-pyo3/src/datetime/iso.rs
+++ b/formatparse-pyo3/src/datetime/iso.rs
@@ -25,7 +25,7 @@ static RE_ISO_DATETIME_NO_TZ: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Parse ISO 8601 datetime string and return Python datetime object
-pub fn parse_iso_datetime(py: Python, value: &str) -> PyResult<PyObject> {
+pub fn parse_iso_datetime(py: Python, value: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
 

--- a/formatparse-pyo3/src/datetime/rfc2822.rs
+++ b/formatparse-pyo3/src/datetime/rfc2822.rs
@@ -19,7 +19,7 @@ static RE_RFC2822_NO_WEEKDAY: Lazy<Regex> = Lazy::new(|| {
 
 /// Parse RFC2822 datetime string and return Python datetime object
 /// Format: Mon, 21 Nov 2011 10:21:36 +1000
-pub fn parse_rfc2822_datetime(py: Python, value: &str) -> PyResult<PyObject> {
+pub fn parse_rfc2822_datetime(py: Python, value: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
 

--- a/formatparse-pyo3/src/datetime/strftime.rs
+++ b/formatparse-pyo3/src/datetime/strftime.rs
@@ -12,7 +12,7 @@ fn is_regex_group_redefinition_error(err: &PyErr) -> bool {
 
 /// Fallback parser for strftime format strings when strptime fails due to regex group conflicts
 /// This manually parses the format string and extracts datetime components
-fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResult<PyObject> {
+fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
     let date_class = datetime_module.getattr("date")?;
@@ -225,7 +225,7 @@ fn parse_strftime_fallback(py: Python, value: &str, format_str: &str) -> PyResul
 }
 
 /// Parse strftime-style datetime using Python's strptime
-pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyResult<PyObject> {
+pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
     let date_class = datetime_module.getattr("date")?;
@@ -442,7 +442,7 @@ pub fn parse_strftime_datetime(py: Python, value: &str, format_str: &str) -> PyR
 pub fn parse_merged_strftime_datetime(
     py: Python<'_>,
     parts: &[(String, String)],
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     if parts.is_empty() {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "merged strftime: empty fragment list",

--- a/formatparse-pyo3/src/datetime/system.rs
+++ b/formatparse-pyo3/src/datetime/system.rs
@@ -10,7 +10,7 @@ static RE_SYSTEM_DATETIME: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Parse Linux system log format: Nov 21 10:21:36 (year is current year)
-pub fn parse_system_datetime(py: Python, value: &str) -> PyResult<PyObject> {
+pub fn parse_system_datetime(py: Python, value: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
     let today = datetime_class.call_method0("today")?;

--- a/formatparse-pyo3/src/datetime/time.rs
+++ b/formatparse-pyo3/src/datetime/time.rs
@@ -8,11 +8,11 @@ use regex::Regex;
 static RE_TIME_TZ: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+([+-]\d{1,2}:?\d{2,4})$").unwrap());
 
 /// Parse time format: 10:21:36, 10:21:36 AM, 10:21:36 PM, 10:21 - returns time object
-pub fn parse_time(py: Python, value: &str) -> PyResult<PyObject> {
+pub fn parse_time(py: Python, value: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let time_class = datetime_module.getattr("time")?;
 
-    let parse_tz = |tz_str: &str| -> PyResult<PyObject> {
+    let parse_tz = |tz_str: &str| -> PyResult<Py<PyAny>> {
         if let Some(caps) = RE_TZ_COLON.captures(tz_str) {
             if let (Some(sign_match), Some(hour_match), Some(min_match)) =
                 (caps.get(1), caps.get(2), caps.get(3))

--- a/formatparse-pyo3/src/datetime/us.rs
+++ b/formatparse-pyo3/src/datetime/us.rs
@@ -15,13 +15,13 @@ static RE_US_NAMED: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Parse US (month/day) datetime format - similar to global but different order
-pub fn parse_us_datetime(py: Python, value: &str) -> PyResult<PyObject> {
+pub fn parse_us_datetime(py: Python, value: &str) -> PyResult<Py<PyAny>> {
     let datetime_module = py.import("datetime")?;
     let datetime_class = datetime_module.getattr("datetime")?;
 
     let month_map = get_month_map();
 
-    let parse_tz = |tz_str: &str| -> PyResult<PyObject> {
+    let parse_tz = |tz_str: &str| -> PyResult<Py<PyAny>> {
         // Handle formats: +1000, +10:00, +10:30, etc.
         if let Some(caps) = RE_TZ_COLON.captures(tz_str) {
             if let (Some(sign_match), Some(hour_match), Some(min_match)) =

--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -39,10 +39,10 @@ pub use error::PatternParseMismatch;
 fn parse(
     pattern: &str,
     string: &str,
-    extra_types: Option<HashMap<String, PyObject>>,
+    extra_types: Option<HashMap<String, Py<PyAny>>>,
     case_sensitive: bool,
     evaluate_result: bool,
-) -> PyResult<Option<PyObject>> {
+) -> PyResult<Option<Py<PyAny>>> {
     // Validate input lengths
     formatparse_core::validate_input_length(string)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
@@ -55,7 +55,7 @@ fn parse(
     }
 
     // Use cached parser if available
-    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+    let extra_types_cloned = Python::attach(|py| -> Option<HashMap<String, Py<PyAny>>> {
         extra_types.as_ref().map(|et| {
             et.iter()
                 .map(|(k, v)| (k.clone(), v.clone_ref(py)))
@@ -69,7 +69,7 @@ fn parse(
             extra_types.as_ref(),
             evaluate_result,
         ),
-        Err(e) => Python::with_gil(|py| {
+        Err(e) => Python::attach(|py| {
             if e.is_instance_of::<PyNotImplementedError>(py) {
                 return Err(e);
             }
@@ -91,10 +91,10 @@ fn parse(
 fn parse_batch(
     pattern: &str,
     strings: Vec<String>,
-    extra_types: Option<HashMap<String, PyObject>>,
+    extra_types: Option<HashMap<String, Py<PyAny>>>,
     case_sensitive: bool,
     evaluate_result: bool,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     for s in &strings {
         formatparse_core::validate_input_length(s)
             .map_err(pyo3::exceptions::PyValueError::new_err)?;
@@ -105,7 +105,7 @@ fn parse_batch(
         }
     }
 
-    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+    let extra_types_cloned = Python::attach(|py| -> Option<HashMap<String, Py<PyAny>>> {
         extra_types.as_ref().map(|et| {
             et.iter()
                 .map(|(k, v)| (k.clone(), v.clone_ref(py)))
@@ -116,13 +116,13 @@ fn parse_batch(
     let parser = match get_or_create_parser(pattern, extra_types_cloned) {
         Ok(p) => p,
         Err(e) => {
-            return Python::with_gil(|py| -> PyResult<PyObject> {
+            return Python::attach(|py| -> PyResult<Py<PyAny>> {
                 if e.is_instance_of::<PyNotImplementedError>(py) {
                     return Err(e);
                 }
                 if e.is_instance_of::<crate::error::PatternParseMismatch>(py) {
                     let none_obj = py.None().into_py_any(py)?;
-                    let mut out: Vec<PyObject> = Vec::with_capacity(strings.len());
+                    let mut out: Vec<Py<PyAny>> = Vec::with_capacity(strings.len());
                     for _ in 0..strings.len() {
                         out.push(none_obj.clone_ref(py));
                     }
@@ -134,8 +134,8 @@ fn parse_batch(
         }
     };
 
-    Python::with_gil(|py| -> PyResult<PyObject> {
-        let mut out: Vec<PyObject> = Vec::with_capacity(strings.len());
+    Python::attach(|py| -> PyResult<Py<PyAny>> {
+        let mut out: Vec<Py<PyAny>> = Vec::with_capacity(strings.len());
         for s in &strings {
             match parser.parse_internal(s, case_sensitive, extra_types.as_ref(), evaluate_result)? {
                 Some(obj) => out.push(obj),
@@ -155,10 +155,10 @@ fn search(
     string: &str,
     pos: usize,
     endpos: Option<usize>,
-    extra_types: Option<HashMap<String, PyObject>>,
+    extra_types: Option<HashMap<String, Py<PyAny>>>,
     case_sensitive: bool,
     evaluate_result: bool,
-) -> PyResult<Option<PyObject>> {
+) -> PyResult<Option<Py<PyAny>>> {
     // Validate pos parameter
     if pos > string.len() {
         return Ok(None);
@@ -184,7 +184,7 @@ fn search(
         ));
     }
 
-    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+    let extra_types_cloned = Python::attach(|py| -> Option<HashMap<String, Py<PyAny>>> {
         extra_types.as_ref().map(|et| {
             et.iter()
                 .map(|(k, v)| (k.clone(), v.clone_ref(py)))
@@ -198,8 +198,8 @@ fn search(
         parser.search_pattern(search_string, case_sensitive, extra_types, evaluate_result)?
     {
         // Adjust positions if it's a ParseResult (not Match)
-        Python::with_gil(|py| {
-            if let Ok(parse_result) = result.bind(py).downcast::<ParseResult>() {
+        Python::attach(|py| {
+            if let Ok(parse_result) = result.bind(py).cast::<ParseResult>() {
                 let result_value = parse_result.borrow();
                 let adjusted = result_value.clone().with_offset(pos);
                 // Py::new() is already optimized when GIL is held
@@ -221,10 +221,10 @@ fn search(
 fn findall(
     pattern: &str,
     string: &str,
-    extra_types: Option<HashMap<String, PyObject>>,
+    extra_types: Option<HashMap<String, Py<PyAny>>>,
     case_sensitive: bool,
     evaluate_result: bool,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     // Validate input lengths
     formatparse_core::validate_input_length(string)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
@@ -236,7 +236,7 @@ fn findall(
         ));
     }
 
-    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+    let extra_types_cloned = Python::attach(|py| -> Option<HashMap<String, Py<PyAny>>> {
         extra_types.as_ref().map(|et| {
             et.iter()
                 .map(|(k, v)| (k.clone(), v.clone_ref(py)))
@@ -262,7 +262,7 @@ fn findall_iter(
     py: Python<'_>,
     pattern: &str,
     string: &str,
-    extra_types: Option<HashMap<String, PyObject>>,
+    extra_types: Option<HashMap<String, Py<PyAny>>>,
     case_sensitive: bool,
     evaluate_result: bool,
 ) -> PyResult<Py<FindallIter>> {
@@ -275,7 +275,7 @@ fn findall_iter(
         ));
     }
 
-    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+    let extra_types_cloned = Python::attach(|py| -> Option<HashMap<String, Py<PyAny>>> {
         extra_types.as_ref().map(|et| {
             et.iter()
                 .map(|(k, v)| (k.clone(), v.clone_ref(py)))
@@ -284,7 +284,7 @@ fn findall_iter(
     });
     let parser = get_or_create_parser(pattern, extra_types_cloned)?;
 
-    let et_map = Python::with_gil(|py| -> HashMap<String, PyObject> {
+    let et_map = Python::attach(|py| -> HashMap<String, Py<PyAny>> {
         extra_types
             .as_ref()
             .map(|et| {
@@ -316,9 +316,9 @@ fn findall_iter(
 #[pyo3(signature = (pattern, extra_types=None))]
 fn compile(
     pattern: &str,
-    extra_types: Option<HashMap<String, PyObject>>,
+    extra_types: Option<HashMap<String, Py<PyAny>>>,
 ) -> PyResult<FormatParser> {
-    let extra_types_cloned = Python::with_gil(|py| -> Option<HashMap<String, PyObject>> {
+    let extra_types_cloned = Python::attach(|py| -> Option<HashMap<String, Py<PyAny>>> {
         extra_types.as_ref().map(|et| {
             et.iter()
                 .map(|(k, v)| (k.clone(), v.clone_ref(py)))
@@ -335,7 +335,7 @@ fn compile(
 fn extract_format(
     format_string: &str,
     _match_dict: Option<&Bound<'_, PyDict>>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     use crate::types::FieldSpec;
 
     // Parse the format spec string
@@ -411,7 +411,7 @@ fn extract_format(
     };
 
     // Build result dictionary
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result = PyDict::new(py);
         result.set_item("type", type_str)?;
 

--- a/formatparse-pyo3/src/match_rs.rs
+++ b/formatparse-pyo3/src/match_rs.rs
@@ -39,11 +39,11 @@ impl Match {
     fn evaluate_result(
         &self,
         py: Python,
-        extra_types: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<PyObject> {
+        extra_types: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Py<PyAny>> {
         let custom_converters = extra_types.unwrap_or_default();
         let mut fixed = Vec::new();
-        let mut named: HashMap<String, PyObject> = HashMap::new();
+        let mut named: HashMap<String, Py<PyAny>> = HashMap::new();
 
         // Apply type conversions using stored field specs
         for (i, spec) in self.field_specs.iter().enumerate() {

--- a/formatparse-pyo3/src/parser/findall_engine.rs
+++ b/formatparse-pyo3/src/parser/findall_engine.rs
@@ -16,10 +16,10 @@ use std::sync::Arc;
 pub(crate) fn findall_matches(
     parser: Arc<FormatParser>,
     string: &str,
-    extra_types: Option<&HashMap<String, PyObject>>,
+    extra_types: Option<&HashMap<String, Py<PyAny>>>,
     case_sensitive: bool,
     evaluate_result: bool,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let has_custom_converters = extra_types
         .as_ref()
         .map(|et| !et.is_empty())
@@ -69,14 +69,14 @@ pub(crate) fn findall_matches(
         }
 
         if !raw_path_failed {
-            return Python::with_gil(|py| -> PyResult<PyObject> {
+            return Python::attach(|py| -> PyResult<Py<PyAny>> {
                 let results = Results::new(raw_results);
                 Py::new(py, results)?.into_py_any(py)
             });
         }
     }
 
-    Python::with_gil(|py| -> PyResult<PyObject> {
+    Python::attach(|py| -> PyResult<Py<PyAny>> {
         let search_regex = parser.get_search_regex(case_sensitive);
         let mut results = Vec::new();
         let mut last_end = 0;

--- a/formatparse-pyo3/src/parser/findall_iter.rs
+++ b/formatparse-pyo3/src/parser/findall_iter.rs
@@ -20,7 +20,7 @@ pub struct FindallIter {
     case_sensitive: bool,
     evaluate_result: bool,
     fast_path: bool,
-    extra_types: HashMap<String, PyObject>,
+    extra_types: HashMap<String, Py<PyAny>>,
     last_end: usize,
     search_pos: usize,
 }
@@ -31,7 +31,7 @@ impl FindallIter {
         haystack: String,
         case_sensitive: bool,
         evaluate_result: bool,
-        extra_types: HashMap<String, PyObject>,
+        extra_types: HashMap<String, Py<PyAny>>,
     ) -> Self {
         let has_custom_converters = !extra_types.is_empty();
         let has_nested_dicts = parser.fields.has_nested_dict_fields.iter().any(|&b| b);
@@ -63,7 +63,7 @@ impl FindallIter {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn __next__(mut slf: PyRefMut<'_, Self>, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
         if slf.fast_path {
             loop {
                 if slf.search_pos > slf.haystack.len() {

--- a/formatparse-pyo3/src/parser/format_parser.rs
+++ b/formatparse-pyo3/src/parser/format_parser.rs
@@ -33,7 +33,7 @@ impl CompiledFields {
     }
 }
 
-#[pyclass(module = "_formatparse")]
+#[pyclass(module = "_formatparse", from_py_object)]
 /// Compiled format pattern for parsing strings.
 ///
 /// Construct with :func:`formatparse.compile` (or ``FormatParser(pattern, extra_types=...)`` in Python).
@@ -58,7 +58,7 @@ pub struct FormatParser {
     pub(crate) fields: CompiledFields,
     #[allow(dead_code)]
     pub(crate) name_mapping: std::collections::HashMap<String, String>, // Map normalized -> original
-    pub(crate) stored_extra_types: Option<HashMap<String, PyObject>>, // Store extra_types for use during conversion
+    pub(crate) stored_extra_types: Option<HashMap<String, Py<PyAny>>>, // Store extra_types for use during conversion
     pub(crate) allows_empty_default_string_match: bool, // True iff parse("") can use empty-field fast path (issue #16)
 }
 
@@ -70,7 +70,7 @@ impl FormatParser {
         &self,
         py: Python<'_>,
         normalized_pattern: &str,
-        extra_types: &Option<HashMap<String, PyObject>>,
+        extra_types: &Option<HashMap<String, Py<PyAny>>>,
     ) -> bool {
         if self.pattern != normalized_pattern {
             return false;
@@ -86,10 +86,10 @@ impl FormatParser {
 
     pub fn new_with_extra_types(
         pattern: &str,
-        extra_types: Option<HashMap<String, PyObject>>,
+        extra_types: Option<HashMap<String, Py<PyAny>>>,
     ) -> PyResult<Self> {
         let pattern_owned = crate::pattern_normalize::prepare_compiled_pattern(pattern)?;
-        let custom_patterns = Python::with_gil(|py| -> PyResult<HashMap<String, String>> {
+        let custom_patterns = Python::attach(|py| -> PyResult<HashMap<String, String>> {
             let mut patterns = HashMap::new();
             if let Some(ref extra_types_map) = extra_types {
                 for (name, converter_obj) in extra_types_map {
@@ -142,7 +142,7 @@ impl FormatParser {
         }
 
         let nested_parsers: Vec<Option<Arc<FormatParser>>> =
-            Python::with_gil(|py| -> PyResult<_> {
+            Python::attach(|py| -> PyResult<_> {
                 let mut out = Vec::with_capacity(field_specs.len());
                 for spec in &field_specs {
                     if matches!(spec.field_type, FieldType::Nested) {
@@ -165,12 +165,12 @@ impl FormatParser {
             })?;
         // Pre-compute custom type validation results (pattern_groups per field)
         // This avoids calling validate_custom_type_pattern for every match
-        let custom_type_groups = Python::with_gil(|py| -> PyResult<Vec<usize>> {
+        let custom_type_groups = Python::attach(|py| -> PyResult<Vec<usize>> {
             let mut groups = Vec::with_capacity(field_specs.len());
             let empty_map = std::collections::HashMap::new();
             let custom_converters = extra_types
                 .as_ref()
-                .map(|et| et as &HashMap<String, PyObject>)
+                .map(|et| et as &HashMap<String, Py<PyAny>>)
                 .unwrap_or(&empty_map);
 
             for spec in &field_specs {
@@ -245,9 +245,9 @@ impl FormatParser {
         &self,
         string: &str,
         case_sensitive: bool,
-        extra_types: Option<HashMap<String, PyObject>>,
+        extra_types: Option<HashMap<String, Py<PyAny>>>,
         evaluate_result: bool,
-    ) -> PyResult<Option<PyObject>> {
+    ) -> PyResult<Option<Py<PyAny>>> {
         // Use pre-compiled search regex
         let search_regex = if case_sensitive {
             &self.search_regex
@@ -257,7 +257,7 @@ impl FormatParser {
                 .unwrap_or(&self.search_regex)
         };
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             if search_regex
                 .captures(string)
                 .map_err(crate::error::fancy_regex_match_error)?
@@ -292,11 +292,11 @@ impl FormatParser {
         &self,
         string: &str,
         case_sensitive: bool,
-        extra_types: Option<&HashMap<String, PyObject>>,
+        extra_types: Option<&HashMap<String, Py<PyAny>>>,
         evaluate_result: bool,
-    ) -> PyResult<Option<PyObject>> {
-        Python::with_gil(|py| {
-            let empty = HashMap::<String, PyObject>::new();
+    ) -> PyResult<Option<Py<PyAny>>> {
+        Python::attach(|py| {
+            let empty = HashMap::<String, Py<PyAny>>::new();
             let extra_types_ref = extra_types.unwrap_or(&empty);
 
             // Use existing regex (custom type handling is done in convert_value)
@@ -357,9 +357,9 @@ impl FormatParser {
         &self,
         py: Python<'_>,
         slice: &str,
-        custom_converters: &HashMap<String, PyObject>,
+        custom_converters: &HashMap<String, Py<PyAny>>,
     ) -> PyResult<Option<Py<ParseResult>>> {
-        use pyo3::types::PyAnyMethods;
+        
         let mut merged = HashMap::new();
         if let Some(ref stored) = self.stored_extra_types {
             for (k, v) in stored {
@@ -374,7 +374,7 @@ impl FormatParser {
             return Ok(None);
         };
         let bound = obj.bind(py);
-        let pr = bound.downcast::<ParseResult>().map_err(|_| {
+        let pr = bound.cast::<ParseResult>().map_err(|_| {
             PyValueError::new_err("internal error: nested parse did not return ParseResult")
         })?;
         Ok(Some(pr.clone().unbind()))
@@ -383,7 +383,7 @@ impl FormatParser {
 
 impl Clone for FormatParser {
     fn clone(&self) -> Self {
-        Python::with_gil(|py| Self {
+        Python::attach(|py| Self {
             pattern: self.pattern.clone(),
             regex: self.regex.clone(),
             regex_str: self.regex_str.clone(),

--- a/formatparse-pyo3/src/parser/format_parser_pymethods.rs
+++ b/formatparse-pyo3/src/parser/format_parser_pymethods.rs
@@ -16,7 +16,7 @@ impl FormatParser {
     #[pyo3(signature = (pattern=None, extra_types=None))]
     fn new_py(
         pattern: Option<&str>,
-        extra_types: Option<HashMap<String, PyObject>>,
+        extra_types: Option<HashMap<String, Py<PyAny>>>,
     ) -> PyResult<Self> {
         match pattern {
             Some(p) => Self::new_with_extra_types(p, extra_types),
@@ -58,9 +58,9 @@ impl FormatParser {
         &self,
         string: &str,
         case_sensitive: bool,
-        extra_types: Option<HashMap<String, PyObject>>,
+        extra_types: Option<HashMap<String, Py<PyAny>>>,
         evaluate_result: bool,
-    ) -> PyResult<Option<PyObject>> {
+    ) -> PyResult<Option<Py<PyAny>>> {
         // Validate input length
         validate_input_length(string).map_err(PyValueError::new_err)?;
 
@@ -70,7 +70,7 @@ impl FormatParser {
         }
         // Merge stored extra_types with provided extra_types (provided takes precedence)
         let merged_extra_types =
-            Python::with_gil(|py| -> PyResult<Option<HashMap<String, PyObject>>> {
+            Python::attach(|py| -> PyResult<Option<HashMap<String, Py<PyAny>>>> {
                 let mut merged = if let Some(ref stored) = self.stored_extra_types {
                     stored
                         .iter()
@@ -178,9 +178,9 @@ impl FormatParser {
         &self,
         string: &str,
         case_sensitive: bool,
-        extra_types: Option<HashMap<String, PyObject>>,
+        extra_types: Option<HashMap<String, Py<PyAny>>>,
         evaluate_result: bool,
-    ) -> PyResult<Option<PyObject>> {
+    ) -> PyResult<Option<Py<PyAny>>> {
         // Validate input length
         validate_input_length(string).map_err(PyValueError::new_err)?;
 
@@ -190,7 +190,7 @@ impl FormatParser {
         }
 
         let merged_extra_types =
-            Python::with_gil(|py| -> PyResult<Option<HashMap<String, PyObject>>> {
+            Python::attach(|py| -> PyResult<Option<HashMap<String, Py<PyAny>>>> {
                 let mut merged = if let Some(ref stored) = self.stored_extra_types {
                     stored
                         .iter()
@@ -222,7 +222,7 @@ impl FormatParser {
         py: Python<'_>,
         string: &str,
         case_sensitive: bool,
-        extra_types: Option<HashMap<String, PyObject>>,
+        extra_types: Option<HashMap<String, Py<PyAny>>>,
         evaluate_result: bool,
     ) -> PyResult<Py<FindallIter>> {
         validate_input_length(string).map_err(PyValueError::new_err)?;
@@ -232,7 +232,7 @@ impl FormatParser {
         }
 
         let merged_extra_types =
-            Python::with_gil(|py| -> PyResult<Option<HashMap<String, PyObject>>> {
+            Python::attach(|py| -> PyResult<Option<HashMap<String, Py<PyAny>>>> {
                 let mut merged = if let Some(ref stored) = self.stored_extra_types {
                     stored
                         .iter()
@@ -275,7 +275,7 @@ impl FormatParser {
     }
 
     /// Pickle state: pattern string only (see class doc for ``extra_types``).
-    fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
+    fn __getstate__(&self, py: Python) -> PyResult<Py<PyAny>> {
         use pyo3::types::PyDict;
         let state = PyDict::new(py);
         state.set_item("pattern", &self.pattern)?;
@@ -285,7 +285,7 @@ impl FormatParser {
     /// Restore from pickle state (pattern only; ``extra_types`` are not recovered).
     fn __setstate__(&mut self, _py: Python, state: &Bound<'_, PyAny>) -> PyResult<()> {
         use pyo3::types::PyDict;
-        let dict = state.downcast::<PyDict>()?;
+        let dict = state.cast::<PyDict>()?;
         let pattern: String = dict
             .get_item("pattern")?
             .ok_or_else(|| error::missing_field_error("pattern"))?
@@ -324,7 +324,7 @@ impl Format {
         let format_method = pattern_obj.getattr("format")?;
 
         // Call format with the args (can be a single value, tuple, or *args)
-        let result = if let Ok(tuple) = args.downcast::<PyTuple>() {
+        let result = if let Ok(tuple) = args.cast::<PyTuple>() {
             format_method.call1(tuple)?
         } else {
             // Single argument

--- a/formatparse-pyo3/src/parser/matching/capture.rs
+++ b/formatparse-pyo3/src/parser/matching/capture.rs
@@ -37,7 +37,7 @@ pub(crate) fn per_field_capture_geometry(
     field_specs: &[FieldSpec],
     _normalized_names: &[Option<String>],
     py: Python<'_>,
-    custom_converters: &HashMap<String, PyObject>,
+    custom_converters: &HashMap<String, Py<PyAny>>,
     precomputed_pattern_groups: Option<&[usize]>,
 ) -> PyResult<Vec<(usize, usize)>> {
     let mut aci = 1usize;

--- a/formatparse-pyo3/src/parser/matching/custom_type.rs
+++ b/formatparse-pyo3/src/parser/matching/custom_type.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 pub fn validate_custom_type_pattern(
     field_spec: &FieldSpec,
-    custom_converters: &HashMap<String, PyObject>,
+    custom_converters: &HashMap<String, Py<PyAny>>,
     py: Python,
 ) -> PyResult<usize> {
     if matches!(&field_spec.field_type, FieldType::Nested) {

--- a/formatparse-pyo3/src/parser/matching/mod.rs
+++ b/formatparse-pyo3/src/parser/matching/mod.rs
@@ -37,7 +37,7 @@ pub struct CapturedMatchContext<'a> {
     pub pattern: &'a str,
     pub fields: FieldCaptureSlices<'a>,
     pub py: Python<'a>,
-    pub custom_converters: &'a HashMap<String, PyObject>,
+    pub custom_converters: &'a HashMap<String, Py<PyAny>>,
     pub evaluate_result: bool,
 }
 
@@ -50,7 +50,7 @@ pub struct RegexMatchContext<'a> {
     pub normalized_names: &'a [Option<String>],
     pub nested_parsers: &'a [Option<Arc<FormatParser>>],
     pub py: Python<'a>,
-    pub custom_converters: &'a HashMap<String, PyObject>,
+    pub custom_converters: &'a HashMap<String, Py<PyAny>>,
     pub evaluate_result: bool,
 }
 

--- a/formatparse-pyo3/src/parser/matching/nested_dict.rs
+++ b/formatparse-pyo3/src/parser/matching/nested_dict.rs
@@ -4,10 +4,10 @@ use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 
 pub fn get_nested_dict_value(
-    named: &HashMap<String, PyObject>,
+    named: &HashMap<String, Py<PyAny>>,
     path: &[String],
     py: Python,
-) -> PyResult<Option<PyObject>> {
+) -> PyResult<Option<Py<PyAny>>> {
     if path.is_empty() {
         return Ok(None);
     }
@@ -19,20 +19,20 @@ pub fn get_nested_dict_value(
 
     // Navigate through nested dicts
     let first_key = &path[0];
-    let mut current_obj: PyObject = match named.get(first_key) {
+    let mut current_obj: Py<PyAny> = match named.get(first_key) {
         Some(v) => v.clone_ref(py),
         None => return Ok(None),
     };
 
     for key in path.iter().skip(1) {
-        let current_dict = match current_obj.bind(py).downcast::<PyDict>() {
+        let current_dict = match current_obj.bind(py).cast::<PyDict>() {
             Ok(d) => d,
             Err(_) => return Ok(None), // Not a dict, path doesn't exist
         };
 
         match current_dict.get_item(key.as_str())? {
             Some(v) => {
-                // Get the PyObject to continue navigation
+                // Get the Py<PyAny> to continue navigation
                 current_obj = v.into();
             }
             None => return Ok(None), // Path doesn't exist
@@ -44,9 +44,9 @@ pub fn get_nested_dict_value(
 
 /// Insert a value into a nested dict structure in the named HashMap
 pub fn insert_nested_dict(
-    named: &mut HashMap<String, PyObject>,
+    named: &mut HashMap<String, Py<PyAny>>,
     path: &[String],
-    value: PyObject,
+    value: Py<PyAny>,
     py: Python,
 ) -> PyResult<()> {
     if path.is_empty() {
@@ -65,7 +65,7 @@ pub fn insert_nested_dict(
     // Get or create the top-level dict
     let top_dict = if let Some(existing) = named.get(first_key) {
         // Check if it's already a dict
-        if let Ok(dict) = existing.bind(py).downcast::<PyDict>() {
+        if let Ok(dict) = existing.bind(py).cast::<PyDict>() {
             dict.clone()
         } else {
             // It's not a dict, we can't nest - this is an error case
@@ -86,7 +86,7 @@ pub fn insert_nested_dict(
     let mut current_dict = top_dict;
     for key in path.iter().skip(1).take(path.len() - 2) {
         let nested_dict = if let Some(existing) = current_dict.get_item(key.as_str())? {
-            if let Ok(dict) = existing.downcast::<PyDict>() {
+            if let Ok(dict) = existing.cast::<PyDict>() {
                 dict.clone()
             } else {
                 // Not a dict, replace it

--- a/formatparse-pyo3/src/parser/matching/py_match.rs
+++ b/formatparse-pyo3/src/parser/matching/py_match.rs
@@ -16,7 +16,7 @@ use super::{
 pub fn match_with_captures(
     captures: &Captures,
     ctx: &CapturedMatchContext<'_>,
-) -> PyResult<Option<PyObject>> {
+) -> PyResult<Option<Py<PyAny>>> {
     let field_specs = ctx.fields.field_specs;
     let field_names = ctx.fields.field_names;
     let normalized_names = ctx.fields.normalized_names;
@@ -46,7 +46,7 @@ pub fn match_with_captures(
     let field_count = field_specs.len();
     // Fast path: for single-field patterns, use optimized allocation
     let mut fixed = Vec::with_capacity(field_count);
-    let mut named: HashMap<String, PyObject> = HashMap::with_capacity(field_count.max(1));
+    let mut named: HashMap<String, Py<PyAny>> = HashMap::with_capacity(field_count.max(1));
     let mut field_spans: HashMap<String, (usize, usize)> =
         HashMap::with_capacity(field_count.max(1));
     let mut captures_vec = Vec::with_capacity(field_count); // For Match object when evaluate_result=False
@@ -180,7 +180,7 @@ pub fn match_with_captures(
                         fixed.push(converted);
                     }
                 } else {
-                    let converted: PyObject = if matches!(spec.field_type, FieldType::Nested) {
+                    let converted: Py<PyAny> = if matches!(spec.field_type, FieldType::Nested) {
                         let nested_arc = ctx
                             .fields
                             .nested_parsers
@@ -296,7 +296,7 @@ pub fn match_with_captures(
 }
 
 /// Match a regex against a string and extract results
-pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<Option<PyObject>> {
+pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<Option<Py<PyAny>>> {
     let string = ctx.string;
     let pattern = ctx.pattern;
     let field_specs = ctx.field_specs;
@@ -314,7 +314,7 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
         // Pre-allocate with capacity based on expected field count
         let field_count = field_specs.len();
         let mut fixed = Vec::with_capacity(field_count);
-        let mut named: HashMap<String, PyObject> = HashMap::with_capacity(field_count);
+        let mut named: HashMap<String, Py<PyAny>> = HashMap::with_capacity(field_count);
         let mut field_spans: HashMap<String, (usize, usize)> = HashMap::with_capacity(field_count);
         let mut captures_vec = Vec::with_capacity(field_count); // For Match object when evaluate_result=False
         let mut named_captures = HashMap::with_capacity(field_count); // For Match object when evaluate_result=False
@@ -477,7 +477,7 @@ pub fn match_with_regex(regex: &Regex, ctx: &RegexMatchContext<'_>) -> PyResult<
                             fixed_index += 1;
                         }
                     } else {
-                        let converted: PyObject = if matches!(spec.field_type, FieldType::Nested) {
+                        let converted: Py<PyAny> = if matches!(spec.field_type, FieldType::Nested) {
                             let nested_arc = nested_parsers
                                 .get(i)
                                 .and_then(|x| x.as_ref())
@@ -626,15 +626,15 @@ pub fn match_empty_default_string_parse(
     field_names: &[Option<String>],
     normalized_names: &[Option<String>],
     py: Python<'_>,
-    custom_converters: &HashMap<String, PyObject>,
+    custom_converters: &HashMap<String, Py<PyAny>>,
     evaluate_result: bool,
-) -> PyResult<Option<PyObject>> {
+) -> PyResult<Option<Py<PyAny>>> {
     let value_str = "";
     let field_start: usize = 0;
     let field_end: usize = 0;
     let field_count = field_specs.len();
-    let mut fixed: Vec<PyObject> = Vec::with_capacity(field_count);
-    let mut named: HashMap<String, PyObject> = HashMap::with_capacity(field_count);
+    let mut fixed: Vec<Py<PyAny>> = Vec::with_capacity(field_count);
+    let mut named: HashMap<String, Py<PyAny>> = HashMap::with_capacity(field_count);
     let mut field_spans: HashMap<String, (usize, usize)> = HashMap::with_capacity(field_count);
     let mut captures_vec: Vec<Option<String>> = Vec::with_capacity(field_count);
     let mut named_captures: HashMap<String, String> = HashMap::with_capacity(field_count);

--- a/formatparse-pyo3/src/parser/raw_match.rs
+++ b/formatparse-pyo3/src/parser/raw_match.rs
@@ -58,9 +58,9 @@ pub fn convert_value_raw(spec: &FieldSpec, value: &str) -> Result<RawValue, Stri
     }
 }
 
-/// Convert RawValue to PyObject (batch conversion)
+/// Convert RawValue to Py<PyAny> (batch conversion)
 impl RawValue {
-    pub fn to_py_object(&self, py: Python) -> PyResult<PyObject> {
+    pub fn to_py_object(&self, py: Python) -> PyResult<Py<PyAny>> {
         match self {
             RawValue::String(s) => s.into_py_any(py),
             RawValue::Integer(n) => n.into_py_any(py),
@@ -76,13 +76,13 @@ impl RawMatchData {
     pub fn to_parse_result(&self, py: Python) -> PyResult<pyo3::Py<crate::result::ParseResult>> {
         use crate::result::ParseResult;
 
-        let fixed: Vec<PyObject> = self
+        let fixed: Vec<Py<PyAny>> = self
             .fixed
             .iter()
             .map(|v| v.to_py_object(py))
             .collect::<PyResult<_>>()?;
 
-        let mut named: HashMap<String, PyObject> = HashMap::with_capacity(self.named.len());
+        let mut named: HashMap<String, Py<PyAny>> = HashMap::with_capacity(self.named.len());
         for (k, v) in &self.named {
             named.insert(k.clone(), v.to_py_object(py)?);
         }

--- a/formatparse-pyo3/src/pattern_cache.rs
+++ b/formatparse-pyo3/src/pattern_cache.rs
@@ -25,7 +25,7 @@ fn lock_pattern_cache(
 /// Must stay aligned with [`create_cache_key_hash`].
 pub(crate) fn extract_extra_types_identity(
     py: Python<'_>,
-    extra_types: &Option<HashMap<String, PyObject>>,
+    extra_types: &Option<HashMap<String, Py<PyAny>>>,
 ) -> Vec<(String, String, i64)> {
     let mut out = Vec::new();
     if let Some(extra_types) = extra_types {
@@ -69,7 +69,7 @@ pub(crate) fn extract_extra_types_identity(
 fn create_cache_key_hash(
     py: Python<'_>,
     pattern: &str,
-    extra_types: &Option<HashMap<String, PyObject>>,
+    extra_types: &Option<HashMap<String, Py<PyAny>>>,
 ) -> u64 {
     let mut hasher = DefaultHasher::new();
     pattern.hash(&mut hasher);
@@ -84,10 +84,10 @@ fn create_cache_key_hash(
 /// Get or create a FormatParser from cache
 pub(crate) fn get_or_create_parser(
     pattern: &str,
-    extra_types: Option<HashMap<String, PyObject>>,
+    extra_types: Option<HashMap<String, Py<PyAny>>>,
 ) -> PyResult<Arc<FormatParser>> {
     let normalized = pattern_normalize::prepare_compiled_pattern(pattern)?;
-    Python::with_gil(|py| -> PyResult<Arc<FormatParser>> {
+    Python::attach(|py| -> PyResult<Arc<FormatParser>> {
         let cache_key = create_cache_key_hash(py, &normalized, &extra_types);
 
         let cached = {

--- a/formatparse-pyo3/src/result.rs
+++ b/formatparse-pyo3/src/result.rs
@@ -3,18 +3,18 @@ use pyo3::types::{PySlice, PyString, PyTuple};
 use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ParseResult {
-    fixed: Vec<PyObject>,
+    fixed: Vec<Py<PyAny>>,
     #[pyo3(get)]
-    pub named: HashMap<String, PyObject>,
+    pub named: HashMap<String, Py<PyAny>>,
     pub span: (usize, usize),
     pub field_spans: HashMap<String, (usize, usize)>, // Maps field index/name to (start, end)
 }
 
 impl Clone for ParseResult {
     fn clone(&self) -> Self {
-        Python::with_gil(|py| Self {
+        Python::attach(|py| Self {
             fixed: self.fixed.iter().map(|obj| obj.clone_ref(py)).collect(),
             named: self
                 .named
@@ -42,8 +42,8 @@ fn repr_trunc(s: &str, max_chars: usize) -> String {
 
 impl ParseResult {
     pub fn new(
-        fixed: Vec<PyObject>,
-        named: HashMap<String, PyObject>,
+        fixed: Vec<Py<PyAny>>,
+        named: HashMap<String, Py<PyAny>>,
         span: (usize, usize),
     ) -> Self {
         Self {
@@ -55,8 +55,8 @@ impl ParseResult {
     }
 
     pub fn new_with_spans(
-        fixed: Vec<PyObject>,
-        named: HashMap<String, PyObject>,
+        fixed: Vec<Py<PyAny>>,
+        named: HashMap<String, Py<PyAny>>,
         span: (usize, usize),
         field_spans: HashMap<String, (usize, usize)>,
     ) -> Self {
@@ -136,16 +136,16 @@ impl ParseResult {
     #[new]
     #[pyo3(signature = (fixed, named, span=None))]
     fn new_py(
-        fixed: Vec<PyObject>,
-        named: HashMap<String, PyObject>,
+        fixed: Vec<Py<PyAny>>,
+        named: HashMap<String, Py<PyAny>>,
         span: Option<(usize, usize)>,
     ) -> Self {
         Self::new(fixed, named, span.unwrap_or((0, 0)))
     }
 
     #[getter]
-    fn fixed(&self) -> PyResult<PyObject> {
-        Python::with_gil(|py| {
+    fn fixed(&self) -> PyResult<Py<PyAny>> {
+        Python::attach(|py| {
             let items: Vec<_> = self.fixed.iter().map(|obj| obj.bind(py)).collect();
             let tuple = PyTuple::new(py, items)?;
             Ok(tuple.into())
@@ -175,10 +175,10 @@ impl ParseResult {
         self.format_display(py)
     }
 
-    fn __getitem__(&self, key: &Bound<'_, PyAny>) -> PyResult<PyObject> {
-        Python::with_gil(|py| {
+    fn __getitem__(&self, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        Python::attach(|py| {
             // Try to extract as slice first
-            if let Ok(slice) = key.downcast::<PySlice>() {
+            if let Ok(slice) = key.cast::<PySlice>() {
                 let len = self.fixed.len() as isize;
                 let indices = slice.indices(len)?;
 
@@ -219,7 +219,7 @@ impl ParseResult {
     }
 
     fn __contains__(&self, key: &Bound<'_, PyAny>) -> PyResult<bool> {
-        Python::with_gil(|_py| {
+        Python::attach(|_py| {
             if let Ok(idx) = key.extract::<usize>() {
                 Ok(idx < self.fixed.len())
             } else if let Ok(name) = key.extract::<String>() {
@@ -231,11 +231,11 @@ impl ParseResult {
     }
 
     #[getter]
-    fn spans(&self) -> PyResult<PyObject> {
-        Python::with_gil(|py| {
+    fn spans(&self) -> PyResult<Py<PyAny>> {
+        Python::attach(|py| {
             let dict = pyo3::types::PyDict::new(py);
             for (key, value) in &self.field_spans {
-                let py_key: PyObject = if let Ok(idx) = key.parse::<usize>() {
+                let py_key: Py<PyAny> = if let Ok(idx) = key.parse::<usize>() {
                     idx.into_py_any(py)?
                 } else {
                     key.clone().into_py_any(py)?

--- a/formatparse-pyo3/src/results.rs
+++ b/formatparse-pyo3/src/results.rs
@@ -11,7 +11,7 @@ use pyo3::IntoPyObjectExt;
 pub struct Results {
     raw_data: Vec<RawMatchData>,
     // Cache for converted ParseResult objects (lazy evaluation)
-    cached_results: Option<PyObject>,
+    cached_results: Option<Py<PyAny>>,
 }
 
 impl Results {
@@ -23,12 +23,12 @@ impl Results {
     }
 
     /// Convert all raw data to ParseResult objects (called lazily)
-    fn convert_all(&mut self, py: Python) -> PyResult<PyObject> {
+    fn convert_all(&mut self, py: Python) -> PyResult<Py<PyAny>> {
         if let Some(ref cached) = self.cached_results {
             return Ok(cached.clone_ref(py));
         }
 
-        let mut py_results: Vec<PyObject> = Vec::with_capacity(self.raw_data.len());
+        let mut py_results: Vec<Py<PyAny>> = Vec::with_capacity(self.raw_data.len());
         for raw_data in &self.raw_data {
             let parse_result = raw_data.to_parse_result(py)?;
             py_results.push(parse_result.into_py_any(py)?);
@@ -44,7 +44,7 @@ impl Results {
     }
 
     /// Convert a single raw data item to ParseResult (for lazy indexing)
-    pub fn convert_item(&self, index: usize, py: Python) -> PyResult<PyObject> {
+    pub fn convert_item(&self, index: usize, py: Python) -> PyResult<Py<PyAny>> {
         if index >= self.raw_data.len() {
             return Err(PyIndexError::new_err("list index out of range"));
         }
@@ -63,7 +63,7 @@ impl Results {
     }
 
     /// Get an item by index (lazy conversion - only converts the requested item)
-    fn __getitem__(&self, key: &Bound<'_, PyAny>, py: Python) -> PyResult<PyObject> {
+    fn __getitem__(&self, key: &Bound<'_, PyAny>, py: Python) -> PyResult<Py<PyAny>> {
         // Try to extract as usize first (positive index)
         if let Ok(index) = key.extract::<usize>() {
             // Single item access - convert only this item
@@ -113,7 +113,7 @@ impl Results {
     /// Convert to list (forces conversion of all items).
     /// Name matches the `parse` library Python API (`results.to_list()`).
     #[allow(clippy::wrong_self_convention)] // `to_*` + `&mut self` is required by pymethods / API parity
-    fn to_list(&mut self, py: Python) -> PyResult<PyObject> {
+    fn to_list(&mut self, py: Python) -> PyResult<Py<PyAny>> {
         self.convert_all(py)
     }
 
@@ -132,7 +132,7 @@ impl Results {
 #[pyclass]
 pub struct ResultsIterator {
     results: Py<Results>,
-    cached_list: Option<PyObject>, // Cached list of converted items
+    cached_list: Option<Py<PyAny>>, // Cached list of converted items
     index: usize,
 }
 
@@ -142,7 +142,7 @@ impl ResultsIterator {
         slf
     }
 
-    fn __next__(&mut self, py: Python) -> PyResult<Option<PyObject>> {
+    fn __next__(&mut self, py: Python) -> PyResult<Option<Py<PyAny>>> {
         // On first iteration, batch convert all items at once
         if self.cached_list.is_none() {
             let results = self.results.bind(py);
@@ -157,7 +157,7 @@ impl ResultsIterator {
             .as_ref()
             .expect("cached_list set immediately above when None")
             .bind(py)
-            .downcast::<pyo3::types::PyList>()?;
+            .cast::<pyo3::types::PyList>()?;
         let len = list_bound.len();
 
         if self.index >= len {

--- a/formatparse-pyo3/src/types/builtin_convert.rs
+++ b/formatparse-pyo3/src/types/builtin_convert.rs
@@ -189,7 +189,7 @@ pub fn convert_builtin_scalar(spec: &FieldSpec, value: &str) -> ConvertOutcome {
 }
 
 impl ConvertedScalar {
-    pub fn to_py_object(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject> {
+    pub fn to_py_object(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::types::PyAny>> {
         use pyo3::IntoPyObjectExt;
         match self {
             ConvertedScalar::String(s) => s.into_py_any(py),

--- a/formatparse-pyo3/src/types/conversion.rs
+++ b/formatparse-pyo3/src/types/conversion.rs
@@ -201,8 +201,8 @@ pub fn convert_value(
     spec: &FieldSpec,
     value: &str,
     py: Python,
-    custom_converters: &HashMap<String, PyObject>,
-) -> PyResult<PyObject> {
+    custom_converters: &HashMap<String, Py<PyAny>>,
+) -> PyResult<Py<PyAny>> {
     // Fast path: if no custom converters, skip the lookup entirely
     if !custom_converters.is_empty() {
         // Check if this type has a custom converter (even if it's a built-in type name)


### PR DESCRIPTION
## Summary

Consolidates all 11 open Dependabot PRs into one branch:

- **Rust:** `pyo3` 0.24 → 0.28 (with API migration: `Py<PyAny>`, `Python::attach`, `Bound::cast`), `fancy-regex` 0.17, `lru` 0.18, `rayon` 1.12, `rand` 0.10.1 (dev-dep)
- **Docs:** `sphinx` ≥7.4.7, `sphinx-rtd-theme` ≥3.1.0, `sphinx-autodoc-typehints` ≥2.3.0, `myst-parser` ≥3.0.1
- **CI:** `actions/upload-artifact` v7, `actions/download-artifact` v8
- **MSRV:** 1.74 → 1.83 (required by PyO3 0.28)

Closes #104, #105, #106, #107, #108, #109, #110, #111, #112, #113, #114.

## Test plan

- [x] `cargo test --workspace` (130 Rust tests)
- [x] `pytest tests/ -m "not slow and not stress and not benchmark"` (677 passed)
- [ ] CI full matrix on merge
- [ ] Close superseded Dependabot PRs after merge