### PR TITLE
deps: bump anyhow to 1.0.104 (RUSTSEC-2026-0190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dependencies**: Bump transitive ``anyhow`` 1.0.102 → 1.0.104 (RUSTSEC-2026-0190 / `#127 <https://github.com/eddiethedean/formatparse/issues/127>`_).
+
 ### Planned
 
 - Inline ``{...:validator(...)}`` syntax and **async** validation pipelines (currently deferred in API documentation).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"


### PR DESCRIPTION
## Summary
- Bump transitive \`anyhow\` **1.0.102 → 1.0.104** in \`Cargo.lock\` to clear [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190.html) (unsound \`Error::downcast_mut\`; patched \`>=1.0.103\`).
- \`anyhow\` is pulled in via the \`rand\` **dev-dependency** chain (\`getrandom\` → \`wasip3\` → \`wit-bindgen\`), not a direct runtime dependency of formatparse.

## Test plan
- [x] \`cargo update -p anyhow\` → 1.0.104
- [x] \`cargo audit\` no longer reports RUSTSEC-2026-0190
- [ ] CI green

Fixes #127