### PR TITLE
deps: bump docs stack (Sphinx 8, MyST 4, autodoc-typehints 3)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx>=7.4.7,<8.0
+sphinx>=8.1.3,<9.0
 sphinx-rtd-theme>=3.1.0
-sphinx-autodoc-typehints>=2.3.0
+sphinx-autodoc-typehints>=3.0.1
 sphinx-copybutton>=0.5.2
-myst-parser>=3.0.1,<4
+myst-parser>=4.0.1,<5


### PR DESCRIPTION
## Summary

- Bump `docs/requirements.txt` to Sphinx 8.x, myst-parser 4.x, and sphinx-autodoc-typehints 3.x together
- Supersedes Dependabot PRs #123, #124, and #125 (those cannot be merged independently due to resolver conflicts)

## Test plan

- [x] `python -m sphinx -W -b html docs docs/_build/html` (succeeded on current main)