### PR TITLE
Reject bool validator keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inline ``{...:validator(...)}`` syntax and **async** validation pipelines (currently deferred in API documentation).
 - ``composed_type`` extensions: pattern ``+``, inheritance, and **flattening** nested parse results into the parent (see `#7 <https://github.com/eddiethedean/formatparse/issues/7>`_).
 
+### Fixed
+
+- **Validation**: Reject ``bool`` validator keys instead of treating them as positional indices (fixes `#132 <https://github.com/eddiethedean/formatparse/issues/132>`_).
+
 ## [0.8.5] - 2026-07-06
 
 ### Fixed

--- a/formatparse/validation.py
+++ b/formatparse/validation.py
@@ -34,7 +34,7 @@ def validator(func: Callable[..., Any]) -> Callable[..., Any]:
 
 def _sorted_validator_keys(keys: Iterable[Union[str, int]]) -> List[Union[str, int]]:
     key_list = list(keys)
-    ints = sorted(k for k in key_list if isinstance(k, int))
+    ints = sorted(k for k in key_list if isinstance(k, int) and not isinstance(k, bool))
     strs = sorted(k for k in key_list if isinstance(k, str))
     if len(ints) + len(strs) != len(key_list):
         raise TypeError("validator keys must be str or int")

--- a/tests/test_bugfixes_0_8_3.py
+++ b/tests/test_bugfixes_0_8_3.py
@@ -190,7 +190,8 @@ def test_in_range_rejects_bool():
 # --- Bug 21: validator key types ---
 
 
-def test_validator_keys_must_be_str_or_int():
+@pytest.mark.parametrize("key", [("tuple",), True, False])
+def test_validator_keys_must_be_str_or_int(key):
     result = parse("{n}", "x")
     with pytest.raises(TypeError, match="str or int"):
-        apply_validators(result, {("tuple",): non_empty_str})
+        apply_validators(result, {key: non_empty_str})


### PR DESCRIPTION
## Summary

- reject `bool` validator keys instead of treating them as positional indices
- extend the existing invalid-key regression test to cover `True` and `False`
- document the fix in the Unreleased changelog

Fixes #132

## Test plan

- `make test` (744 passed, 2 skipped)
- `cargo test -p formatparse-core` (97 passed)
- `cargo test --workspace` (97 core and 37 PyO3 tests passed)
- `cargo test -p formatparse-pyo3 --features python-tests` (37 passed)
- `ruff format --check .`
- `ruff check .`
- `ty check`
- targeted `mypy` for the changed implementation and regression test
- warning-strict Sphinx HTML, doctest, and linkcheck builds
- release wheel build and installed-wheel behavior probe