### PR TITLE
docs: close PyO3 RUSTSEC-2026-0177 / 0176 tracking (#121, #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Dependencies**: PyO3 0.28 → 0.29 (addresses RUSTSEC-2026-0176 and RUSTSEC-2026-0177).
+- **Dependencies**: PyO3 0.28 → 0.29 (addresses RUSTSEC-2026-0176 / `#120 <https://github.com/eddiethedean/formatparse/issues/120>`_ and RUSTSEC-2026-0177 / `#121 <https://github.com/eddiethedean/formatparse/issues/121>`_).
 
 ## [0.8.4] - 2026-06-06
 

--- a/formatparse-pyo3/Cargo.toml
+++ b/formatparse-pyo3/Cargo.toml
@@ -29,6 +29,7 @@ python-tests = []
 
 [dependencies]
 formatparse-core.workspace = true
+# 0.29+ required for RUSTSEC-2026-0176 / RUSTSEC-2026-0177 (issues #120, #121).
 pyo3 = { version = "0.29", default-features = false, features = ["macros"] }
 regex = "1.12.3"
 fancy-regex = "0.18"


### PR DESCRIPTION
## Summary
- RUSTSEC-2026-0177 / RUSTSEC-2026-0176 were already fixed by bumping PyO3 to **0.29.0** in **0.8.5**; `Cargo.lock` is on `pyo3 0.29.0` and `cargo audit` no longer reports those advisories.
- Link issues `#121` / `#120` from the 0.8.5 changelog entry and document the PyO3 `>=0.29` floor in `formatparse-pyo3/Cargo.toml` so the auto-opened trackers can close.

## Test plan
- [x] Confirm `formatparse-pyo3` depends on `pyo3 0.29` and lockfile resolves `0.29.0`
- [x] Confirm `cargo audit` does not list RUSTSEC-2026-0177 / 0176
- [ ] CI green on this docs-only PR

Fixes #121
Fixes #120