### PR TITLE
Fix search() Unicode pos/endpos panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Docs**: ``ValidatorMap`` typed as ``Dict`` instead of ``typing.Mapping`` so Sphinx autodoc builds on Python 3.13.
+- **Docs**: Document ``ValidatorMap`` manually in Sphinx (autodoc on Python 3.13.14 chokes on ``typing.Dict`` / ``typing.Mapping`` docstrings).
 
 ### Planned
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dependencies**: PyO3 0.28 → 0.29 (addresses RUSTSEC-2026-0176 and RUSTSEC-2026-0177).
+
+### Fixed
+
+- **Docs**: ``ValidatorMap`` typed as ``Dict`` instead of ``typing.Mapping`` so Sphinx autodoc builds on Python 3.13.
+
 ### Planned
 
 - Inline ``{...:validator(...)}`` syntax and **async** validation pipelines (currently deferred in API documentation).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **Dependencies**: PyO3 0.28 → 0.29 (addresses RUSTSEC-2026-0176 and RUSTSEC-2026-0177).
-
-### Fixed
-
-- **Docs**: Document ``ValidatorMap`` manually in Sphinx (autodoc on Python 3.13.14 chokes on ``typing.Dict`` / ``typing.Mapping`` docstrings).
-
 ### Planned
 
 - Inline ``{...:validator(...)}`` syntax and **async** validation pipelines (currently deferred in API documentation).
 - ``composed_type`` extensions: pattern ``+``, inheritance, and **flattening** nested parse results into the parent (see `#7 <https://github.com/eddiethedean/formatparse/issues/7>`_).
+
+## [0.8.5] - 2026-07-06
+
+### Fixed
+
+- **search**: ``pos`` / ``endpos`` are interpreted as Unicode character indices, fixing a panic when slicing UTF-8 on non-ASCII text (fixes `#129 <https://github.com/eddiethedean/formatparse/issues/129>`_).
+- **Docs**: Document ``ValidatorMap`` manually in Sphinx (autodoc on Python 3.13.14 chokes on ``typing.Dict`` / ``typing.Mapping`` docstrings).
+
+### Changed
+
+- **Dependencies**: PyO3 0.28 → 0.29 (addresses RUSTSEC-2026-0176 and RUSTSEC-2026-0177).
 
 ## [0.8.4] - 2026-06-06
 
@@ -156,6 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: load `pytest-cov` when `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`; bump `cargo-audit` in the main CI Ubuntu step for advisory DB compatibility.
 - Dependency updates (e.g. `lru` for RustSec advisories), formatting, and Clippy cleanups.
 
+[0.8.5]: https://github.com/eddiethedean/formatparse/releases/tag/v0.8.5
 [0.8.4]: https://github.com/eddiethedean/formatparse/releases/tag/v0.8.4
 [0.8.3]: https://github.com/eddiethedean/formatparse/releases/tag/v0.8.3
 [0.8.2]: https://github.com/eddiethedean/formatparse/releases/tag/v0.8.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "formatparse-core"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "fancy-regex",
  "once_cell",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "formatparse-pyo3"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "fancy-regex",
  "formatparse-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -382,18 +382,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -413,13 +413,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["formatparse-core", "formatparse-pyo3"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Odos Matthews <odosmatthews@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/eddiethedean/formatparse"
@@ -11,4 +11,4 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-formatparse-core = { path = "formatparse-core", version = "0.8.4" }
+formatparse-core = { path = "formatparse-core", version = "0.8.5" }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,14 +4,14 @@ This document explains how to release a new version of `formatparse` to PyPI.
 
 ## Current version
 
-The canonical version is **`0.8.4`** in the workspace [`Cargo.toml`](Cargo.toml) (`[workspace.package] version` and `[workspace.dependencies] formatparse-core` must match). Member crates use `version.workspace = true`. PyPI metadata uses `dynamic = ["version"]`; Maturin reads the workspace version when building wheels and sdist.
+The canonical version is **`0.8.5`** in the workspace [`Cargo.toml`](Cargo.toml) (`[workspace.package] version` and `[workspace.dependencies] formatparse-core` must match). Member crates use `version.workspace = true`. PyPI metadata uses `dynamic = ["version"]`; Maturin reads the workspace version when building wheels and sdist.
 
-**PyPI / crates.io latest published:** `0.8.3` (tag `v0.8.3`). To ship 0.8.4, tag `v0.8.4` after the checklist below—do **not** run `release.sh 0.8.4` (that would create a redundant version commit); use [Tag without a version bump](#tag-without-a-version-bump) instead.
+**PyPI / crates.io latest published:** `0.8.3` (tag `v0.8.3`). To ship 0.8.5, tag `v0.8.5` after the checklist below—do **not** run `release.sh 0.8.5` (that would create a redundant version commit); use [Tag without a version bump](#tag-without-a-version-bump) instead.
 
 Before tagging, confirm:
 
-- `[workspace.package] version` and `formatparse-core` dependency version in root [`Cargo.toml`](Cargo.toml) are both **`0.8.4`**.
-- [`CHANGELOG.md`](CHANGELOG.md) lists all 0.8.4 changes under `## [0.8.4]` (not only under `[Unreleased]`).
+- `[workspace.package] version` and `formatparse-core` dependency version in root [`Cargo.toml`](Cargo.toml) are both **`0.8.5`**.
+- [`CHANGELOG.md`](CHANGELOG.md) lists all 0.8.5 changes under `## [0.8.5]` (not only under `[Unreleased]`).
 - CI on `main` is green.
 
 If the workspace version is **already** `X.Y.Z` on `main` (for example after a merge that bumped it), you do **not** need `release.sh` to edit `Cargo.toml` again. Push the tag only (see [Tag without a version bump](#tag-without-a-version-bump) below).

--- a/docs/api/validation.rst
+++ b/docs/api/validation.rst
@@ -35,5 +35,13 @@ Type aliases
 .. autodata:: formatparse.ValidationMode
    :annotation:
 
-.. autodata:: formatparse.ValidatorMap
-   :annotation:
+``ValidatorMap``
+~~~~~~~~~~~~~~~~
+
+.. py:data:: ValidatorMap
+   :module: formatparse
+
+   Type alias: ``Dict[Union[str, int], Callable[..., Any]]``.
+
+   Keys are field names (:class:`str`) or positional indices (:class:`int`);
+   values are callables invoked during post-parse validation.

--- a/formatparse-pyo3/Cargo.toml
+++ b/formatparse-pyo3/Cargo.toml
@@ -29,7 +29,7 @@ python-tests = []
 
 [dependencies]
 formatparse-core.workspace = true
-pyo3 = { version = "0.28", default-features = false, features = ["macros"] }
+pyo3 = { version = "0.29", default-features = false, features = ["macros"] }
 regex = "1.12.3"
 fancy-regex = "0.18"
 serde = { version = "1.0", features = ["derive"] }

--- a/formatparse-pyo3/src/lib.rs
+++ b/formatparse-pyo3/src/lib.rs
@@ -17,8 +17,10 @@ mod pattern_normalize;
 mod result;
 mod results;
 mod types;
+mod unicode_offsets;
 
 pub(crate) use pattern_cache::extract_extra_types_identity;
+use unicode_offsets::search_byte_range;
 use pattern_cache::get_or_create_parser;
 
 pub use datetime::FixedTzOffset;
@@ -159,19 +161,10 @@ fn search(
     case_sensitive: bool,
     evaluate_result: bool,
 ) -> PyResult<Option<Py<PyAny>>> {
-    // Validate pos parameter
-    if pos > string.len() {
+    // `pos` / `endpos` are Python character indices (like str slicing), not byte offsets.
+    let Some((byte_start, byte_end)) = search_byte_range(string, pos, endpos) else {
         return Ok(None);
-    }
-
-    // Validate endpos parameter
-    let end = endpos.unwrap_or(string.len());
-    if end > string.len() {
-        return Ok(None);
-    }
-    if end < pos {
-        return Ok(None);
-    }
+    };
 
     // Validate input lengths
     formatparse_core::validate_input_length(string)
@@ -192,20 +185,26 @@ fn search(
         })
     });
     let parser = get_or_create_parser(pattern, extra_types_cloned)?;
-    let search_string = &string[pos..end];
+    let search_string = &string[byte_start..byte_end];
 
     if let Some(result) =
         parser.search_pattern(search_string, case_sensitive, extra_types, evaluate_result)?
     {
-        // Adjust positions if it's a ParseResult (not Match)
+        // Adjust byte spans to absolute offsets, then expose character indices to Python.
         Python::attach(|py| {
             if let Ok(parse_result) = result.bind(py).cast::<ParseResult>() {
                 let result_value = parse_result.borrow();
-                let adjusted = result_value.clone().with_offset(pos);
-                // Py::new() is already optimized when GIL is held
+                let adjusted = result_value
+                    .clone()
+                    .with_offset(byte_start)
+                    .spans_as_char_indices(string);
                 Ok(Some(Py::new(py, adjusted)?.into_py_any(py)?))
             } else if let Ok(match_obj) = result.bind(py).cast::<crate::match_rs::Match>() {
-                let adjusted = match_obj.borrow().clone().with_offset(pos);
+                let adjusted = match_obj
+                    .borrow()
+                    .clone()
+                    .with_offset(byte_start)
+                    .spans_as_char_indices(string);
                 Ok(Some(Py::new(py, adjusted)?.into_py_any(py)?))
             } else {
                 Ok(Some(result))

--- a/formatparse-pyo3/src/match_rs.rs
+++ b/formatparse-pyo3/src/match_rs.rs
@@ -1,5 +1,6 @@
 use crate::error;
 use crate::result::ParseResult;
+use crate::unicode_offsets::byte_to_char_index;
 use crate::types::FieldSpec;
 use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
@@ -130,6 +131,27 @@ impl Match {
             .field_spans
             .into_iter()
             .map(|(k, (start, end))| (k, (start + offset, end + offset)))
+            .collect();
+        self
+    }
+
+    pub fn spans_as_char_indices(mut self, haystack: &str) -> Self {
+        self.span = (
+            byte_to_char_index(haystack, self.span.0),
+            byte_to_char_index(haystack, self.span.1),
+        );
+        self.field_spans = self
+            .field_spans
+            .into_iter()
+            .map(|(k, (start, end))| {
+                (
+                    k,
+                    (
+                        byte_to_char_index(haystack, start),
+                        byte_to_char_index(haystack, end),
+                    ),
+                )
+            })
             .collect();
         self
     }

--- a/formatparse-pyo3/src/result.rs
+++ b/formatparse-pyo3/src/result.rs
@@ -1,3 +1,4 @@
+use crate::unicode_offsets::byte_to_char_index;
 use pyo3::prelude::*;
 use pyo3::types::{PySlice, PyString, PyTuple};
 use pyo3::IntoPyObjectExt;
@@ -75,6 +76,28 @@ impl ParseResult {
             .field_spans
             .into_iter()
             .map(|(k, (start, end))| (k, (start + offset, end + offset)))
+            .collect();
+        self
+    }
+
+    /// Convert absolute byte spans in `haystack` to Python character indices.
+    pub fn spans_as_char_indices(mut self, haystack: &str) -> Self {
+        self.span = (
+            byte_to_char_index(haystack, self.span.0),
+            byte_to_char_index(haystack, self.span.1),
+        );
+        self.field_spans = self
+            .field_spans
+            .into_iter()
+            .map(|(k, (start, end))| {
+                (
+                    k,
+                    (
+                        byte_to_char_index(haystack, start),
+                        byte_to_char_index(haystack, end),
+                    ),
+                )
+            })
             .collect();
         self
     }

--- a/formatparse-pyo3/src/unicode_offsets.rs
+++ b/formatparse-pyo3/src/unicode_offsets.rs
@@ -1,0 +1,84 @@
+//! Map Python str character indices to UTF-8 byte offsets for search(pos/endpos).
+
+/// Number of Unicode scalar values in `s` (same as Python `len(s)`).
+pub(crate) fn char_len(s: &str) -> usize {
+    s.chars().count()
+}
+
+/// Byte offset at the start of the character at `char_index`, or `s.len()` when
+/// `char_index == char_len(s)`. Returns `None` when `char_index > char_len(s)`.
+pub(crate) fn char_index_to_byte_start(s: &str, char_index: usize) -> Option<usize> {
+    let n = char_len(s);
+    if char_index > n {
+        return None;
+    }
+    if char_index == n {
+        return Some(s.len());
+    }
+    if char_index == 0 {
+        return Some(0);
+    }
+    s.char_indices()
+        .nth(char_index)
+        .map(|(byte_idx, _)| byte_idx)
+}
+
+/// Exclusive end: byte offset of the character at `char_index`, or `s.len()` when
+/// `char_index == char_len(s)`.
+pub(crate) fn char_index_to_byte_end(s: &str, char_index: usize) -> Option<usize> {
+    char_index_to_byte_start(s, char_index)
+}
+
+/// Resolve Python `pos` / `endpos` (character indices) to a UTF-8 byte range.
+/// Returns `None` when the range is invalid or empty.
+pub(crate) fn search_byte_range(
+    s: &str,
+    pos: usize,
+    endpos: Option<usize>,
+) -> Option<(usize, usize)> {
+    let char_count = char_len(s);
+    if pos > char_count {
+        return None;
+    }
+    let end_char = endpos.unwrap_or(char_count);
+    if end_char > char_count || end_char < pos {
+        return None;
+    }
+    let byte_start = char_index_to_byte_start(s, pos)?;
+    let byte_end = char_index_to_byte_end(s, end_char)?;
+    if byte_end < byte_start {
+        return None;
+    }
+    Some((byte_start, byte_end))
+}
+
+/// Convert a byte offset (on a char boundary) to a Python character index.
+pub(crate) fn byte_to_char_index(s: &str, byte_offset: usize) -> usize {
+    if byte_offset == 0 {
+        return 0;
+    }
+    debug_assert!(byte_offset <= s.len());
+    debug_assert!(s.is_char_boundary(byte_offset));
+    s[..byte_offset].chars().count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rocket_ab_range() {
+        let s = "🚀ab value=42";
+        assert_eq!(char_len(s), 12);
+        assert_eq!(char_index_to_byte_start(s, 0), Some(0));
+        assert_eq!(char_index_to_byte_start(s, 1), Some(4)); // 'a'
+        assert_eq!(search_byte_range(s, 1, None), Some((4, s.len())));
+    }
+
+    #[test]
+    fn byte_to_char_roundtrip() {
+        let s = "🚀ab";
+        assert_eq!(byte_to_char_index(s, 4), 1);
+        assert_eq!(byte_to_char_index(s, 0), 0);
+    }
+}

--- a/formatparse/types.py
+++ b/formatparse/types.py
@@ -7,7 +7,6 @@ from typing import (
     Callable,
     Dict,
     Literal,
-    Mapping,
     Optional,
     Protocol,
     TypedDict,
@@ -39,4 +38,4 @@ class FieldConstraint(TypedDict, total=False):
 
 
 ValidationMode = Literal["strict", "collect", "lenient"]
-ValidatorMap = Mapping[Union[str, int], Callable[..., Any]]
+ValidatorMap = Dict[Union[str, int], Callable[..., Any]]

--- a/formatparse/types.py
+++ b/formatparse/types.py
@@ -38,4 +38,6 @@ class FieldConstraint(TypedDict, total=False):
 
 
 ValidationMode = Literal["strict", "collect", "lenient"]
+
 ValidatorMap = Dict[Union[str, int], Callable[..., Any]]
+"""Validators keyed by field name (:class:`str`) or positional index (:class:`int`)."""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -264,3 +264,30 @@ def test_search_partial_match():
     # Should still match "age: 30" part
     assert result is not None
     assert result.named["age"] == 30
+
+
+def test_search_unicode_pos_char_index():
+    """search(pos) uses Python character indices, not UTF-8 byte offsets (issue #129)."""
+    text = "🚀ab value=42"
+    result = search("{v:d}", text, pos=1)
+    assert result is not None
+    assert result.named["v"] == 42
+    assert result.start >= 1
+
+
+def test_search_unicode_endpos_char_index():
+    """search(endpos) uses Python character indices (issue #129)."""
+    text = "🚀ab value=42"
+    # Only search through "🚀ab" (chars 0..3 exclusive of rest)
+    result = search("{v:d}", text, endpos=3)
+    assert result is None
+
+
+def test_search_unicode_pos_with_evaluate_result_false():
+    """Match objects from search also get char-index spans (issue #129)."""
+    text = "🚀ab value=42"
+    m = search("{v:d}", text, pos=1, evaluate_result=False)
+    assert m is not None
+    assert m.span[0] >= 1
+    evaluated = m.evaluate_result()
+    assert evaluated.named["v"] == 42


### PR DESCRIPTION
## Summary

Fixes #129.

`search(pos=...)` and `search(endpos=...)` now treat bounds as **Python character indices** (like `str` slicing), not UTF-8 byte offsets. This removes the Rust panic on non-ASCII text and returns correct matches.

## Changes

- Add `unicode_offsets` module to map character indices ↔ UTF-8 byte offsets
- Slice the haystack using byte bounds; apply span offsets in bytes
- Convert `ParseResult` / `Match` spans back to character indices before returning to Python
- Add regression tests in `tests/test_search.py`

## Test plan

- [x] `cargo test -p formatparse-pyo3 unicode_offsets`
- [x] `pytest tests/test_search.py` (30 tests)
- [x] `pytest tests/test_bugfixes_0_8_3.py::test_search_match_offset_when_not_evaluated`